### PR TITLE
Add missing multipolygon import

### DIFF
--- a/osmnx/buildings.py
+++ b/osmnx/buildings.py
@@ -9,7 +9,7 @@ import time
 import geopandas as gpd
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection
-from shapely.geometry import Polygon, Point
+from shapely.geometry import Polygon, MultiPolygon, Point
 from descartes import PolygonPatch
 
 from .projection import project_geometry


### PR DESCRIPTION
The function `plot_buildings` uses MultiPolygon but it is not imported:
~~~~ python
elif isinstance(geometry, MultiPolygon):
    for subpolygon in geometry: #if geometry is multipolygon, go through each constituent subpolygon
        patches.append(PolygonPatch(subpolygon))
~~~~
I only discovered this bug because i modified my buildings gdf so that it included multipolygons. `create_buildings_gdf` only generates a gdf consisting of polygons so alternatively the quoted lines could also be deleted and the additional import omitted.