### PR TITLE
Option for download of other infrastructures

### DIFF
--- a/osmnx/__init__.py
+++ b/osmnx/__init__.py
@@ -15,4 +15,4 @@ from .simplify import *
 from .stats import *
 from .utils import *
 
-__version__ = '0.5'
+__version__ = '0.5.1'

--- a/osmnx/buildings.py
+++ b/osmnx/buildings.py
@@ -131,30 +131,32 @@ def create_buildings_gdf(polygon=None, north=None, south=None, east=None, west=N
     GeoDataFrame
     """
 
-    results = osm_bldg_download(polygon, north, south, east, west)
+    responses = osm_bldg_download(polygon, north, south, east, west)
 
     vertices = {}
-    for result in results[0]['elements']:
-        if 'type' in result and result['type']=='node':
-            vertices[result['id']] = {'lat' : result['lat'],
-                                      'lon' : result['lon']}
+    for response in responses:
+        for result in response['elements']:
+            if 'type' in result and result['type']=='node':
+                vertices[result['id']] = {'lat' : result['lat'],
+                                          'lon' : result['lon']}
 
     buildings = {}
-    for result in results[0]['elements']:
-        if 'type' in result and result['type']=='way':
-            nodes = result['nodes']
-            try:
-                polygon = Polygon([(vertices[node]['lon'], vertices[node]['lat']) for node in nodes])
-            except:
-                log('Polygon has invalid geometry: {}'.format(nodes))
-            building = {'nodes' : nodes,
-                        'geometry' : polygon}
+    for response in responses:
+        for result in response['elements']:
+            if 'type' in result and result['type']=='way':
+                nodes = result['nodes']
+                try:
+                    polygon = Polygon([(vertices[node]['lon'], vertices[node]['lat']) for node in nodes])
+                except:
+                    log('Polygon has invalid geometry: {}'.format(nodes))
+                building = {'nodes' : nodes,
+                            'geometry' : polygon}
 
-            if 'tags' in result:
-                for tag in result['tags']:
-                    building[tag] = result['tags'][tag]
+                if 'tags' in result:
+                    for tag in result['tags']:
+                        building[tag] = result['tags'][tag]
 
-            buildings[result['id']] = building
+                buildings[result['id']] = building
 
     gdf = gpd.GeoDataFrame(buildings).T
     gdf.crs = {'init':'epsg:4326'}

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -168,18 +168,18 @@ def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=Fal
     """
     Calculate extended topological stats and metrics for a graph.
 
-    Global topological analysis of large complex networks is extremely
-    time consuming and may exhaust computer memory. Consider using function
-    arguments to not run metrics that require computation of
-    a full matrix of paths if they will not be needed.
+    Many of these algorithms have an inherently high time complexity. Global topological analysis of 
+    large complex networks is extremely time consuming and may exhaust computer memory. Consider using 
+    function arguments to not run metrics that require computation of a full matrix of paths if they 
+    will not be needed.
 
     Parameters
     ----------
     G : networkx multidigraph
     connectivity : bool
         if True, calculate node and edge connectivity
-    anc : bool, if True
-        calculate average node connectivity
+    anc : bool
+        if True, calculate average node connectivity
     ecc : bool
         if True, calculate shortest paths, eccentricity, and topological metrics that use eccentricity
     bc : bool
@@ -190,7 +190,8 @@ def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=Fal
     Returns
     -------
     stats : dict
-        dictionary of network measures containing the following elements (some only calculated/returned optionally, based on passed parameters):
+        dictionary of network measures containing the following elements (some only calculated/returned 
+        optionally, based on passed parameters):
 
           - avg_neighbor_degree
           - avg_neighbor_degree_avg

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ classifiers=['Development Status :: 5 - Production/Stable',
 
 # now call setup
 setup(name='osmnx',
-      version='0.5',
+      version='0.5.1',
       description='Retrieve, construct, analyze, and visualize street networks from OpenStreetMap',
       long_description=long_description,
       classifiers=classifiers,


### PR DESCRIPTION
A new keyword parameter infrastructure='way["highway"]' was added to enable download and analysis of other infrastructures:

    infrastructure : string
        download infrastructure of given type (default is streets (ie, 'way["highway"]') but other 
        infrastructures may be selected like power grids (ie, 'way["power"~"line"]'))

A neutral filter network_type='none' was added so that other infrastructures are not removed due to missing "highway" tags.

Thanks and best,
David