### PR TITLE
get_nearest_node doc correction and clarification

### DIFF
--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -285,8 +285,9 @@ def get_nearest_node(G, point, return_dist=False):
 
     Returns
     -------
-    networkx multidigraph or tuple
-        multidigraph or optionally (multidigraph, float)
+    int or tuple of (int, float)
+        nearest node ID or optionally (node ID, dist), where dist is the distance between
+        the point and nearest node
     """
     start_time = time.time()
 


### PR DESCRIPTION
`get_nearest_node` returns the nearest node for a given point as an integer and not as a networkx MultiDiGraph object. @gboeing I'm not particularly attached to the wording that I added, so I'd be happy to change it to suit your preference.

To reproduce, run:
```python
graph = ox.graph_from_place('Tysons Corner, Virginia, USA')
point = (38.921589, -77.216288)
nearest_node = ox.get_nearest_node(graph, point)
type(nearest_node)
```

Output:
```
int
```