### PR TITLE
Possible bug in simplify.py:build_path

### DIFF
--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -116,6 +116,7 @@ def build_path(G, node, endpoints, path):
                 # if this successor is not an endpoint, recursively call
                 # build_path until you find an endpoint
                 path = build_path(G, successor, endpoints, path)
+                break
             else:
                 # if this successor is an endpoint, we've completed the path,
                 # so return it


### PR DESCRIPTION
Currently simplify.build_path function looks for all successors of a node and tries to build a path ending in one of teh endpoint nodes specified. However, if it finds a path, it does not stop, but explores all remaining successors. I think this is a bug.