### PR TITLE
modified folium polyline to be compatible with folium-0.5

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -610,7 +610,9 @@ def make_folium_polyline(edge, edge_color, edge_width, edge_opacity, popup_attri
         raise ImportError('The folium package must be installed to use this optional feature.')
 
     # locations is a list of points for the polyline
-    locations = list(edge['geometry'].coords)
+    # folium takes coords in lat,lon but geopandas provides them in lon,lat
+    # so we have to flip them around
+    locations = list([(lat, lon) for lon, lat in edge['geometry'].coords])
 
     # if popup_attribute is None, then create no pop-up
     if popup_attribute is None:
@@ -622,7 +624,7 @@ def make_folium_polyline(edge, edge_color, edge_width, edge_opacity, popup_attri
         popup = folium.Popup(html=popup_text)
 
     # create a folium polyline with attributes
-    pl = folium.PolyLine(locations=locations, popup=popup, latlon=False,
+    pl = folium.PolyLine(locations=locations, popup=popup,
                          color=edge_color, weight=edge_width, opacity=edge_opacity)
     return pl
 


### PR DESCRIPTION
folium-0.5 does not appear to support the 'latlon=False' flag for Polyline anymore, so it's necessary to flip the coords from lonlat ourselves before building the polyline. This should be backward compatible with previous versions of folium as well.