### PR TITLE
Switch from US-only NAD83 datum to global WGS84 datum

### DIFF
--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -108,7 +108,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
             # calculate the UTM zone from this avg longitude and define the UTM
             # CRS to project
             utm_zone = int(math.floor((avg_longitude + 180) / 6.) + 1)
-            utm_crs = {'datum': 'NAD83',
+            utm_crs = {'datum': 'WGS84',
                        'ellps': 'GRS80',
                        'proj' : 'utm',
                        'zone' : utm_zone,

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -109,7 +109,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
             # CRS to project
             utm_zone = int(math.floor((avg_longitude + 180) / 6.) + 1)
             utm_crs = {'datum': 'WGS84',
-                       'ellps': 'GRS80',
+                       'ellps': 'WGS84',
                        'proj' : 'utm',
                        'zone' : utm_zone,
                        'units': 'm'}


### PR DESCRIPTION
In [osmnx/projection.py](https://github.com/gboeing/osmnx/blob/cddf8ac83b4e800b4059a1b74c6a4b6b8e135c23/osmnx/projection.py#L108-L115), output CRS always gets `NAD83` as its datum. Since this is only defined for North America, there’s not a complete set of corresponding EPSG codes: http://spatialreference.org/ref/?search=NAD83+UTM

Consider switching to WGS84, which is defined globally: http://spatialreference.org/ref/?search=WGS84+UTM

