### PR TITLE
Add junction roundabout as oneway

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1248,7 +1248,7 @@ def add_paths(G, paths, network_type):
             # add this path (in only one direction) to the graph
             add_path(G, data, one_way=True)
 
-        elif 'junction' in data and data['junction'] == 'roundabout':
+        elif ('junction' in data and data['junction'] == 'roundabout') and not network_type == 'walk':
             # roundabout are also oneway but not tagged as is
             add_path(G, data, one_way=True)
 

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1248,6 +1248,10 @@ def add_paths(G, paths, network_type):
             # add this path (in only one direction) to the graph
             add_path(G, data, one_way=True)
 
+        elif 'junction' in data and data['junction'] == 'roundabout':
+            # roundabout are also oneway but not tagged as is
+            add_path(G, data, one_way=True)
+
         # else, this path is not tagged as one-way or it is a walking network
         # (you can walk both directions on a one-way street)
         else:

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -30,4 +30,4 @@ log_filename = 'osmnx'
 useful_tags_node = ['ref', 'highway']
 useful_tags_path = ['bridge', 'tunnel', 'oneway', 'lanes', 'ref', 'name',
                     'highway', 'maxspeed', 'service', 'access', 'area',
-                    'landuse', 'width', 'est_width']
+                    'landuse', 'width', 'est_width', 'junction']


### PR DESCRIPTION
Roundabout implies oneway=yes but is not tagged in OSM as it would be redundant.
It still needs to be taken as oneway=yes by not adding edges in both ways between nodes.
[OSM wiki about roundabouts](https://wiki.openstreetmap.org/wiki/Tag:junction%3Droundabout)