### PR TITLE
Update argument names in add_edge to support NetworkX 2.1+

### DIFF
--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -510,7 +510,7 @@ def gdfs_to_graph(gdf_nodes, gdf_edges):
         for label, value in row.iteritems():
             if (label not in ['u', 'v', 'key']) and (isinstance(value, list) or pd.notnull(value)):
                 attrs[label] = value
-        G.add_edge(u=row['u'], v=row['v'], key=row['key'], **attrs)
+        G.add_edge(row['u'], row['v'], key=row['key'], **attrs)
 
     return G
 

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -243,7 +243,7 @@ def simplify_graph(G, strict=True):
         for u, v in zip(path[:-1], path[1:]):
 
             # there shouldn't be multiple edges between interstitial nodes
-            if not G.number_of_edges(u=u, v=v) == 1:
+            if not G.number_of_edges(u, v) == 1:
                 log('Multiple edges between "{}" and "{}" found when simplifying'.format(u, v), level=lg.WARNING)
 
             # the only element in this list as long as above check is True


### PR DESCRIPTION
Fixes https://github.com/gboeing/osmnx/issues/127

Update `add_edge` to rely on the position of `u` and `v` arrays, as the names of these arguments have been updated/changed from `u` to `u_for_edge ` and `v` to `v_for_edge `.

PTAL and squash/merge if everything looks good!