### PR TITLE
use haversine formula for great-circle distance

### DIFF
--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -291,19 +291,16 @@ def great_circle_vec(lat1, lng1, lat2, lng2, earth_radius=6371009):
         units of earth_radius
     """
 
-    phi1 = np.deg2rad(90 - lat1)
-    phi2 = np.deg2rad(90 - lat2)
+    phi1 = np.deg2rad(lat1) 
+    phi2 = np.deg2rad(lat2) 
+    dphi = phi2-phi1 
 
-    theta1 = np.deg2rad(lng1)
-    theta2 = np.deg2rad(lng2)
+    dtheta = np.deg2rad(lng2 - lng1)
 
-    cos = (np.sin(phi1) * np.sin(phi2) * np.cos(theta1 - theta2) + np.cos(phi1) * np.cos(phi2))
+    h = np.sin(dphi/2)**2 + np.cos(phi1) * np.cos(phi2) * np.sin(dtheta/2)**2 
+    h = np.minimum(1.0, h) # protection against floating point errors
 
-    # ignore warnings during this calculation because numpy warns it cannot
-    # calculate arccos for self-loops since u==v
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        arc = np.arccos(cos)
+    arc = 2 * np.arcsin(np.sqrt(h))
 
     # return distance in units of earth_radius
     distance = arc * earth_radius


### PR DESCRIPTION
Haversine formula is commonly [prefered](https://gis.stackexchange.com/questions/4906/why-is-law-of-cosines-more-preferable-than-haversine-when-calculating-distance-b) due to smaller floating point errors. 