### PR TITLE
Fixed issue with windows paths

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -78,7 +78,7 @@ def save_to_cache(url, response_json):
             # hash the url (to make filename shorter than the often extremely
             # long url)
             filename = hashlib.md5(url.encode('utf-8')).hexdigest()
-            cache_path_filename = '{}/{}.json'.format(settings.cache_folder, filename)
+            cache_path_filename = os.path.join(settings.cache_folder, os.extsep.join([filename, 'json']))
 
             # dump to json, and save to file
             json_str = make_str(json.dumps(response_json))
@@ -105,7 +105,8 @@ def get_from_cache(url):
     if settings.use_cache:
         # determine the filename by hashing the url
         filename = hashlib.md5(url.encode('utf-8')).hexdigest()
-        cache_path_filename = '{}/{}.json'.format(settings.cache_folder, filename)
+
+        cache_path_filename = os.path.join(settings.cache_folder, os.extsep.join([filename, 'json']))
         # open the cache file for this url hash if it already exists, otherwise
         # return None
         if os.path.isfile(cache_path_filename):

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -246,7 +246,7 @@ def save_and_show(fig, ax, save, show, close, filename, file_format, dpi, axis_o
         # create the save folder if it doesn't already exist
         if not os.path.exists(settings.imgs_folder):
             os.makedirs(settings.imgs_folder)
-        path_filename = '{}/{}.{}'.format(settings.imgs_folder, filename, file_format)
+        path_filename = os.path.join(settings.imgs_folder, os.extsep.join([filename, file_format]))
 
         if file_format == 'svg':
             # if the file_format is svg, prep the fig/ax a bit for saving

--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -49,7 +49,7 @@ def save_gdf_shapefile(gdf, filename=None, folder=None):
 
     # give the save folder a filename subfolder to make the full path to the
     # files
-    folder_path = '{}/{}'.format(folder, filename)
+    folder_path = os.path.join(folder, filename)
 
     # make everything but geometry column a string
     for col in [c for c in gdf.columns if not c == 'geometry']:
@@ -134,7 +134,7 @@ def save_graph_shapefile(G, filename='graph', folder=None, encoding='utf-8'):
 
     # if the save folder does not already exist, create it with a filename
     # subfolder
-    folder = '{}/{}'.format(folder, filename)
+    folder = os.path.join(folder, filename)
     if not os.path.exists(folder):
         os.makedirs(folder)
 
@@ -183,8 +183,8 @@ def save_graphml(G, filename='graph.graphml', folder=None):
     if not os.path.exists(folder):
         os.makedirs(folder)
 
-    nx.write_graphml(G_save, '{}/{}'.format(folder, filename))
-    log('Saved graph "{}" to disk as GraphML at "{}/{}" in {:,.2f} seconds'.format(G_save.name, folder, filename, time.time()-start_time))
+    nx.write_graphml(G_save, os.path.join(folder, filename))
+    log('Saved graph "{}" to disk as GraphML at "{}" in {:,.2f} seconds'.format(G_save.name, os.path.join(folder, filename), time.time()-start_time))
 
 
 def load_graphml(filename, folder=None):
@@ -208,7 +208,7 @@ def load_graphml(filename, folder=None):
     # read the graph from disk
     if folder is None:
         folder = settings.data_folder
-    path = '{}/{}'.format(folder, filename)
+    path = os.path.join(folder, filename)
     G = nx.MultiDiGraph(nx.read_graphml(path, node_type=int))
 
     # convert graph crs attribute from saved string to correct dict data type

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -190,7 +190,7 @@ def get_logger(level=None, name=None, filename=None):
 
         # get today's date and construct a log filename
         todays_date = dt.datetime.today().strftime('%Y_%m_%d')
-        log_filename = '{}/{}_{}.log'.format(settings.logs_folder, filename, todays_date)
+        log_filename = os.path.join(settings.logs_folder, '{}_{}.log'.format(filename, todays_date))
 
         # if the logs folder does not already exist, create it
         if not os.path.exists(settings.logs_folder):


### PR DESCRIPTION
Windows paths are seperated using '\\' rather than '/'. This PR implements the use of `os.path.join` for path operations as is best practice. Also this properly handles an empty string to represent the current working directory like this: `ox.load_graphml('test.gml', folder='')`