### PR TITLE
Turn off x-axis and y-axis visibility to reduce plot margin when axis_off is True

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -403,8 +403,11 @@ def plot_graph(G, bbox=None, fig_height=6, fig_width=None, margin=0.02,
     ax.set_xlim((west - margin_ew, east + margin_ew))
 
     # configure axis appearance
-    ax.get_xaxis().get_major_formatter().set_useOffset(False)
-    ax.get_yaxis().get_major_formatter().set_useOffset(False)
+    xaxis = ax.get_xaxis()
+    yaxis = ax.get_yaxis()
+
+    xaxis.get_major_formatter().set_useOffset(False)
+    yaxis.get_major_formatter().set_useOffset(False)
 
     # if axis_off, turn off the axis display set the margins to zero and point
     # the ticks in so there's no space around the plot
@@ -412,6 +415,8 @@ def plot_graph(G, bbox=None, fig_height=6, fig_width=None, margin=0.02,
         ax.axis('off')
         ax.margins(0)
         ax.tick_params(which='both', direction='in')
+        xaxis.set_visible(False)
+        yaxis.set_visible(False)
         fig.canvas.draw()
 
     if equal_aspect:


### PR DESCRIPTION
When creating plots using the ``plot_graph`` function there are bigger margins on the left and bottom sides than on right and top because ``ax.axis('off')`` only removes the lines, ticks and labels, but not the space they take up. 

Turning of the visibility of the axes results in an image that sill has a margin around it, but it is considerably smaller and the actual plot appears centered. Please see the 2 images below for a comparison.

Plot created with unpatched version of osmnx:
![current](https://user-images.githubusercontent.com/60051/37060579-01da5e1a-2191-11e8-8aca-3352d0eb42bf.png)

Plot created with patched version of osmnx:
![patched](https://user-images.githubusercontent.com/60051/37060590-0cb066e0-2191-11e8-8636-69b35cd05ae1.png)