### PR TITLE
Allow create_graph to return a graph with no edges

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1331,7 +1331,8 @@ def create_graph(response_jsons, name='unnamed', retain_all=False, network_type=
 
     # add length (great circle distance between nodes) attribute to each edge to
     # use as weight
-    G = add_edge_lengths(G)
+    if len(G.edges) > 0:
+        G = add_edge_lengths(G)
 
     return G
 


### PR DESCRIPTION
A minor proposal: add a conditional in `create_graph` requiring `G` to have edges before calling `add_edge_lengths`. This allows a graph to be returned even if the overpass response includes only nodes. Otherwise, an error is thrown when `add_edge_lengths` is called on an edgeless graph.