### PR TITLE
Enable finding nearest edges from list of coordinates

### DIFF
--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -640,23 +640,23 @@ def get_nearest_edges(G, X, Y, method='kdtree', dist=10):
     G : networkx multidigraph
     X : list-like
         The vector of longitudes or x's for which we will find the nearest
-        edge in the graph
+        edge in the graph. For projected graphs, use the projected coordinates, usually in meters.
     Y : list-like
         The vector of latitudes or y's for which we will find the nearest
-        edge in the graph
-    method : str {None, 'kdtree'}
+        edge in the graph. For projected graphs, use the projected coordinates, usually in meters.
+    method : str {'kdtree', None}
         Which method to use for finding nearest edge to each point.
+        If 'kdtree' we use scipy.spatial.cKDTree for very fast euclidean search.
         If None, we manually find each edge one at a time using
-        osmnx.utils.get_nearest_edge. If 'kdtree' we use
-        scipy.spatial.cKDTree for very fast euclidean search.
+        osmnx.utils.get_nearest_edge.
     dist : float
-        spacing  distance for the point creation along edges. The smaller, the more points are created.
+        spacing length along edges. Units are the same as the geom; Degrees for unprojected
+        geometries and meters for projected geometries. The smaller the value, the more points are created.
 
     Returns
     -------
-    closest_road_to_point : tuple
-        A geometry object representing the segment and the coordinates of the two
-        nodes that determine the road section, u and v, the OSM ids of the nodes.
+    ne : ndarray
+        array of nearest edges represented by their startpoint and endpoint ids, u and v, the OSM ids of the nodes.
     """
     start_time = time.time()
 
@@ -716,8 +716,8 @@ def redistribute_vertices(geom, dist):
     geom: LineString or MultiLineString
         a Shapely geometry
     dist : float
-        point spacing along edges. The smaller, the more points are created.
-        Units must
+        spacing length along edges. Units are the same as the geom; Degrees for unprojected geometries and meters
+        for projected geometries. The smaller the value, the more points are created.
 
     Returns
     -------

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -618,45 +618,57 @@ def get_nearest_nodes(G, X, Y, method=None):
     return np.array(nn)
 
 
-def get_nearest_edges(G, X, Y, method='kdtree', dist=10):
+def get_nearest_edges(G, X, Y, method=None, dist=0.0001):
     """
     Return the graph edges nearest to a list of points. Pass in points
     as separate vectors of X and Y coordinates. The 'kdtree' method
     is by far the fastest with large data sets, but only finds approximate
     nearest edges if working in unprojected coordinates like lat-lng (it
     precisely finds the nearest edge if working in projected coordinates).
-
-    The method creates equally distanced points along the edges of the network.
-    Then, these points are used in a kdTree search to identify which is nearest to the
-
-    This method will not give the exact perpendicular point along the edge, but the
-    smaller the *dist* parameter, the closer the solution will be.
-
-    Code is adapted from an answer by JHuw from this original question:
-    https://gis.stackexchange.com/questions/222315/geopandas-find-nearest-point-in-other-dataframe
+    The 'balltree' method is second fastest with large data sets, but it
+    is precise if working in unprojected coordinates like lat-lng.
 
     Parameters
     ----------
     G : networkx multidigraph
     X : list-like
         The vector of longitudes or x's for which we will find the nearest
-        edge in the graph. For projected graphs, use the projected coordinates, usually in meters.
+        edge in the graph. For projected graphs, use the projected coordinates,
+        usually in meters.
     Y : list-like
         The vector of latitudes or y's for which we will find the nearest
-        edge in the graph. For projected graphs, use the projected coordinates, usually in meters.
-    method : str {'kdtree', None}
+        edge in the graph. For projected graphs, use the projected coordinates,
+        usually in meters.
+    method : str {None, 'kdtree', 'balltree'}
         Which method to use for finding nearest edge to each point.
-        If 'kdtree' we use scipy.spatial.cKDTree for very fast euclidean search.
         If None, we manually find each edge one at a time using
-        osmnx.utils.get_nearest_edge.
+        osmnx.utils.get_nearest_edge. If 'kdtree' we use
+        scipy.spatial.cKDTree for very fast euclidean search. Recommended for
+        projected graphs. If 'balltree', we use sklearn.neighbors.BallTree for
+        fast haversine search. Recommended for unprojected graphs.
+
     dist : float
-        spacing length along edges. Units are the same as the geom; Degrees for unprojected
-        geometries and meters for projected geometries. The smaller the value, the more points are created.
+        spacing length along edges. Units are the same as the geom; Degrees for
+        unprojected geometries and meters for projected geometries. The smaller
+        the value, the more points are created.
 
     Returns
     -------
     ne : ndarray
-        array of nearest edges represented by their startpoint and endpoint ids, u and v, the OSM ids of the nodes.
+        array of nearest edges represented by their startpoint and endpoint ids,
+        u and v, the OSM ids of the nodes.
+
+    Info
+    ----
+    The method creates equally distanced points along the edges of the network.
+    Then, these points are used in a kdTree or BallTree search to identify which
+    is nearest.Note that this method will not give the exact perpendicular point
+    along the edge, but the smaller the *dist* parameter, the closer the solution
+    will be.
+
+    Code is adapted from an answer by JHuw from this original question:
+    https://gis.stackexchange.com/questions/222315/geopandas-find-nearest-point
+    -in-other-dataframe
     """
     start_time = time.time()
 

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -661,11 +661,6 @@ def get_nearest_edges(G, X, Y, method=None, dist=10):
     """
     start_time = time.time()
 
-    if not isinstance(X, list) or not isinstance(Y, list):
-        # Check X or Y are not lists, throw them in one
-        X = [X]
-        Y = [Y]
-
     if method is None:
         # calculate nearest edge one at a time for each point
         ne = [get_nearest_edge(G, (x, y)) for x, y in zip(X, Y)]

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -618,7 +618,7 @@ def get_nearest_nodes(G, X, Y, method=None):
     return np.array(nn)
 
 
-def get_nearest_edges(G, X, Y, method=None, dist=10):
+def get_nearest_edges(G, X, Y, method='kdtree', dist=10):
     """
     Return the graph edges nearest to a list of points. Pass in points
     as separate vectors of X and Y coordinates. The 'kdtree' method
@@ -627,11 +627,10 @@ def get_nearest_edges(G, X, Y, method=None, dist=10):
     precisely finds the nearest edge if working in projected coordinates).
 
     The method creates equally distanced points along the edges of the network.
-    Then, these points are used in a kdTree search to find the nearest point along
-    an edge.
+    Then, these points are used in a kdTree search to identify which is nearest to the
 
     This method will not give the exact perpendicular point along the edge, but the
-    smaller the *dist* parameter, closer the solution will be.
+    smaller the *dist* parameter, the closer the solution will be.
 
     Code is adapted from an answer by JHuw from this original question:
     https://gis.stackexchange.com/questions/222315/geopandas-find-nearest-point-in-other-dataframe

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -755,7 +755,7 @@ def redistribute_vertices(geom, dist):
 
     Parameters
     ----------
-    geom: LineString or MultiLineString
+    geom : LineString or MultiLineString
         a Shapely geometry
     dist : float
         spacing length along edges. Units are the same as the geom; Degrees for unprojected geometries and meters

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -282,12 +282,25 @@ def test_nearest_edge():
 
 def test_nearest_edges():
 
+    from pyproj import Proj
+
     # test in closest edge section
     sheik_sayed_dubai = [25.09, 25.06, 55.16, 55.11]
     location_coordinates = (25.071764, 55.138978)
     G = ox.graph_from_bbox(*sheik_sayed_dubai, simplify=False, retain_all=True, network_type='drive')
-    ne = ox.get_nearest_edges(G, X=location_coordinates[0], Y=location_coordinates[1], dist=10)
 
+    # Unprojected
+    ne1 = ox.get_nearest_edges(G, X=[location_coordinates[1], location_coordinates[1]],
+                                  Y=[location_coordinates[0], location_coordinates[0]], method='balltree', dist=0.0001)
+
+    # Projected
+    G2 = ox.project_graph(G)
+    crs = Proj(G2.graph['crs'])
+
+    projected_point = crs(location_coordinates[1], location_coordinates[0])
+    ne2 = ox.get_nearest_edges(G2, X=[projected_point[0], projected_point[0]],
+                                   Y=[projected_point[1], projected_point[1]], method='kdtree', dist=10)
+    assert (ne1 == ne2).all()
 
 def test_buildings():
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -273,7 +273,7 @@ def test_routing_folium():
 
 def test_nearest_edge():
 
-    # test in closest road section
+    # test in closest edge section
     sheik_sayed_dubai = [25.09, 25.06, 55.16, 55.11]
     location_coordinates = (25.071764, 55.138978)
     G = ox.graph_from_bbox(*sheik_sayed_dubai, simplify=False, retain_all=True, network_type='drive')
@@ -282,7 +282,7 @@ def test_nearest_edge():
 
 def test_nearest_edges():
 
-    # test in closest road section
+    # test in closest edge section
     sheik_sayed_dubai = [25.09, 25.06, 55.16, 55.11]
     location_coordinates = (25.071764, 55.138978)
     G = ox.graph_from_bbox(*sheik_sayed_dubai, simplify=False, retain_all=True, network_type='drive')


### PR DESCRIPTION
This in part builds on top of #231 by @miskolc and is an answer to issue #198.

The biggest change is in the implementation of the kdTree search applied to virtual points created along all edges of the graph. Therefore the function can take in a list of points (such as building centroids) and find the corresponding edges in a very quick fashion.

This is one of my first pull requests so I am not sure if I have done everything correctly!