### PR TITLE
stop changing the type of the node ID to `float` and back to `int`, a…

### DIFF
--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -148,7 +148,6 @@ def project_graph(G, to_crs=None):
     gdf_nodes = gpd.GeoDataFrame(nodes).T
     gdf_nodes.crs = G_proj.graph['crs']
     gdf_nodes.gdf_name = '{}_nodes'.format(G_proj.name)
-    gdf_nodes['osmid'] = gdf_nodes['osmid'].astype(np.int64).map(make_str)
 
     # create new lat/lon columns just to save that data for later, and create a
     # geometry column from x/y

--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -102,7 +102,6 @@ def save_graph_shapefile(G, filename='graph', folder=None, encoding='utf-8'):
     gdf_nodes = gdf_nodes.drop(['x', 'y'], axis=1)
 
     # make everything but geometry column a string
-    gdf_nodes['osmid'] = gdf_nodes['osmid'].astype(np.int64)
     for col in [c for c in gdf_nodes.columns if not c == 'geometry']:
         gdf_nodes[col] = gdf_nodes[col].fillna('').map(make_str)
 
@@ -248,7 +247,6 @@ def load_graphml(filename, folder=None):
     # convert numeric node tags from string to numeric data types
     log('Converting node and edge attribute data types')
     for _, data in G.nodes(data=True):
-        data['osmid'] = int(data['osmid'])
         data['x'] = float(data['x'])
         data['y'] = float(data['y'])
 
@@ -276,10 +274,7 @@ def load_graphml(filename, folder=None):
         # osmid might have a single value or a list, but if single value, then
         # parse int
         if 'osmid' in data:
-            if data['osmid'][0] == '[' and data['osmid'][-1] == ']':
-                data['osmid'] = ast.literal_eval(data['osmid'])
-            else:
-                data['osmid'] = int(data['osmid'])
+            data['osmid'] = ast.literal_eval(data['osmid'])
 
         # if geometry attribute exists, load the string as well-known text to
         # shapely LineString
@@ -537,7 +532,6 @@ def graph_to_gdfs(G, nodes=True, edges=True, node_geometry=True, fill_edge_geome
             gdf_nodes['geometry'] = gdf_nodes.apply(lambda row: Point(row['x'], row['y']), axis=1)
         gdf_nodes.crs = G.graph['crs']
         gdf_nodes.gdf_name = '{}_nodes'.format(G.graph['name'])
-        gdf_nodes['osmid'] = gdf_nodes['osmid'].astype(np.int64).map(make_str)
 
         to_return.append(gdf_nodes)
         log('Created GeoDataFrame "{}" from graph in {:,.2f} seconds'.format(gdf_nodes.gdf_name, time.time()-start_time))

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -448,7 +448,7 @@ def get_nearest_node(G, point, method='haversine', return_dist=False):
 
     # dump graph node coordinates into a pandas dataframe indexed by node id
     # with x and y columns
-    coords = np.array([[node, data['x'], data['y']] for node, data in G.nodes(data=True)])
+    coords = [[node, data['x'], data['y']] for node, data in G.nodes(data=True)]
     df = pd.DataFrame(coords, columns=['node', 'x', 'y']).set_index('node')
 
     # add columns to the dataframe representing the (constant) coordinates of
@@ -477,7 +477,7 @@ def get_nearest_node(G, point, method='haversine', return_dist=False):
         raise ValueError('method argument must be either "haversine" or "euclidean"')
 
     # nearest node's ID is the index label of the minimum distance
-    nearest_node = int(distances.idxmin())
+    nearest_node = distances.idxmin()
     log('Found nearest node ({}) to point {} in {:,.2f} seconds'.format(nearest_node, point, time.time()-start_time))
 
     # if caller requested return_dist, return distance between the point and the


### PR DESCRIPTION
Avoids changing the type of the node ID to `float` and back to `int`. 
Allow other types than `int` as `osmid`