### PR TITLE
Add support for plotting planar spatial graphs

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -359,8 +359,8 @@ def plot_graph(G, bbox=None, fig_height=6, fig_width=None, margin=0.02,
     # get north, south, east, west values either from bbox parameter or from the
     # spatial extent of the edges' geometries
     if bbox is None:
-        edges = graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
-        west, south, east, north = edges.total_bounds
+        nodes = graph_to_gdfs(G, nodes=True, edges=False)
+        west, south, east, north = nodes.total_bounds
     else:
         north, south, east, west = bbox
 

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -10,6 +10,7 @@ import os
 import json
 import numpy as np
 import pandas as pd
+import networkx as nx
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 from matplotlib.collections import LineCollection
@@ -376,7 +377,8 @@ def plot_graph(G, bbox=None, fig_height=6, fig_width=None, margin=0.02,
     # draw the edges as lines from node to node
     start_time = time.time()
     lines = []
-    for u, v, data in G.edges(keys=False, data=True):
+
+    for u, v, data in nx.Graph(G).edges(data=True):
         if 'geometry' in data and use_geom:
             # if it has a geometry attribute (a list of line segments), add them
             # to the list of lines to plot

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -360,3 +360,21 @@ def test_nominatim():
         response_json = ox.nominatim_request(
                             params = params,
                             type = "transfer")
+
+def test_planar_plot():
+
+    # This test shows that we can use either statement to get the total bounds
+    # Using nodes instead of edges avoids the use of G.edges(keys=True)
+    # so that planar graphs are supported for plotting
+    G = ox.graph_from_place('Piedmont, California, USA')
+
+    nodes = ox.graph_to_gdfs(G, nodes=True, edges=False)
+    edges = ox.graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
+
+    assert nodes.total_bounds.all() == edges.total_bounds.all()
+
+    # Make sure that plot_graph runs smoothly with a dummy nx.Graph()
+    import networkx as nx
+
+    planar_G = nx.Graph(G)
+    ox.plot_graph(planar_G)


### PR DESCRIPTION
When plotting a graph, if `G` is a planar graph and hence of type `nx.DiGraph`, instead of `nx.MultiDiGraph`, then `plot_graph` will throw a `KeyError` exception for the `keys` attribute. The workaround, which does not affect the output, is to cast to `G` to a Graph when iterating through the edges and their geometries to get the list of lines (which is kind of what is being done anyway).

An example of _downgrading_ `G`, is when using `clean_intersections()` to obtain the intersection points' centroids and then trying to construct a new graph, planar for simplification, using the centroids as nodes.