### PR TITLE
add which_result argument parameter to footprints/pois_from_place #290

### DIFF
--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -330,7 +330,7 @@ def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=F
                                  retain_invalid=retain_invalid)
 
 
-def footprints_from_place(place, footprint_type='building', retain_invalid=False):
+def footprints_from_place(place, footprint_type='building', retain_invalid=False, which_result=1):
     """
     Get footprints within the boundaries of some place.
 
@@ -348,13 +348,15 @@ def footprints_from_place(place, footprint_type='building', retain_invalid=False
         type of footprint to be downloaded. OSM tag key e.g. 'building', 'landuse', 'place', etc.
     retain_invalid : bool
         if False discard any footprints with an invalid geometry
+    which_result : int
+        max number of results to return and which to process upon receipt
 
     Returns
     -------
     GeoDataFrame
     """
 
-    city = gdf_from_place(place)
+    city = gdf_from_place(place, which_result=which_result)
     polygon = city['geometry'].iloc[0]
     return create_footprints_gdf(polygon, retain_invalid=retain_invalid,
                                  footprint_type=footprint_type)

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -433,7 +433,7 @@ def pois_from_polygon(polygon, amenities=None):
     return create_poi_gdf(polygon=polygon, amenities=amenities)
 
 
-def pois_from_place(place, amenities=None):
+def pois_from_place(place, amenities=None, which_result=1):
     """
     Get points of interest (POIs) within the boundaries of some place.
 
@@ -444,12 +444,14 @@ def pois_from_place(place, amenities=None):
     amenities : list
         List of amenities that will be used for finding the POIs from the selected area.
         See available amenities from: http://wiki.openstreetmap.org/wiki/Key:amenity
+    which_result : int
+        max number of results to return and which to process upon receipt
 
     Returns
     -------
     GeoDataFrame
     """
 
-    city = gdf_from_place(place)
+    city = gdf_from_place(place, which_result=which_result)
     polygon = city['geometry'].iloc[0]
     return create_poi_gdf(polygon=polygon, amenities=amenities)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -306,6 +306,8 @@ def test_nearest_edges():
 
 def test_footprints():
 
+    import pytest
+
     # download footprints and plot them
     gdf = ox.footprints_from_place(place='Emeryville, California, USA')
     gdf = ox.footprints_from_address(address='600 Montgomery St, San Francisco, California, USA', distance=300)
@@ -318,9 +320,17 @@ def test_footprints():
     assert 1767022 in gdf.index, "relation 1767022 was not returned in the geodataframe"
     assert gdf.loc[1767022]['geometry'].type=='MultiPolygon', "relation 1767022 is not a multipolygon"
 
+    # should raise an exception
+    # polygon or -north, south, east, west- should be provided
+    with pytest.raises(ValueError):
+        ox.create_footprints_gdf(polygon=None, north=None, south=None, east=None, west=None)
+
+    gdf = ox.footprints_from_place(place='kusatsu, shiga, japan', which_result=2)
+
 
 def test_pois():
 
+    import pytest
     # download all points of interests from place
     gdf = ox.pois_from_place(place='Kamppi, Helsinki, Finland')
 
@@ -336,6 +346,13 @@ def test_pois():
     # by point and by address
     restaurants = ox.pois_from_point(point=(42.344490, -71.070570), distance=1000, amenities=['restaurant'])
     restaurants = ox.pois_from_address(address='Emeryville, California, USA', distance=1000, amenities=['restaurant'])
+
+    # should raise an exception
+    # polygon or -north, south, east, west- should be provided
+    with pytest.raises(ValueError):
+        ox.create_poi_gdf(polygon=None, north=None, south=None, east=None, west=None)
+
+    gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2)
 
 
 def test_nominatim():


### PR DESCRIPTION
Issue #290 

Add which_result argument parameter to footprints_from_place and pois_from_place.

Extended the tests `test_footprints` and `test_pois`. Also added a couple of extra lines to increase the coverage (let me know if that's ok).