### PR TITLE
issue #219, allow changing the nominatim endpoint

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -250,9 +250,12 @@ def nominatim_request(params, type = "search", pause_duration=1, timeout=30, err
 
     # prepare the Nominatim API URL and see if request already exists in the
     # cache
-    url = 'https://nominatim.openstreetmap.org/{}'.format(type)
+    url = settings.nominatim_endpoint.rstrip('/') + '/{}'.format(type)
     prepared_url = requests.Request('GET', url, params=params).prepare().url
     cached_response_json = get_from_cache(prepared_url)
+
+    if settings.nominatim_key:
+        params['key'] = settings.nominatim_key
 
     if cached_response_json is not None:
         # found this request in the cache, just return it instead of making a

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -59,3 +59,6 @@ default_crs = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
 default_user_agent = 'Python OSMnx package (https://github.com/gboeing/osmnx)'
 default_referer = 'Python OSMnx package (https://github.com/gboeing/osmnx)'
 default_accept_language = 'en'
+
+nominatim_endpoint = "https://nominatim.openstreetmap.org/"
+nominatim_key = None

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -62,7 +62,9 @@ def config(data_folder=settings.data_folder,
            default_crs=settings.default_crs,
            default_user_agent=settings.default_user_agent,
            default_referer=settings.default_referer,
-           default_accept_language=settings.default_accept_language):
+           default_accept_language=settings.default_accept_language,
+           nominatim_endpoint=settings.nominatim_endpoint,
+           nominatim_key=settings.nominatim_key):
     """
     Configure osmnx by setting the default global vars to desired values.
 
@@ -133,6 +135,8 @@ def config(data_folder=settings.data_folder,
     settings.default_user_agent = default_user_agent
     settings.default_referer = default_referer
     settings.default_accept_language = default_accept_language
+    settings.nominatim_endpoint = nominatim_endpoint
+    settings.nominatim_key = nominatim_key
 
     # if logging is turned on, log that we are configured
     if settings.log_file or settings.log_console:

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -372,6 +372,25 @@ def test_nominatim():
                             params = params,
                             type = "transfer")
 
+    # Searching on public nominatim should work even if a key was provided
+    ox.config(
+        nominatim_key="NOT_A_KEY"
+    )
+    response_json = ox.nominatim_request(params = params,
+                                         type = "search")
+
+    # Test changing the endpoint. It should fail because we didn't provide a valid key
+    ox.config(
+        nominatim_endpoint="http://open.mapquestapi.com/nominatim/v1/"
+    )
+    with pytest.raises(Exception):
+        response_json = ox.nominatim_request(params=params,
+                                             type="search")
+
+    ox.config(log_console=True, log_file=True, use_cache=True,
+              data_folder='.temp/data', logs_folder='.temp/logs',
+              imgs_folder='.temp/imgs', cache_folder='.temp/cache')
+
 
 def test_osm_xml_output():
     G = ox.graph_from_place('Piedmont, California, USA')


### PR DESCRIPTION
Allow the use of a different Nominatim instance.
This is how it works:

1. Of course, without any change in the configuration, everything works as before:

```python
>>> import osmnx as ox
>>> g = ox.gdf_from_place("shimogyo, kyoto, japan")
>>>
```

2. If, for some reason you added a key, but didn't change the endpoint, the OSM nominatim still works as before

```python
>>> ox.config(nominatim_key="NOT_A_KEY")
>>> g = ox.gdf_from_place("shimogyo, kyoto, japan")
>>>
```

3. Of course, if you change to a commercial instance, you need a valid key, otherwise:

```python
>>> ox.config(nominatim_endpoint="http://open.mapquestapi.com/nominatim/v1/")
>>> g = ox.gdf_from_place("shimogyo, kyoto, japan")
Traceback (most recent call last):
  File "/Users/enriquearriaga/git/oxdev/osmnx/core.py", line 279, in nominatim_request
    response_json = response.json()
  File "/Users/enriquearriaga/git/sandpox/env/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/enriquearriaga/git/oxdev/osmnx/core.py", line 447, in gdf_from_place
    data = osm_polygon_download(query, limit=which_result)
  File "/Users/enriquearriaga/git/oxdev/osmnx/core.py", line 415, in osm_polygon_download
    response_json = nominatim_request(params=params, timeout=30)
  File "/Users/enriquearriaga/git/oxdev/osmnx/core.py", line 297, in nominatim_request
    raise Exception('Server returned no JSON data.\n{} {}\n{}'.format(response, response.reason, response.text))
Exception: Server returned no JSON data.
<Response [403]> Forbidden
The AppKey submitted with this request is invalid.
>>>
```

4. When you configure it with a valid key, it works just as OSM nominatim:

```python
>>> ox.config(nominatim_endpoint="http://open.mapquestapi.com/nominatim/v1/", 
              nominatim_key=my_key)
>>> g = ox.gdf_from_place("shimogyo, kyoto, japan")
>>> g
    bbox_east  bbox_north  bbox_south   bbox_west                                           geometry                                     place_name
0  135.771569    35.00429   34.981467  135.727291  POLYGON ((135.727291 34.985768, 135.728138 34....  Shimogyo Ward, Kyoto, Kyoto Prefecture, Japan
>>> 
```

=================

Now, there are few points we need to consider.

1. Since the results are cached using the prepared URL, if you change the endpoint, automatically all the cached results will be ignored.
1. The behavior of last point is correct. I have tested extensively both OSM and MapQuest nominatim, and sometimes they are not in sync. Specially the order of the results. Hence, some of the `which_result=` arguments used for one instance may not work on another.
1. I added the key to params after we use the prepared URL for caching. Thanks to this, even if you use a different key, all the cached results should work the same.
1. Everything else is supposed to behave the same way.
1. I don't know if there is a 'cleaner' way to restore the config after `test_nominatim()`.