### PR TITLE
Allow change overpass endpoint

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -185,13 +185,13 @@ def get_pause_duration(recursive_delay=5, default_duration=10):
     """
 
     try:
-        response = requests.get(settings.overpass_endpoint.replace('interpteter', 'status'), headers=get_http_headers())
+        response = requests.get(settings.overpass_endpoint.replace('interpreter', 'status'), headers=get_http_headers())
         status = response.text.split('\n')[3]
         status_first_token = status.split(' ')[0]
     except Exception:
         # if we cannot reach the status endpoint or parse its output, log an
         # error and return default duration
-        log('Unable to query %s'%settings.overpass_endpoint.replace('interpteter', 'status'), level=lg.ERROR)
+        log('Unable to query %s'%settings.overpass_endpoint.replace('interpreter', 'status'), level=lg.ERROR)
         return default_duration
 
     try:

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -183,14 +183,15 @@ def get_pause_duration(recursive_delay=5, default_duration=10):
     -------
     int
     """
+
     try:
-        response = requests.get('http://overpass-api.de/api/status', headers=get_http_headers())
+        response = requests.get(settings.overpass_endpoint.replace('interpteter', 'status'), headers=get_http_headers())
         status = response.text.split('\n')[3]
         status_first_token = status.split(' ')[0]
     except Exception:
         # if we cannot reach the status endpoint or parse its output, log an
         # error and return default duration
-        log('Unable to query http://overpass-api.de/api/status', level=lg.ERROR)
+        log('Unable to query %s'%settings.overpass_endpoint.replace('interpteter', 'status'), level=lg.ERROR)
         return default_duration
 
     try:
@@ -323,7 +324,7 @@ def overpass_request(data, pause_duration=None, timeout=180, error_pause_duratio
 
     # define the Overpass API URL, then construct a GET-style URL as a string to
     # hash to look up/save to cache
-    url = 'http://overpass-api.de/api/interpreter'
+    url = settings.overpass_endpoint
     prepared_url = requests.Request('GET', url, params=data).prepare().url
     cached_response_json = get_from_cache(prepared_url)
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -64,3 +64,6 @@ default_accept_language = 'en'
 # and your API key, if you are using a commercial endpoint that requires it
 nominatim_endpoint = "https://nominatim.openstreetmap.org/"
 nominatim_key = None
+
+# which API endpoint to use for overpass queries
+overpass_endpoint = "http://overpass-api.de/api/interpreter"

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -64,7 +64,8 @@ def config(data_folder=settings.data_folder,
            default_referer=settings.default_referer,
            default_accept_language=settings.default_accept_language,
            nominatim_endpoint=settings.nominatim_endpoint,
-           nominatim_key=settings.nominatim_key):
+           nominatim_key=settings.nominatim_key,
+           overpass_endpoint=settings.overpass_endpoint):
     """
     Configure osmnx by setting the default global vars to desired values.
 
@@ -139,6 +140,7 @@ def config(data_folder=settings.data_folder,
     settings.default_accept_language = default_accept_language
     settings.nominatim_endpoint = nominatim_endpoint
     settings.nominatim_key = nominatim_key
+    settings.overpass_endpoint = overpass_endpoint
 
     # if logging is turned on, log that we are configured
     if settings.log_file or settings.log_console:


### PR DESCRIPTION
Similar to [this](https://github.com/gboeing/osmnx/commit/68fc1065734f792edbafd67d119ba01fd9e0d5e3). 

It's a crucial change for osmnx users from Russia – http://overpass-api.de is unavailable here without a proxy. Some of the other public endpoints (for example https://overpass.kumi.systems/api/ and others provided on the [overpass-turbo](https://overpass-turbo.eu/) website) work fine.

This is my first pull request, I'll be happy to discuss and improve it. It seems to work for me locally.