### PR TITLE
Add node elevations from DEM files

### DIFF
--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -6,7 +6,6 @@
 # Web: https://github.com/gboeing/osmnx
 ################################################################################
 
-import demquery
 import math
 import networkx as nx
 import pandas as pd
@@ -16,6 +15,11 @@ import time
 from .core import get_from_cache
 from .core import save_to_cache
 from .utils import log
+
+try:
+    import demquery
+except ImportError:
+    demquery = None
 
 
 def add_node_elevations(G, api_key, max_locations_per_batch=350,
@@ -117,6 +121,9 @@ def add_node_elevations_from_dem(G, dem_paths, band=1, interp_kind=None):
     -------
     G : networkx multidigraph
     """
+    if demquery is None:
+        msg = 'The demquery package must be installed to use this optional feature.'
+        raise ImportError(msg)
 
     nodes = [(node, data['x'], data['y']) for node, data in G.nodes(data=True)]
     df = pd.DataFrame(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 coverage
 coveralls
+demquery>=0.2.0
 folium
 pytest
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-demquery>=0.2.0
 descartes>=1.1
 geopandas>=0.5
 matplotlib>=2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+demquery>=0.2.0
 descartes>=1.1
 geopandas>=0.5
 matplotlib>=2.2


### PR DESCRIPTION
Refactor of #343 to use [`demquery`](https://github.com/kylebarron/demquery).

**Overview**:

- I split my code into a new Python package on PyPI. 
- Since learning about [Virtual Rasters](https://gdal.org/drivers/raster/vrt.html), the code to find elevations is an order of magnitude simpler. I don't do any joining of nearby rasters; GDAL does all of that.
- I discovered that `interp2d` gives those warnings only when the grid is not the expected size for the type of interpolation: 3x3 for linear interpolation, 5x5 for cubic interpolation, and 7x7 for quintic interpolation. So I removed the option to manually choose the size of the interpolation region. If `interp_kind` is `linear`, it creates a 3x3 grid.
- Checks for nodata values; the virtual raster can have regions with no data that are inside the file's bounds, if the provided files didn't create an exact rectangle. My package raises an error if it sees those values in the interpolation region.
- I'm working on writing tests in the demquery package. ~~I'm having issues with rasterio working on Travis CI~~ the osmnx `.travis.yml` was quite helpful.
- Do you have plans to deprecate Python 2.7 and 3.4? Python 3.4 is already end of life, and 2.7 is in a month. I made `demquery` 3.5+ compatible, but haven't tested Python 2.7.
- Right now, `demquery` is only on PyPI, and I think that's why the current Travis build is failing.

**Example**:

Download both the files 
[`USGS_NED_13_n33w117_IMG`](https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/IMG/USGS_NED_13_n33w117_IMG.zip) 
[`USGS_NED_13_n34w117_IMG`](https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/IMG/USGS_NED_13_n34w117_IMG.zip) 
450MB extracted each

```py
import osmnx as ox
west = -116.66587829589844
south = 32.90120475753773
north = 33.094201303793194
east = -116.46263122558594
G = ox.graph_from_bbox(north=north, south=south, west=west, east=east)
dem_paths = ['USGS_NED_13_n33w117_IMG.img', 'USGS_NED_13_n34w117_IMG.img']
# interp_kind can be None, linear, cubic, or quintic
G = add_node_elevations_from_dem(G, dem_paths, interp_kind=None)
G = add_edge_grades(G)
```