### PR TITLE
Fixed pois_from_polygon returning pois outside the polygon

### DIFF
--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -360,6 +360,9 @@ def create_poi_gdf(polygon=None, amenities=None, north=None, south=None, east=No
     # Combine GeoDataFrames
     gdf = gdf_nodes.append(gdf_ways, sort=False)
 
+    if polygon:
+        gdf = gdf.loc[gdf['geometry'].centroid.within(polygon)==True]
+
     return gdf
 
 


### PR DESCRIPTION
I noticed that `pois_from_polygon` was returning POIs from outside the polygon.

Added line to mask the GeoDataFrame with POIs that are within the polygon if a polygon argument is present when calling `create_poi_gdf`