### PR TITLE
Fix improper geometry assignment

### DIFF
--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -148,6 +148,7 @@ def project_graph(G, to_crs=None):
     gdf_nodes['lon'] = gdf_nodes['x']
     gdf_nodes['lat'] = gdf_nodes['y']
     gdf_nodes['geometry'] = gdf_nodes.apply(lambda row: Point(row['x'], row['y']), axis=1)
+    gdf_nodes.set_geometry('geometry', inplace=True)
     log('Created a GeoDataFrame from graph in {:,.2f} seconds'.format(time.time()-start_time))
 
     # project the nodes GeoDataFrame to UTM

--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -630,6 +630,7 @@ def graph_to_gdfs(G, nodes=True, edges=True, node_geometry=True, fill_edge_geome
         gdf_nodes = gpd.GeoDataFrame(list(data), index=nodes)
         if node_geometry:
             gdf_nodes['geometry'] = gdf_nodes.apply(lambda row: Point(row['x'], row['y']), axis=1)
+            gdf_nodes.set_geometry('geometry', inplace=True)
         gdf_nodes.crs = G.graph['crs']
         gdf_nodes.gdf_name = '{}_nodes'.format(G.graph['name'])
 


### PR DESCRIPTION
Patch for https://github.com/geopandas/geopandas/issues/1249. In the geopandas master, geometry column assigned after the creation of gdf is not properly recognised and `unary_union` does not work. `set_geometry` fixes the issue.

Hopefully this will be fixed in geopandas before the next release, but there is no harm ensuring that gdf is created correctly in OSMnx.

As a side note, I would recommend having one Travis env with master of geopandas and networkx (+ maybe other) to capture this kind of issues ahead of release. E.g. Geopandas is changing the way it stores CRS [which will require another minor change in OSMnx](https://github.com/geopandas/geopandas/pull/1101#issuecomment-570727439).