### PR TITLE
Final updates to osm XML output method

### DIFF
--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -293,7 +293,7 @@ def save_as_osm(
         # many ways with the same OSM id. This does not conform to the
         # OSM XML schema standard, however, the data will still comprise a
         # valid network and will be readable by *most* OSM tools.
-        for i, row in tqdm(edges.iterrows(), total=len(edges)):
+        for i, row in edges.iterrows():
             edge = etree.SubElement(
                 root, 'way', attrib=row[edge_attrs].dropna().to_dict())
             etree.SubElement(edge, 'nd', attrib={'ref': row['u']})

--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -21,8 +21,6 @@ from xml.etree import ElementTree as etree
 from . import settings
 from .utils import make_str, log, get_unique_nodes_ordered_from_way
 
-from tqdm import tqdm
-
 
 def save_gdf_shapefile(gdf, filename=None, folder=None):
     """

--- a/osmnx/save_load.py
+++ b/osmnx/save_load.py
@@ -21,6 +21,8 @@ from xml.etree import ElementTree as etree
 from . import settings
 from .utils import make_str, log, get_unique_nodes_ordered_from_way
 
+from tqdm import tqdm
+
 
 def save_gdf_shapefile(gdf, filename=None, folder=None):
     """
@@ -140,7 +142,7 @@ def save_graph_shapefile(G, filename='graph', folder=None, encoding='utf-8'):
     # save the nodes and edges as separate ESRI shapefiles
     gdf_nodes.to_file('{}/nodes'.format(folder), encoding=encoding)
     gdf_edges.to_file('{}/edges'.format(folder), encoding=encoding)
-    log('Saved graph "{}" to disk as shapefiles at "{}" in {:,.2f} seconds'.format(G_save.name, folder, time.time()-start_time))
+    log('Saved graph "{}" to disk as shapefiles at "{}" in {:,.2f} seconds'.format(G_save.name, folder, time.time() - start_time))
 
 
 def save_as_osm(
@@ -148,8 +150,8 @@ def save_as_osm(
         node_attrs=settings.osm_xml_node_attrs,
         edge_tags=settings.osm_xml_way_tags,
         edge_attrs=settings.osm_xml_way_attrs,
-        oneway=False, filename='graph.osm',
-        folder=None):
+        oneway=False, merge_edges=True, edge_tag_aggs=None,
+        filename='graph.osm', folder=None):
     """
     Save a graph as an OSM XML formatted file. NOTE: for very large
     networks this method can take upwards of 30+ minutes to finish.
@@ -162,6 +164,28 @@ def save_as_osm(
         the name of the osm file (including file extension)
     folder : string
         the folder to contain the file, if None, use default data folder
+    node_attrs: list
+        osm node attributes to include in output OSM XML
+    edge_tags : list
+        osm way tags to include in output OSM XML
+    edge_attrs : list
+        osm way attributes to include in output OSM XML
+    oneway : bool
+        the default oneway value used to fill this tag where missing
+    merge_edges : bool
+        if True merges graph edges such that each OSM way has one entry
+            and one entry only in the OSM XML. Otherwise, every OSM way
+            will have a separate entry for each node pair it contains.
+    edge_tag_aggs : list of length-2 string tuples
+        useful only if merge_edges is True, this argument allows the user
+            to specify edge attributes to aggregate such that the merged
+            OSM way entry tags accurately represent the sum total of
+            their component edge attributes. For example, if the user
+            wants the OSM way to have a "length" attribute, the user must
+            specify `edge_tag_aggs=[('length', 'sum')]` in order to tell
+            this method to aggregate the lengths of the individual
+            component edges. Otherwise, the length attribute will simply
+            reflect the length of the first edge associated with the way.
 
     Returns
     -------
@@ -228,23 +252,57 @@ def save_as_osm(
                 node, 'tag', attrib={'k': tag, 'v': row[tag]})
 
     # append edges to the XML tree
-    for e in edges['id'].unique():
-        all_way_edges = edges[edges['id'] == e]
-        first = all_way_edges.iloc[0]
-        edge = etree.SubElement(
-            root, 'way', attrib=first[edge_attrs].dropna().to_dict())
+    if merge_edges:
+        for e in edges['id'].unique():
+            all_way_edges = edges[edges['id'] == e]
+            first = all_way_edges.iloc[0]
+            edge = etree.SubElement(
+                root, 'way', attrib=first[edge_attrs].dropna().to_dict())
 
-        if len(all_way_edges) == 1:
-            etree.SubElement(edge, 'nd', attrib={'ref': first['u']})
-            etree.SubElement(edge, 'nd', attrib={'ref': first['v']})
-        else:
-            ordered_nodes = get_unique_nodes_ordered_from_way(all_way_edges)
-            for node in ordered_nodes:
-                etree.SubElement(edge, 'nd', attrib={'ref': node})
+            if len(all_way_edges) == 1:
 
-        for tag in edge_tags:
-            etree.SubElement(
-                edge, 'tag', attrib={'k': tag, 'v': first[tag]})
+                etree.SubElement(edge, 'nd', attrib={'ref': first['u']})
+                etree.SubElement(edge, 'nd', attrib={'ref': first['v']})
+
+            else:
+
+                # topological sort
+                ordered_nodes = get_unique_nodes_ordered_from_way(
+                    all_way_edges)
+
+                for node in ordered_nodes:
+                    etree.SubElement(edge, 'nd', attrib={'ref': node})
+
+            if edge_tag_aggs is None:
+                for tag in edge_tags:
+                    etree.SubElement(
+                        edge, 'tag', attrib={'k': tag, 'v': first[tag]})
+            else:
+                for tag in edge_tags:
+                    if tag not in [t for t, agg in edge_tag_aggs]:
+                        etree.SubElement(
+                            edge, 'tag', attrib={'k': tag, 'v': first[tag]})
+
+                for tag, agg in edge_tag_aggs:
+                    etree.SubElement(edge, 'tag', attrib={
+                        'k': tag, 'v': all_way_edges[tag].aggregate(agg)})
+
+    else:
+
+        # NOTE: this will generate separate OSM ways for each network edge,
+        # even if the edges are all part of the same original OSM way. As
+        # such, each way will be comprised of two nodes, and there will be
+        # many ways with the same OSM id. This does not conform to the
+        # OSM XML schema standard, however, the data will still comprise a
+        # valid network and will be readable by *most* OSM tools.
+        for i, row in tqdm(edges.iterrows(), total=len(edges)):
+            edge = etree.SubElement(
+                root, 'way', attrib=row[edge_attrs].dropna().to_dict())
+            etree.SubElement(edge, 'nd', attrib={'ref': row['u']})
+            etree.SubElement(edge, 'nd', attrib={'ref': row['v']})
+            for tag in edge_tags:
+                etree.SubElement(
+                    edge, 'tag', attrib={'k': tag, 'v': row[tag]})
 
     et = etree.ElementTree(root)
 

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -2,6 +2,7 @@ import sys
 import os
 import datetime as dt
 import unicodedata
+import networkx as nx
 import numpy as np
 import logging as lg
 from . import settings
@@ -356,66 +357,54 @@ def get_unique_nodes_ordered_from_way(way_edges_df):
 
     NOTE: If the edges do not all connect (e.g. [(1, 2), (2,3),
     (10, 11), (11, 12), (12, 13)]), then this method will return
-    only those nodes associated with the FIRST chunk of connected
-    edges, even if subsequent connected chunks are contain more
-    total nodes. I don't believe that we would ever encounter this
-    kind of disconnected structure of nodes within a given way,
+    only those nodes associated with the largest component of
+    connected edges, even if subsequent connected chunks are contain
+    more total nodes. This is done to ensure a proper topological
+    representation of nodes in the XML way records because if there
+    are unconnected components, the sorting algorithm cannot recover
+    their original order. I don't believe that we would ever encounter
+    this kind of disconnected structure of nodes within a given way,
     but as best I could tell it is not explicitly forbidden in the
-    OSM XML design schema. As such, I had to safeguard against it
-    to ensure this method wouldn't get stuck in the while loop if
-    encountered a disconnected structure. I'm using a print
-    statement right now to tell the user whether or not any nodes
-    have been dropped and how many.
+    OSM XML design schema. I'm using a print statement right now to
+    tell the user whether or not any nodes have been dropped and
+    how many.
     """
+
+    G = nx.MultiDiGraph()
     all_nodes = list(way_edges_df['u'].values) + \
         list(way_edges_df['v'].values)
+
+    G.add_nodes_from(all_nodes)
+    G.add_edges_from(way_edges_df[['u', 'v']].values)
+    wccs = nx.weakly_connected_components(G)
+    largest_wcc = max(wccs, key=len)
+    node_subset = set(largest_wcc)
+
+    # NOTE: this code (L387-403) is copied from geo_utils.py
+    # which cannot be imported here without triggering a
+    # circular import error. This should be fixed next time the
+    # code base is refactored
+
+    # copy nodes into new graph
+    G2 = G.__class__()
+    G2.add_nodes_from((n, G.nodes[n]) for n in node_subset)
+
+    # copy edges to new graph, including parallel edges
+    if G2.is_multigraph:
+        G2.add_edges_from((n, nbr, key, d)
+            for n, nbrs in G.adj.items() if n in node_subset
+            for nbr, keydict in nbrs.items() if nbr in node_subset
+            for key, d in keydict.items())
+    else:
+        G2.add_edges_from((n, nbr, d)
+            for n, nbrs in G.adj.items() if n in node_subset
+            for nbr, d in nbrs.items() if nbr in node_subset)
+
+    # update graph attribute dict, and return graph
+    G2.graph.update(G.graph)
+
+    unique_ordered_nodes = list(nx.topological_sort(G2))
     num_unique_nodes = len(np.unique(all_nodes))
-    node_pairs = list(way_edges_df[['u', 'v']].values)
-    unique_ordered_nodes = []
-    recycled = []
-
-    while len(node_pairs) > 0:
-
-        pair = node_pairs.pop(0)
-        start = pair[0]
-        end = pair[1]
-        the_rest = [element for p in node_pairs for element in p]
-
-        # first pair
-        if len(unique_ordered_nodes) == 0:
-
-            # if there are subsequent pairs to match on
-            if start in the_rest or end in the_rest:
-                unique_ordered_nodes = list(pair)
-            continue
-
-        # if both nodes are already in the list, we don't need them
-        if (start in unique_ordered_nodes) and (end in unique_ordered_nodes):
-            continue
-
-        # if start node is in the list, add the end node to the right of it
-        if start in unique_ordered_nodes:
-            start_idx = unique_ordered_nodes.index(start)
-            end_idx = start_idx + 1
-            unique_ordered_nodes[end_idx:end_idx] = [end]
-
-        # if end node is in the list, add the start node to the left of it
-        elif end in unique_ordered_nodes:
-            end_idx = unique_ordered_nodes.index(end)
-            start_idx = end_idx
-            unique_ordered_nodes[start_idx:start_idx] = [start]
-
-        else:
-            # if we've already processed this pair and there is still no way
-            # to match it in the list, then we're done
-            if list(pair) in recycled:
-                break
-
-            # if there's no match in the list but there's a match in the
-            # remaining pairs to be processed, recycle it to process again
-            elif start in the_rest or end in the_rest:
-                node_pairs.append(pair)
-                recycled.append(list(pair))
 
     if len(unique_ordered_nodes) < num_unique_nodes:
         print('Recovered order for {0} of {1} nodes'.format(

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -437,7 +437,13 @@ def test_nominatim():
 def test_osm_xml_output():
     ox.settings.all_oneway = True
     G = ox.graph_from_place('Piedmont, California, USA')
-    ox.save_as_osm(G)
+    ox.save_as_osm(G, merge_edges=False)
+
+
+def test_osm_xml_output_merge_edges():
+    ox.settings.all_oneway = True
+    G = ox.graph_from_place('Piedmont, California, USA')
+    ox.save_as_osm(G, merge_edges=True, edge_tag_aggs=[('length', 'sum')])
 
 
 def test_osm_xml_output_from_gdfs():
@@ -448,8 +454,8 @@ def test_osm_xml_output_from_gdfs():
 
 
 def test_ordered_nodes_from_way():
-    df = pd.DataFrame({
-        'u': [54, 2, 5, 3, 10, 19, 20],
+    df = pd.DataFrame(
+        {'u':[54, 2, 5, 3, 10, 19, 20],
         'v': [76, 3, 8, 10, 5, 20, 15]})
     ordered_nodes = ox.get_unique_nodes_ordered_from_way(df)
     assert ordered_nodes == [2, 3, 10, 5, 8]


### PR DESCRIPTION
Three principal changes here, pretty straightforward:

1. replaced my hacky node ordering algorithm with NetworkX's built-in topological sort.
2. made the many-to-one edge to OSM way merge optional, because for use cases where the user doesn't care about preserving unique OSM way IDs in their output, it is MUCH faster to not have to do the topological sorting of nodes.
3. for the case where the user does want to merge edges by OSM way, I added functionality to give users the ability to specify edge attributes to aggregate as well as how they should be aggregated. For instance, if the user wants the output to contain accurate "length" tags, they would need to sum the length attributes from the individual component edges when creating the singular OSM way entry in the XML output.