### PR TITLE
Allow flexible overpass settings

### DIFF
--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -190,6 +190,9 @@ def osm_net_download(polygon=None, north=None, south=None, east=None, west=None,
         grids, ie, 'way["power"~"line"]'
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1116,7 +1116,7 @@ def graph_from_point(center_point, distance=1000, distance_type='bbox',
                      truncate_by_edge=False, name='unnamed', timeout=180,
                      memory=None, max_query_area_size=50*1000*50*1000,
                      clean_periphery=True, infrastructure='way["highway"]',
-                     custom_filter=None):
+                     custom_filter=None, custom_settings=None):
     """
     Create a networkx graph from OSM data within some distance of some (lat,
     lon) center point.
@@ -1159,6 +1159,9 @@ def graph_from_point(center_point, distance=1000, distance_type='bbox',
         infrastructures may be selected like power grids (ie, 'way["power"~"line"]'))
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -1177,7 +1180,7 @@ def graph_from_point(center_point, distance=1000, distance_type='bbox',
                         retain_all=retain_all, truncate_by_edge=truncate_by_edge, name=name,
                         timeout=timeout, memory=memory, max_query_area_size=max_query_area_size,
                         clean_periphery=clean_periphery, infrastructure=infrastructure,
-                        custom_filter=custom_filter)
+                        custom_filter=custom_filter, custom_settings=custom_settings)
 
     # if the network distance_type is network, find the node in the graph
     # nearest to the center point, and truncate the graph by network distance

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -191,7 +191,7 @@ def osm_net_download(polygon=None, north=None, south=None, east=None, west=None,
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
 
     Returns
@@ -1046,7 +1046,7 @@ def graph_from_bbox(north, south, east, west, network_type='all_private',
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
 
     Returns
@@ -1160,7 +1160,7 @@ def graph_from_point(center_point, distance=1000, distance_type='bbox',
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
 
     Returns
@@ -1246,7 +1246,7 @@ def graph_from_address(address, distance=1000, distance_type='bbox',
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
 
     Returns
@@ -1317,7 +1317,7 @@ def graph_from_polygon(polygon, network_type='all_private', simplify=True,
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
 
     Returns
@@ -1450,7 +1450,7 @@ def graph_from_place(query, network_type='all_private', simplify=True,
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
-        a custom settings to be used in the overpass query instead of the default
+        custom settings to be used in the overpass query instead of the default
         ones
     Returns
     -------

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -228,7 +228,7 @@ def osm_net_download(polygon=None, north=None, south=None, east=None, west=None,
     if custom_settings:
         overpass_settings = custom_settings
     else:
-        overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
+        overpass_settings = settings.default_overpass_query_settings.format(timeout=timeout, maxsize=maxsize)
 
     # define the query to send the API
     # specifying way["highway"] means that all ways returned must have a highway

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1199,7 +1199,7 @@ def graph_from_address(address, distance=1000, distance_type='bbox',
                        name='unnamed', timeout=180, memory=None,
                        max_query_area_size=50*1000*50*1000,
                        clean_periphery=True, infrastructure='way["highway"]',
-                       custom_filter=None):
+                       custom_filter=None, custom_settings=None):
     """
     Create a networkx graph from OSM data within some distance of some address.
 
@@ -1245,6 +1245,9 @@ def graph_from_address(address, distance=1000, distance_type='bbox',
         infrastructures may be selected like power grids (ie, 'way["power"~"line"]'))
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -1261,7 +1264,7 @@ def graph_from_address(address, distance=1000, distance_type='bbox',
                          name=name, timeout=timeout, memory=memory,
                          max_query_area_size=max_query_area_size,
                          clean_periphery=clean_periphery, infrastructure=infrastructure,
-                         custom_filter=custom_filter)
+                         custom_filter=custom_filter, custom_settings=custom_settings)
     log('graph_from_address() returning graph with {:,} nodes and {:,} edges'.format(len(list(G.nodes())), len(list(G.edges()))))
 
     if return_coords:

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1395,7 +1395,8 @@ def graph_from_place(query, network_type='all_private', simplify=True,
                      retain_all=False, truncate_by_edge=False, name='unnamed',
                      which_result=1, buffer_dist=None, timeout=180, memory=None,
                      max_query_area_size=50*1000*50*1000, clean_periphery=True,
-                     infrastructure='way["highway"]', custom_filter=None):
+                     infrastructure='way["highway"]', custom_filter=None,
+                     custom_settings=None):
     """
     Create a networkx graph from OSM data within the spatial boundaries of some
     geocodable place(s).
@@ -1445,7 +1446,9 @@ def graph_from_place(query, network_type='all_private', simplify=True,
         infrastructures may be selected like power grids (ie, 'way["power"~"line"]'))
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
-
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
     Returns
     -------
     networkx multidigraph
@@ -1473,7 +1476,7 @@ def graph_from_place(query, network_type='all_private', simplify=True,
                            name=name, timeout=timeout, memory=memory,
                            max_query_area_size=max_query_area_size,
                            clean_periphery=clean_periphery, infrastructure=infrastructure,
-                           custom_filter=custom_filter)
+                           custom_filter=custom_filter, custom_settings=custom_settings)
 
     log('graph_from_place() returning graph with {:,} nodes and {:,} edges'.format(len(list(G.nodes())), len(list(G.edges()))))
     return G

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1272,7 +1272,7 @@ def graph_from_polygon(polygon, network_type='all_private', simplify=True,
                        timeout=180, memory=None,
                        max_query_area_size=50*1000*50*1000,
                        clean_periphery=True, infrastructure='way["highway"]',
-                       custom_filter=None):
+                       custom_filter=None, custom_settings=None):
     """
     Create a networkx graph from OSM data within the spatial boundaries of the
     passed-in shapely polygon.
@@ -1310,6 +1310,9 @@ def graph_from_polygon(polygon, network_type='all_private', simplify=True,
         like power grids (ie, 'way["power"~"line"]'))
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -1338,7 +1341,8 @@ def graph_from_polygon(polygon, network_type='all_private', simplify=True,
         response_jsons = osm_net_download(polygon=polygon_buffered, network_type=network_type,
                                           timeout=timeout, memory=memory,
                                           max_query_area_size=max_query_area_size,
-                                          infrastructure=infrastructure, custom_filter=custom_filter)
+                                          infrastructure=infrastructure, custom_filter=custom_filter,
+                                          custom_settings=custom_settings)
         G_buffered = create_graph(response_jsons, name=name, retain_all=True,
                                   bidirectional=network_type in settings.bidirectional_network_types)
         G_buffered = truncate_graph_polygon(G_buffered, polygon_buffered, retain_all=True, truncate_by_edge=truncate_by_edge)
@@ -1363,7 +1367,8 @@ def graph_from_polygon(polygon, network_type='all_private', simplify=True,
         response_jsons = osm_net_download(polygon=polygon, network_type=network_type,
                                           timeout=timeout, memory=memory,
                                           max_query_area_size=max_query_area_size,
-                                          infrastructure=infrastructure, custom_filter=custom_filter)
+                                          infrastructure=infrastructure, custom_filter=custom_filter,
+                                          custom_settings=custom_settings)
 
         # create the graph from the downloaded data
         G = create_graph(response_jsons, name=name, retain_all=True,

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -1003,7 +1003,8 @@ def graph_from_bbox(north, south, east, west, network_type='all_private',
                     simplify=True, retain_all=False, truncate_by_edge=False,
                     name='unnamed', timeout=180, memory=None,
                     max_query_area_size=50*1000*50*1000, clean_periphery=True,
-                    infrastructure='way["highway"]', custom_filter=None):
+                    infrastructure='way["highway"]', custom_filter=None,
+                    custom_settings=None):
     """
     Create a networkx graph from OSM data within some bounding box.
 
@@ -1044,6 +1045,9 @@ def graph_from_bbox(north, south, east, west, network_type='all_private',
         infrastructures may be selected like power grids (ie, 'way["power"~"line"]'))
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
+    custom_settings : string
+        a custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -1064,7 +1068,8 @@ def graph_from_bbox(north, south, east, west, network_type='all_private',
                                           east=east_buffered, west=west_buffered,
                                           network_type=network_type, timeout=timeout,
                                           memory=memory, max_query_area_size=max_query_area_size,
-                                          infrastructure=infrastructure, custom_filter=custom_filter)
+                                          infrastructure=infrastructure, custom_filter=custom_filter,
+                                          custom_settings=custom_settings)
         G_buffered = create_graph(response_jsons, name=name, retain_all=retain_all,
                                   bidirectional=network_type in settings.bidirectional_network_types)
         G = truncate_graph_bbox(G_buffered, north, south, east, west, retain_all=True, truncate_by_edge=truncate_by_edge)
@@ -1087,7 +1092,8 @@ def graph_from_bbox(north, south, east, west, network_type='all_private',
                                           west=west, network_type=network_type,
                                           timeout=timeout, memory=memory,
                                           max_query_area_size=max_query_area_size,
-                                          infrastructure=infrastructure, custom_filter=custom_filter)
+                                          infrastructure=infrastructure, custom_filter=custom_filter,
+                                          custom_settings=custom_settings)
 
         # create the graph, then truncate to the bounding box
         G = create_graph(response_jsons, name=name, retain_all=retain_all,

--- a/osmnx/core.py
+++ b/osmnx/core.py
@@ -225,9 +225,10 @@ def osm_net_download(polygon=None, north=None, south=None, east=None, west=None,
         maxsize = '[maxsize:{}]'.format(memory)
 
     # use custom settings if delivered, otherwise just the default ones.
-    overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
     if custom_settings:
         overpass_settings = custom_settings
+    else:
+        overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
 
     # define the query to send the API
     # specifying way["highway"] means that all ways returned must have a highway

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -496,7 +496,8 @@ def footprints_from_address(address, distance, footprint_type='building', retain
                                  retain_invalid=retain_invalid, custom_settings=custom_settings)
 
 
-def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=False):
+def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=False,
+                            custom_settings=None):
     """
     Get footprints within some polygon.
 
@@ -509,14 +510,16 @@ def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=F
         type of footprint to be downloaded. OSM tag key e.g. 'building', 'landuse', 'place', etc.
     retain_invalid : bool
         if False discard any footprints with an invalid geometry
-
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
     Returns
     -------
     GeoDataFrame
     """
 
     return create_footprints_gdf(polygon=polygon, footprint_type=footprint_type,
-                                 retain_invalid=retain_invalid)
+                                 retain_invalid=retain_invalid, custom_settings=custom_settings)
 
 
 def footprints_from_place(place, footprint_type='building', retain_invalid=False, which_result=1):

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -152,7 +152,8 @@ def osm_footprints_download(polygon=None, north=None, south=None, east=None, wes
 
 
 def create_footprints_gdf(polygon=None, north=None, south=None, east=None, west=None,
-                          footprint_type='building', retain_invalid=False, responses=None):
+                          footprint_type='building', retain_invalid=False, responses=None,
+                          custom_settings=None):
     """
     Get footprint (polygon) data from OSM and convert it into a GeoDataFrame.
 
@@ -174,6 +175,9 @@ def create_footprints_gdf(polygon=None, north=None, south=None, east=None, west=
         if False discard any footprints with an invalid geometry
     responses : list
         list of response jsons
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -181,7 +185,8 @@ def create_footprints_gdf(polygon=None, north=None, south=None, east=None, west=
     """
     # allow pickling between downloading footprints and converting them to a GeoDataFrame
     if responses is None:
-        responses = osm_footprints_download(polygon, north, south, east, west, footprint_type)
+        responses = osm_footprints_download(polygon, north, south, east, west, footprint_type,
+                                            custom_settings=custom_settings)
 
     # parse the list of responses into separate dicts of vertices, footprints and relations
     # create a set of ways not directly tagged with footprint_type

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -431,7 +431,8 @@ def create_relation_geometry(relation_key, relation_val, footprints):
         log('relation {} could not be converted to a complex footprint'.format(relation_key))
 
 
-def footprints_from_point(point, distance, footprint_type='building', retain_invalid=False):
+def footprints_from_point(point, distance, footprint_type='building', retain_invalid=False,
+                          custom_settings=None):
     """
     Get footprints within some distance north, south, east, and west of
     a lat-long point.
@@ -446,6 +447,9 @@ def footprints_from_point(point, distance, footprint_type='building', retain_inv
         type of footprint to be downloaded. OSM tag key e.g. 'building', 'landuse', 'place', etc.
     retain_invalid : bool
         if False discard any footprints with an invalid geometry
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -455,7 +459,8 @@ def footprints_from_point(point, distance, footprint_type='building', retain_inv
     bbox = bbox_from_point(point=point, distance=distance)
     north, south, east, west = bbox
     return create_footprints_gdf(north=north, south=south, east=east, west=west,
-                                 footprint_type=footprint_type, retain_invalid=retain_invalid)
+                                 footprint_type=footprint_type, retain_invalid=retain_invalid,
+                                 custom_settings=custom_settings)
 
 
 def footprints_from_address(address, distance, footprint_type='building', retain_invalid=False):

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -89,7 +89,7 @@ def osm_footprints_download(polygon=None, north=None, south=None, east=None, wes
     if custom_settings:
         overpass_settings = custom_settings
     else:
-        overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
+        overpass_settings = settings.default_overpass_query_settings.format(timeout=timeout, maxsize=maxsize)
 
     # define the query to send the API
     if by_bbox:

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -522,7 +522,8 @@ def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=F
                                  retain_invalid=retain_invalid, custom_settings=custom_settings)
 
 
-def footprints_from_place(place, footprint_type='building', retain_invalid=False, which_result=1):
+def footprints_from_place(place, footprint_type='building', retain_invalid=False, which_result=1,
+                          custom_settings=None):
     """
     Get footprints within the boundaries of some place.
 
@@ -542,7 +543,9 @@ def footprints_from_place(place, footprint_type='building', retain_invalid=False
         if False discard any footprints with an invalid geometry
     which_result : int
         max number of results to return and which to process upon receipt
-
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
     Returns
     -------
     GeoDataFrame
@@ -551,7 +554,7 @@ def footprints_from_place(place, footprint_type='building', retain_invalid=False
     city = gdf_from_place(place, which_result=which_result)
     polygon = city['geometry'].iloc[0]
     return create_footprints_gdf(polygon, retain_invalid=retain_invalid,
-                                 footprint_type=footprint_type)
+                                 footprint_type=footprint_type, custom_settings=custom_settings)
 
 
 def plot_footprints(gdf, fig=None, ax=None, figsize=None, color='#333333', bgcolor='w',

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -463,7 +463,8 @@ def footprints_from_point(point, distance, footprint_type='building', retain_inv
                                  custom_settings=custom_settings)
 
 
-def footprints_from_address(address, distance, footprint_type='building', retain_invalid=False):
+def footprints_from_address(address, distance, footprint_type='building', retain_invalid=False,
+                            custom_settings=None):
     """
     Get footprints within some distance north, south, east, and west of
     an address.
@@ -478,6 +479,9 @@ def footprints_from_address(address, distance, footprint_type='building', retain
         type of footprint to be downloaded. OSM tag key e.g. 'building', 'landuse', 'place', etc.
     retain_invalid : bool
         if False discard any footprints with an invalid geometry
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -489,7 +493,7 @@ def footprints_from_address(address, distance, footprint_type='building', retain
 
     # get footprints within distance of this point
     return footprints_from_point(point, distance, footprint_type=footprint_type,
-                                 retain_invalid=retain_invalid)
+                                 retain_invalid=retain_invalid, custom_settings=custom_settings)
 
 
 def footprints_from_polygon(polygon, footprint_type='building', retain_invalid=False):

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -387,7 +387,7 @@ def create_poi_gdf(polygon=None, amenities=None, north=None, south=None, east=No
     return gdf
 
 
-def pois_from_point(point, distance=None, amenities=None):
+def pois_from_point(point, distance=None, amenities=None, custom_settings=None):
     """
     Get point of interests (POIs) within some distance north, south, east, and west of
     a lat-long point.
@@ -401,7 +401,9 @@ def pois_from_point(point, distance=None, amenities=None):
     amenities : list
         List of amenities that will be used for finding the POIs from the selected area.
         See available amenities from: http://wiki.openstreetmap.org/wiki/Key:amenity
-
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
     Returns
     -------
     GeoDataFrame
@@ -409,7 +411,8 @@ def pois_from_point(point, distance=None, amenities=None):
 
     bbox = bbox_from_point(point=point, distance=distance)
     north, south, east, west = bbox
-    return create_poi_gdf(amenities=amenities, north=north, south=south, east=east, west=west)
+    return create_poi_gdf(amenities=amenities, north=north, south=south, east=east, west=west,
+                          custom_settings=custom_settings)
 
 
 def pois_from_address(address, distance, amenities=None, custom_settings=None):

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -77,7 +77,7 @@ def parse_poi_query(north, south, east, west, amenities=None, timeout=180, maxsi
 
 
 def osm_poi_download(polygon=None, amenities=None, north=None, south=None, east=None, west=None,
-                     timeout=180, max_query_area_size=50*1000*50*1000):
+                     timeout=180, max_query_area_size=50*1000*50*1000, custom_settings=None):
     """
     Get points of interests (POIs) from OpenStreetMap based on selected amenity types.
     Note that if a polygon is passed-in, the query will be limited to its bounding box
@@ -89,6 +89,9 @@ def osm_poi_download(polygon=None, amenities=None, north=None, south=None, east=
         Polygon that will be used to limit the POI search.
     amenities : list
         List of amenities that will be used for finding the POIs from the selected area.
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -101,7 +104,8 @@ def osm_poi_download(polygon=None, amenities=None, north=None, south=None, east=
         west, south, east, north = polygon.bounds
 
         # Parse the Overpass QL query
-        query = parse_poi_query(amenities=amenities, west=west, south=south, east=east, north=north)
+        query = parse_poi_query(amenities=amenities, west=west, south=south, east=east, north=north,
+                                custom_settings=custom_settings)
 
     elif not (north is None or south is None or east is None or west is None):
         # TODO: Add functionality for subdividing search area geometry based on max_query_area_size
@@ -109,7 +113,8 @@ def osm_poi_download(polygon=None, amenities=None, north=None, south=None, east=
         #polygon = bbox_to_poly(north=north, south=south, east=east, west=west)
 
         # Parse the Overpass QL query
-        query = parse_poi_query(amenities=amenities, west=west, south=south, east=east, north=north)
+        query = parse_poi_query(amenities=amenities, west=west, south=south, east=east, north=north,
+                                custom_settings=custom_settings)
 
     else:
         raise ValueError('You must pass a polygon or north, south, east, and west')

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -412,7 +412,7 @@ def pois_from_point(point, distance=None, amenities=None):
     return create_poi_gdf(amenities=amenities, north=north, south=south, east=east, west=west)
 
 
-def pois_from_address(address, distance, amenities=None):
+def pois_from_address(address, distance, amenities=None, custom_settings=None):
     """
     Get OSM points of Interests within some distance north, south, east, and west of
     an address.
@@ -426,6 +426,9 @@ def pois_from_address(address, distance, amenities=None):
     amenities : list
         List of amenities that will be used for finding the POIs from the selected area. See available
         amenities from: http://wiki.openstreetmap.org/wiki/Key:amenity
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -436,7 +439,7 @@ def pois_from_address(address, distance, amenities=None):
     point = geocode(query=address)
 
     # get POIs within distance of this point
-    return pois_from_point(point=point, amenities=amenities, distance=distance)
+    return pois_from_point(point=point, amenities=amenities, distance=distance, custom_settings=custom_settings)
 
 
 def pois_from_polygon(polygon, amenities=None, custom_settings=None):

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -439,7 +439,7 @@ def pois_from_address(address, distance, amenities=None):
     return pois_from_point(point=point, amenities=amenities, distance=distance)
 
 
-def pois_from_polygon(polygon, amenities=None):
+def pois_from_polygon(polygon, amenities=None, custom_settings=None):
     """
     Get OSM points of interest within some polygon.
 
@@ -450,13 +450,15 @@ def pois_from_polygon(polygon, amenities=None):
     amenities : list
         List of amenities that will be used for finding the POIs from the selected area.
         See available amenities from: http://wiki.openstreetmap.org/wiki/Key:amenity
-
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
     Returns
     -------
     GeoDataFrame
     """
 
-    return create_poi_gdf(polygon=polygon, amenities=amenities)
+    return create_poi_gdf(polygon=polygon, amenities=amenities, custom_settings=custom_settings)
 
 
 def pois_from_place(place, amenities=None, which_result=1, custom_settings=None):

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -304,7 +304,8 @@ def parse_osm_relations(relations, osm_way_df):
     return osm_way_df
 
 
-def create_poi_gdf(polygon=None, amenities=None, north=None, south=None, east=None, west=None):
+def create_poi_gdf(polygon=None, amenities=None, north=None, south=None, east=None, west=None,
+                   custom_settings=None):
     """
     Parse GeoDataFrames from POI json that was returned by Overpass API.
 
@@ -323,13 +324,17 @@ def create_poi_gdf(polygon=None, amenities=None, north=None, south=None, east=No
         eastern longitude of bounding box
     west : float
         western longitude of bounding box
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
     Geopandas GeoDataFrame with POIs and the associated attributes.
     """
 
-    responses = osm_poi_download(polygon=polygon, amenities=amenities, north=north, south=south, east=east, west=west)
+    responses = osm_poi_download(polygon=polygon, amenities=amenities, north=north, south=south, east=east, west=west,
+                                 custom_settings=custom_settings)
 
     # Parse coordinates from all the nodes in the response
     coords = parse_nodes_coords(responses)

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -50,7 +50,7 @@ def parse_poi_query(north, south, east, west, amenities=None, timeout=180, maxsi
     if custom_settings:
         overpass_settings = custom_settings
     else:
-        overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
+        overpass_settings = settings.default_overpass_query_settings.format(timeout=timeout, maxsize=maxsize)
 
     if amenities:
         # Overpass QL template

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -459,7 +459,7 @@ def pois_from_polygon(polygon, amenities=None):
     return create_poi_gdf(polygon=polygon, amenities=amenities)
 
 
-def pois_from_place(place, amenities=None, which_result=1):
+def pois_from_place(place, amenities=None, which_result=1, custom_settings=None):
     """
     Get points of interest (POIs) within the boundaries of some place.
 
@@ -472,6 +472,9 @@ def pois_from_place(place, amenities=None, which_result=1):
         See available amenities from: http://wiki.openstreetmap.org/wiki/Key:amenity
     which_result : int
         max number of place geocoding results to return and which to process upon receipt
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
 
     Returns
     -------
@@ -480,4 +483,4 @@ def pois_from_place(place, amenities=None, which_result=1):
 
     city = gdf_from_place(place, which_result=which_result)
     polygon = city['geometry'].iloc[0]
-    return create_poi_gdf(polygon=polygon, amenities=amenities)
+    return create_poi_gdf(polygon=polygon, amenities=amenities, custom_settings=custom_settings)

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -20,7 +20,8 @@ from .geo_utils import geocode, bbox_to_poly
 from .utils import log
 
 
-def parse_poi_query(north, south, east, west, amenities=None, timeout=180, maxsize=''):
+def parse_poi_query(north, south, east, west, amenities=None, timeout=180, maxsize='',
+                    custom_settings=None):
     """
     Parse the Overpass QL query based on the list of amenities.
 
@@ -39,27 +40,38 @@ def parse_poi_query(north, south, east, west, amenities=None, timeout=180, maxsi
         List of amenities that will be used for finding the POIs from the selected area.
     timeout : int
         Timeout for the API request.
+    custom_settings : string
+        custom settings to be used in the overpass query instead of the default
+        ones
+
     """
+
+    # use custom settings if delivered, otherwise just the default ones.
+    if custom_settings:
+        overpass_settings = custom_settings
+    else:
+        overpass_settings = '[out:json][timeout:{timeout}]{maxsize}'.format(timeout=timeout, maxsize=maxsize)
+
     if amenities:
         # Overpass QL template
-        query_template = ('[out:json][timeout:{timeout}]{maxsize};((node["amenity"~"{amenities}"]({south:.6f},'
+        query_template = ('{settings};((node["amenity"~"{amenities}"]({south:.6f},'
                           '{west:.6f},{north:.6f},{east:.6f});(._;>;););(way["amenity"~"{amenities}"]({south:.6f},'
                           '{west:.6f},{north:.6f},{east:.6f});(._;>;););(relation["amenity"~"{amenities}"]'
                           '({south:.6f},{west:.6f},{north:.6f},{east:.6f});(._;>;);););out;')
 
         # Parse amenties
         query_str = query_template.format(amenities="|".join(amenities), north=north, south=south, east=east, west=west,
-                                          timeout=timeout, maxsize=maxsize)
+                                          timeout=timeout, maxsize=maxsize, settings=overpass_settings)
     else:
         # Overpass QL template
-        query_template = ('[out:json][timeout:{timeout}]{maxsize};((node["amenity"]({south:.6f},'
+        query_template = ('{settings};((node["amenity"]({south:.6f},'
                           '{west:.6f},{north:.6f},{east:.6f});(._;>;););(way["amenity"]({south:.6f},'
                           '{west:.6f},{north:.6f},{east:.6f});(._;>;););(relation["amenity"]'
                           '({south:.6f},{west:.6f},{north:.6f},{east:.6f});(._;>;);););out;')
 
         # Parse amenties
         query_str = query_template.format(north=north, south=south, east=east, west=west,
-                                          timeout=timeout, maxsize=maxsize)
+                                          timeout=timeout, maxsize=maxsize, settings=overpass_settings)
 
     return query_str
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -52,6 +52,10 @@ default_access = '["access"!~"private"]'
 # The network types for which a bidirectional graph will be created
 bidirectional_network_types = ['walk']
 
+#default settings string schema for overpass queries. Timeout and maxsized needs to
+#be dinamically set where used.
+default_overpass_query_settings = '[out:json][timeout:{timeout}]{maxsize}'
+
 # all one-way mode to maintain original OSM node order
 # when constructing graphs specifically to save to .osm xml file
 all_oneway = False

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -201,6 +201,7 @@ def test_get_network_methods():
              '["access"!~"private"]')
     G = ox.graph_from_point(location_point, network_type='walk', custom_filter=filtr)
 
+    # TODO test custom settings
 
 def test_stats():
     # create graph, add bearings, project it
@@ -354,6 +355,7 @@ def test_footprints():
 
     gdf = ox.footprints_from_place(place='kusatsu, shiga, japan', which_result=2)
 
+    #TODO Test custom settings
 
 def test_pois():
     import pytest
@@ -380,6 +382,7 @@ def test_pois():
 
     gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2)
 
+    # TODO Test custom settings
 
 def test_nominatim():
     import pytest

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -201,7 +201,8 @@ def test_get_network_methods():
              '["access"!~"private"]')
     G = ox.graph_from_point(location_point, network_type='walk', custom_filter=filtr)
 
-    # TODO test custom settings
+    test_custom_settings = """[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]"""
+    G = ox.graph_from_point(location_point, custom_settings=test_custom_settings)
 
 def test_stats():
     # create graph, add bearings, project it
@@ -355,7 +356,10 @@ def test_footprints():
 
     gdf = ox.footprints_from_place(place='kusatsu, shiga, japan', which_result=2)
 
-    #TODO Test custom settings
+    test_custom_settings = """[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]"""
+    gdf = ox.footprints_from_place(place='kusatsu, shiga, japan', which_result=2,
+                                   custom_settings=test_custom_settings)
+
 
 def test_pois():
     import pytest
@@ -382,7 +386,9 @@ def test_pois():
 
     gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2)
 
-    # TODO Test custom settings
+    test_custom_settings = """[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]"""
+    gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2,
+                             custom_settings=test_custom_settings)
 
 def test_nominatim():
     import pytest


### PR DESCRIPTION
Until now, overpass QL [settings](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#Settings) (the first statement in an overpass query) were mostly hardcoded, with only maxsize and timeout being open to change from the high level functions of OSMnx.

In issue https://github.com/gboeing/osmnx/issues/384, the ability to modify the date for the overpass query was requested as a feature. The date in an overpass query is modified in its settings. When I looked into it, I noticed it would be probably wiser to make settings customizable in a similar fashion to the current `custom_filters`, instead of making an hyperspecialized design just for the date.

The proposed change allows the user to feed a customized settings string. If no string is given, the same default values that are now hardcoded will be used, thus not breaking backwards compatibility.

@gboeing , no tests for this yet. I've tried to understand the testing philosophy of OSMnx from the current tests but I haven't seen any testing related to querying Overpass. Could you kindly let me know your thoughts on this?
