### PR TITLE
Changes to return key in edge finding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ ENV/
 
 # PyCharm IDE idea files
 .idea
+
+# VSCode IDE idea files
+.vscode

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -288,7 +288,7 @@ def test_nearest_edge():
     sheik_sayed_dubai = [25.09, 25.06, 55.16, 55.11]
     location_coordinates = (25.071764, 55.138978)
     G = ox.graph_from_bbox(*sheik_sayed_dubai, simplify=False, retain_all=True, network_type='drive')
-    geometry, u, v = ox.get_nearest_edge(G, location_coordinates)
+    geometry, u, v, k = ox.get_nearest_edge(G, location_coordinates)
 
 
 def test_nearest_edges():


### PR DESCRIPTION
The edge finding algorithms currently only return the end nodes of the identified edge, meaning instances of multiple edges between two nodes are not accounted for. This change adds key returning as well to correct this.