### PR TITLE
Generalize POIs module

### DIFF
--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -37,8 +37,17 @@ def create_poi_query(north, south, east, west, tags,
     tags : dict
         Dict of tags used for finding POIs from the selected area. Results
         returned are the union, not intersection of each individual tag.
-        Each result matches at least one tag given. Providing `False` is not
-        currently supported.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     timeout : int
         Timeout for the API request.
     memory : int
@@ -130,7 +139,19 @@ def osm_poi_download(tags, polygon=None,
     Parameters
     ----------
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     polygon : shapely.geometry.Polygon
         Polygon that will be used to limit the POI search.
     north : float
@@ -368,7 +389,19 @@ def create_poi_gdf(tags, polygon=None, north=None, south=None, east=None, west=N
     Parameters
     ----------
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     polygon : shapely Polygon or MultiPolygon
         geographic shape to fetch the POIs within
     north : float
@@ -459,7 +492,19 @@ def pois_from_point(point, tags, distance=1000,
     point : tuple
         a lat-long point
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     distance : numeric
         distance in meters
     timeout : int
@@ -492,7 +537,19 @@ def pois_from_address(address, tags, distance=1000,
     address : string
         the address to geocode to a lat-long point
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     distance : numeric
         distance in meters
     timeout : int
@@ -526,7 +583,19 @@ def pois_from_polygon(polygon, tags,
     polygon : Polygon
         Polygon where the POIs are search from.
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     timeout : int
         Timeout for the API request.
     memory : int
@@ -554,7 +623,19 @@ def pois_from_place(place, tags, which_result=1,
     place : string
         the query to geocode to get geojson boundary polygon.
     tags : dict
-        x
+        Dict of tags used for finding POIs from the selected area. Results
+        returned are the union, not intersection of each individual tag.
+        Each result matches at least one tag given. The dict keys should be
+        OSM tags, (e.g., `amenity`, `landuse`, `highway`, etc) and the dict
+        values should be either `True` to retrieve all items with the given
+        tag, or a string to get a single tag-value combination, or a list of
+        strings to get multiple values for the given tag. For example,
+            tags = {
+                'amenity':True,
+                'landuse':['retail','commercial'],
+                'highway':'bus_stop'}
+        would return all amenities, `landuse=retail`, `landuse=commercial`,
+        and `highway=bus_stop`.
     which_result : int
         max number of place geocoding results to return and which to process upon receipt
     timeout : int

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -6,8 +6,6 @@
 ################################################################################
 
 import geopandas as gpd
-from shapely.geometry import box
-from shapely.geometry import LineString
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Point
 from shapely.geometry import Polygon
@@ -16,7 +14,6 @@ from . import settings
 from .core import bbox_from_point
 from .core import gdf_from_place
 from .downloader import overpass_request
-from .geo_utils import bbox_to_poly
 from .geo_utils import geocode
 from .utils import log
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -370,33 +370,26 @@ def test_footprints():
 
 
 def test_pois():
-    import pytest
-    # download all points of interests from place
-    gdf = ox.pois_from_place(place='Kamppi, Helsinki, Finland')
 
-    # get all restaurants and schools from place
-    restaurants = ox.pois_from_place(place='Emeryville, California, USA', amenities=['restaurant'])
-    schools = ox.pois_from_place(place='Emeryville, California, USA', amenities=['school'])
+    tags = {'amenity' : True,
+            'landuse' : ['retail', 'commercial'],
+            'highway' : 'bus_stop'}
 
-    # get all universities from Boston area (with 2 km buffer to cover also Cambridge)
-    boston_q = 'Boston, Massachusetts, United States of America'
-    boston_poly = ox.gdf_from_place(boston_q, buffer_dist=2000)
-    universities = ox.pois_from_polygon(boston_poly.geometry.values[0], amenities=['university'])
+    gdf = ox.pois_from_place(place='Piedmont, California, USA', tags=tags)
 
-    # by point and by address
-    restaurants = ox.pois_from_point(point=(42.344490, -71.070570), distance=1000, amenities=['restaurant'])
-    restaurants = ox.pois_from_address(address='Emeryville, California, USA', distance=1000, amenities=['restaurant'])
+    poly = ox.gdf_from_place('Boston, MA, USA', buffer_dist=2000)
+    gdf = ox.pois_from_polygon(poly['geometry'].iloc[0], tags={'amenity':'university'})
 
-    # should raise an exception
-    # polygon or -north, south, east, west- should be provided
-    with pytest.raises(ValueError):
-        ox.create_poi_gdf(polygon=None, north=None, south=None, east=None, west=None)
+    gdf = ox.pois_from_address(address='Piedmont, California, USA',
+                               tags={'amenity' : 'school'},
+                               custom_settings='[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]')
 
-    gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2)
+    gdf = ox.pois_from_point(point=(42.344490, -71.070570),
+                             distance=500,
+                             tags={'amenity' : 'restaurant'},
+                             timeout=200,
+                             memory=100000)
 
-    test_custom_settings = '[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.pois_from_place(place='kusatsu, shiga, japan', which_result=2,
-                             custom_settings=test_custom_settings)
 
 def test_nominatim():
     import pytest


### PR DESCRIPTION
Generalizes the POIs module to query using a `tags` dict instead of an `amenities` list. Removes the `amenities` parameter from all POI functions. The `tags` dict accepts key:value pairs of the form:

  1. 'tag' : True (to retrieve all items with `tag`)
  2. 'tag' : 'value' (to retrieve all items with `tag` = `value`)
  3. 'tag' : ['value1', 'value2', etc] (to retrieve all items with `tag` equal to either `value1` or `value2` etc.

Resolves #190. Adapts contributions from stale PRs #240 #342 with enhancements from #446.

Usage examples of the new POI querying functionality:

```python
import osmnx as ox
ox.config(use_cache=True, log_console=True)

poly = ox.gdf_from_place('Boston, MA, USA', buffer_dist=2000)
gdf = ox.pois_from_polygon(poly['geometry'].iloc[0], tags={'amenity':'university'})

gdf = ox.pois_from_address(address='Piedmont, California, USA',
                           tags={'amenity' : 'school'},
                           custom_settings='[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]')

gdf = ox.pois_from_point(point=(42.344490, -71.070570),
                         distance=500,
                         tags={'amenity' : 'restaurant'},
                         timeout=200,
                         memory=100000)

tags = {'amenity' : True,
        'landuse' : ['retail', 'commercial'],
        'highway' : 'bus_stop'}
gdf = ox.pois_from_place(place='Piedmont, California, USA', tags=tags)
```