### PR TITLE
Topological intersection consolidation

### DIFF
--- a/environments/windows/create-environment.bat
+++ b/environments/windows/create-environment.bat
@@ -15,4 +15,4 @@ CALL conda clean --all --yes
 CALL conda env export > environment.yml
 CALL conda list
 CALL jupyter kernelspec list
-CALL python -c "import osmnx; print(osmnx.__version__)"
+CALL ipython -c "import osmnx; print(osmnx.__version__)"

--- a/environments/windows/environment.yml
+++ b/environments/windows/environment.yml
@@ -10,16 +10,16 @@ dependencies:
   - babel=2.8.0=py_0
   - backcall=0.1.0=py_0
   - beautifulsoup4=4.9.0=py38h32f6830_0
-  - bleach=3.1.4=pyh9f0ad1d_0
+  - bleach=3.1.5=pyh9f0ad1d_0
   - blosc=1.18.1=h6538335_0
   - bokeh=2.0.1=py38h32f6830_0
   - boost-cpp=1.72.0=h0caebb8_0
   - bottleneck=1.3.2=py38h4b8e87e_1
-  - branca=0.4.0=py_0
+  - branca=0.4.1=py_0
   - brotlipy=0.7.0=py38h1e8a9f7_1000
   - bzip2=1.0.8=hfa6e2cd_2
   - ca-certificates=2020.4.5.1=hecc5488_0
-  - cartopy=0.17.0=py38h08d5512_1015
+  - cartopy=0.18.0=py38h4990f70_0
   - certifi=2020.4.5.1=py38h32f6830_0
   - cffi=1.14.0=py38ha419a9e_0
   - cfitsio=3.470=he774522_5
@@ -45,7 +45,7 @@ dependencies:
   - entrypoints=0.3=py38h32f6830_1001
   - expat=2.2.9=he025d50_2
   - fiona=1.8.13=py38h41bf4fa_1
-  - folium=0.10.1=py_0
+  - folium=0.11.0=py_0
   - freetype=2.10.1=ha9979f8_0
   - freexl=1.0.5=hd288d7e_1002
   - future=0.18.2=py38h32f6830_1
@@ -65,9 +65,9 @@ dependencies:
   - imagesize=1.2.0=py_0
   - importlib-metadata=1.6.0=py38h32f6830_0
   - importlib_metadata=1.6.0=0
-  - intel-openmp=2020.0=166
+  - intel-openmp=2020.1=216
   - ipykernel=5.2.1=py38h5ca1d4c_0
-  - ipython=7.13.0=py38h32f6830_2
+  - ipython=7.14.0=py38h32f6830_0
   - ipython_genutils=0.2.0=py_1
   - jedi=0.17.0=py38h32f6830_0
   - jinja2=2.11.2=pyh9f0ad1d_0
@@ -77,10 +77,10 @@ dependencies:
   - jsonschema=3.2.0=py38h32f6830_1
   - jupyter_client=6.1.3=py_0
   - jupyter_core=4.6.3=py38h32f6830_1
-  - jupyterlab=2.1.1=py_0
-  - jupyterlab_server=1.1.1=py_0
+  - jupyterlab=2.1.2=py_0
+  - jupyterlab_server=1.1.3=py_0
   - kealib=1.4.13=h3b59ab9_1
-  - keyring=21.1.1=py38h32f6830_2
+  - keyring=21.2.1=py38h32f6830_0
   - kiwisolver=1.2.0=py38heaebd3c_0
   - krb5=1.17.1=hdd46e55_0
   - libblas=3.8.0=15_mkl
@@ -92,7 +92,7 @@ dependencies:
   - libiconv=1.15=hfa6e2cd_1006
   - libkml=1.3.0=h7e985d0_1011
   - liblapack=3.8.0=15_mkl
-  - libnetcdf=4.7.4=nompi_h256d12c_103
+  - libnetcdf=4.7.4=nompi_h256d12c_104
   - libpng=1.6.37=hfe6a214_1
   - libpq=12.2=hd9aa61d_1
   - libsodium=1.0.17=h2fa13f4_0
@@ -101,8 +101,8 @@ dependencies:
   - libssh2=1.8.2=h642c060_2
   - libtiff=4.1.0=h885aae3_6
   - libwebp-base=1.1.0=hfa6e2cd_3
-  - libxml2=2.9.10=h9ce36c8_0
-  - lz4-c=1.9.2=h33f27b4_0
+  - libxml2=2.9.10=h5d81f1c_1
+  - lz4-c=1.9.2=h62dcd97_1
   - m2w64-expat=2.1.1=2
   - m2w64-gcc-libgfortran=5.3.0=6
   - m2w64-gcc-libs=5.3.0=7
@@ -117,17 +117,17 @@ dependencies:
   - matplotlib-base=3.2.1=py38h1626042_0
   - mistune=0.8.4=py38h9de7a3e_1001
   - mkl=2020.0=166
-  - mock=3.0.5=py38h32f6830_1
+  - mock=4.0.2=py38h32f6830_0
   - more-itertools=8.2.0=py_0
   - msys2-conda-epoch=20160418=1
   - munch=2.5.0=py_0
   - nbconvert=5.6.1=py38h32f6830_1
   - nbformat=5.0.6=py_0
   - networkx=2.4=py_1
-  - nodejs=13.13.0=0
-  - notebook=6.0.3=py38_0
+  - nodejs=14.2.0=1
+  - notebook=6.0.3=py38h32f6830_0
   - numexpr=2.7.1=py38hb99c5c2_1
-  - numpy=1.18.1=py38ha749109_1
+  - numpy=1.18.4=py38h72c728b_0
   - olefile=0.46=py_0
   - openjpeg=2.3.1=h57dd2e7_3
   - openssl=1.1.1g=he774522_0
@@ -146,7 +146,7 @@ dependencies:
   - pillow=7.1.2=py38h7011068_0
   - pip=20.1=pyh9f0ad1d_0
   - pkginfo=1.5.0.1=py_0
-  - pluggy=0.13.1=py38_0
+  - pluggy=0.13.1=py38h32f6830_1
   - poppler=0.87.0=h0cd1227_1
   - poppler-data=0.4.9=1
   - postgresql=12.2=he14cc48_1
@@ -158,18 +158,17 @@ dependencies:
   - pycparser=2.20=py_0
   - pyepsg=0.4.0=py_0
   - pygments=2.6.1=py_0
-  - pykdtree=1.3.1=py38h4b8e87e_1003
   - pyopenssl=19.1.0=py_1
   - pyparsing=2.4.7=pyh9f0ad1d_0
-  - pyproj=2.6.0=py38h1d58662_1
-  - pyqt=5.12.3=py38h6538335_1
+  - pyproj=2.6.1.post1=py38h1dd9442_0
+  - pyqt=5.12.3=py38h7ae7562_3
   - pyreadline=2.1=py38_1001
   - pyrsistent=0.16.0=py38h9de7a3e_0
   - pysal=2.1.0=py_0
   - pyshp=2.1.0=py_0
   - pysocks=1.7.1=py38h32f6830_1
   - pytables=3.6.1=py38hd2a2a0e_2
-  - pytest=5.4.1=py38h32f6830_0
+  - pytest=5.4.2=py38h32f6830_0
   - python=3.8.2=h5fd99cc_7_cpython
   - python-dateutil=2.8.1=py_0
   - python_abi=3.8=1_cp38
@@ -178,7 +177,7 @@ dependencies:
   - pywin32-ctypes=0.2.0=py38h32f6830_1001
   - pywinpty=0.5.7=py38_0
   - pyyaml=5.3.1=py38h9de7a3e_0
-  - pyzmq=19.0.0=py38hc5dc6fd_1
+  - pyzmq=19.0.1=py38h77b9d75_0
   - qt=5.12.5=h7ef1ec2_0
   - rasterio=1.1.3=py38h2617b1b_0
   - readme_renderer=24.0=py_0
@@ -189,7 +188,7 @@ dependencies:
   - scipy=1.3.2=py38h582fac2_0
   - seaborn=0.10.1=py_0
   - send2trash=1.5.0=py_0
-  - setuptools=46.1.3=py38h32f6830_0
+  - setuptools=46.2.0=py38h32f6830_0
   - shapely=1.7.0=py38hbf43935_3
   - six=1.14.0=py_1
   - snowballstemmer=2.0.0=py_0
@@ -210,14 +209,13 @@ dependencies:
   - tiledb=1.7.7=h0b90766_1
   - tk=8.6.10=hfa6e2cd_0
   - tornado=6.0.4=py38hfa6e2cd_0
-  - tqdm=4.45.0=pyh9f0ad1d_1
+  - tqdm=4.46.0=pyh9f0ad1d_0
   - traitlets=4.3.3=py38h32f6830_1
   - twine=3.1.1=py38_0
-  - typing_extensions=3.7.4.1=py38h32f6830_3
+  - typing_extensions=3.7.4.2=py_0
   - urbanaccess=0.2.0=py_1
   - urllib3=1.25.9=py_0
   - vc=14.1=h869be7e_1
-  - vincent=0.4.4=py_1
   - vs2015_runtime=14.16.27012=h30e32a0_2
   - wcwidth=0.1.9=pyh9f0ad1d_0
   - webencodings=0.5.1=py_1
@@ -237,7 +235,8 @@ dependencies:
   - zstd=1.4.4=h9f78265_3
   - pip:
     - pyqt5-sip==4.19.18
+    - pyqtchart==5.12
     - pyqtwebengine==5.12.1
     - python-igraph==0.7.1.post6
-prefix: C:\Anaconda\envs\ox
+prefix: C:\Users\Geoff\miniconda3\envs\ox
 

--- a/environments/windows/environment.yml
+++ b/environments/windows/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - cython=0.29.17=py38h7ae7562_0
   - decorator=4.4.2=py_0
   - defusedxml=0.6.0=py_0
-  - deprecated=1.2.8=pyh9f0ad1d_0
+  - deprecated=1.2.10=pyh9f0ad1d_0
   - descartes=1.1.0=py_4
   - dill=0.3.1.1=py38h32f6830_1
   - docopt=0.6.2=py_1
@@ -46,13 +46,13 @@ dependencies:
   - expat=2.2.9=he025d50_2
   - fiona=1.8.13=py38h41bf4fa_1
   - folium=0.11.0=py_0
-  - freetype=2.10.1=ha9979f8_0
+  - freetype=2.10.2=hd328e21_0
   - freexl=1.0.5=hd288d7e_1002
   - future=0.18.2=py38h32f6830_1
   - gdal=3.0.4=py38h3ba59e7_9
   - geographiclib=1.50=py_0
   - geopandas=0.7.0=py_1
-  - geopy=1.21.0=py_0
+  - geopy=1.22.0=pyh9f0ad1d_0
   - geos=3.8.1=he025d50_0
   - geotiff=1.5.1=h3d29ae3_10
   - gettext=0.19.8.1=hb01d8f6_1002
@@ -184,11 +184,11 @@ dependencies:
   - requests=2.23.0=pyh8c360ce_2
   - requests-toolbelt=0.9.1=py_0
   - rtree=0.9.4=py38h7ad75cc_1
-  - scikit-learn=0.22.2.post1=py38h7208079_0
+  - scikit-learn=0.23.0=py38ha1d60b4_0
   - scipy=1.3.2=py38h582fac2_0
   - seaborn=0.10.1=py_0
   - send2trash=1.5.0=py_0
-  - setuptools=46.2.0=py38h32f6830_0
+  - setuptools=46.3.0=py38h32f6830_0
   - shapely=1.7.0=py38hbf43935_3
   - six=1.14.0=py_1
   - snowballstemmer=2.0.0=py_0
@@ -206,6 +206,7 @@ dependencies:
   - tbb=2018.0.5=he980bc4_0
   - terminado=0.8.3=py38h32f6830_1
   - testpath=0.4.4=py_0
+  - threadpoolctl=2.0.0=pyh5ca1d4c_0
   - tiledb=1.7.7=h0b90766_1
   - tk=8.6.10=hfa6e2cd_0
   - tornado=6.0.4=py38hfa6e2cd_0
@@ -238,5 +239,5 @@ dependencies:
     - pyqtchart==5.12
     - pyqtwebengine==5.12.1
     - python-igraph==0.7.1.post6
-prefix: C:\Users\Geoff\miniconda3\envs\ox
+prefix: C:\Anaconda\envs\ox
 

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -304,13 +304,21 @@ def simplify_graph(G, strict=True):
 
 
 
-def clean_intersections(G, tolerance=10, dead_ends=False):
+def clean_intersections(G, tolerance=10, dead_ends=False,
+                        rebuild_graph=False, update_edge_lengths=False):
     """
+    Deprecated pass-through function that calls consolidate_intersections.
+    Will be removed in future release.
+
+    Parameters
+    ----------
     G : networkx.MultiDiGraph
     tolerance : float
     dead_ends : bool
 
-    Deprecated pass-through function that calls consolidate_intersections
+    Returns
+    ----------
+    networkx.MultiDiGraph or geopandas.GeoSeries
     """
     from warnings import warn
     msg = 'The `clean_intersections` function has been deprecated and will be ' \

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -332,12 +332,17 @@ def clean_intersections(G, tolerance=10, dead_ends=False,
 def consolidate_intersections(G, tolerance=10, rebuild_graph=True,
                               dead_ends=False, update_edge_lengths=True):
     """
-    Consolidate intersections comprising clusters of nodes by merging them and
-    returning their centroids.
+    Consolidate intersections comprising clusters of nodes by merging them
+    and returning either their centroids or a rebuilt graph with consolidated 
+    intersections and reconnected edge geometries.
 
-    Divided roads are represented by separate centerline edges. The intersection
-    of two divided roads thus creates 4 nodes, representing where each edge
-    intersects a perpendicular edge. These 4 nodes represent a single
+    The tolerance argument should be adjusted to approximately match street
+    design standards in the specific street network, and you should always use
+    a projected graph to work in meaningful and consistent units like meters.
+
+    Divided roads are often represented by separate centerline edges. The 
+    intersection of two divided roads thus creates 4 nodes, representing where
+    each edge intersects a perpendicular edge. These 4 nodes represent a single
     intersection in the real world. This function consolidates them up by
     buffering them to an arbitrary distance, merging overlapping buffers, and
     taking their centroid. For best results, the tolerance argument should be
@@ -347,7 +352,7 @@ def consolidate_intersections(G, tolerance=10, rebuild_graph=True,
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        for best results, pass a projected graph
+        a projected graph
     tolerance : float
         nodes within this distance (in graph's geometry's units) will be
         dissolved into a single intersection
@@ -423,7 +428,7 @@ def consolidate_intersections_rebuild_graph(G, tolerance=10,
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        for best results, pass a projected graph
+        a projected graph
     tolerance : float
         nodes within this distance (in graph's geometry's units) will be
         dissolved into a single node, with edges reconnected to this new

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -175,7 +175,7 @@ def get_paths_to_simplify(G, strict=True):
                 try:
                     path = build_path(G, successor, endpoints, path=[node, successor])
                     paths_to_simplify.append(path)
-                except RuntimeError:
+                except RecursionError:
                     log('Recursion error: exceeded max depth, moving on to next endpoint successor', level=lg.WARNING)
                     # recursion errors occur if some connected component is a
                     # self-contained ring in which all nodes are not end points.
@@ -183,9 +183,6 @@ def get_paths_to_simplify(G, strict=True):
                     # rural areas) with too many nodes between true endpoints.
                     # handle it by just ignoring that component and letting its
                     # topology remain intact (this should be a rare occurrence)
-                    # RuntimeError is what Python <3.5 will throw, Py3.5+ throws
-                    # RecursionError but it is a subtype of RuntimeError so it
-                    # still gets handled
 
     log('Constructed all paths to simplify in {:,.2f} seconds'.format(time.time()-start_time))
     return paths_to_simplify

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -5,17 +5,18 @@
 # Web: https://github.com/gboeing/osmnx
 ################################################################################
 
-import time
-import logging as lg
 import geopandas as gpd
+import logging as lg
+import networkx as nx
+import time
 from shapely.geometry import Polygon
 from shapely.geometry import Point
 from shapely.geometry import LineString
-import networkx as nx
 
+from .geo_utils import count_streets_per_node
+from .projection import project_graph
 from .save_load import graph_to_gdfs
 from .utils import log
-from .geo_utils import count_streets_per_node
 
 
 def is_endpoint(G, node, strict=True):

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -420,14 +420,16 @@ def clean_intersections_rebuild_graph(G, tolerance=10, update_edge_lengths=True)
 
     # STEP 2
     # attach each node to its cluster of merged nodes
-    # first turn buffered nodes into gdf then get centroids of each cluster as x, y
+    # first get the original graph's node points
+    node_points = gdf_nodes[['geometry']]
+
+    # then turn buffered nodes into gdf and get centroids of each cluster as x, y
     clusters = gpd.GeoDataFrame(geometry=list(buffered_nodes), crs=node_points.crs)
     centroids = clusters.centroid
     clusters['x'] = centroids.x
     clusters['y'] = centroids.y
 
-    # get the original graph's node points, then spatially join
-    node_points = gdf_nodes[['geometry']]
+    # then spatial join
     gdf = gpd.sjoin(node_points, clusters, how='left', op='within')
     gdf = gdf.drop(columns='geometry').rename(columns={'index_right':'cluster'})
 

--- a/osmnx/simplify.py
+++ b/osmnx/simplify.py
@@ -344,8 +344,8 @@ def consolidate_intersections(G, tolerance=10, rebuild_graph=True,
         nodes within this distance (in graph's geometry's units) will be
         dissolved into a single intersection
     rebuild_graph : bool
-        if True, use clean_intersections_rebuild_graph to consolidate the
-        intersections and rebuild the graph, then return as
+        if True, use consolidate_intersections_rebuild_graph to consolidate 
+        the intersections and rebuild the graph, then return as
         networkx.MultiDiGraph. if False, just return the consolidated
         intersection points as a geopandas.GeoSeries (faster than rebuilding
         graph)
@@ -353,7 +353,7 @@ def consolidate_intersections(G, tolerance=10, rebuild_graph=True,
         if False, discard dead-end nodes to return only street-intersection
         points
     update_edge_lengths : bool
-        just passed to clean_intersections_rebuild_graph.
+        just passed to consolidate_intersections_rebuild_graph.
         if True, update the length attribute of edges reconnected to a new
         merged node; if False, just retain the original edge length.
 

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -144,7 +144,7 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15,
 
     # calculate clean intersection counts
     if clean_intersects:
-        clean_intersection_points = clean_intersections(G, tolerance=tolerance, dead_ends=False )
+        clean_intersection_points = clean_intersections(G, tolerance=tolerance, rebuild_graph=False, dead_ends=False)
         clean_intersection_count = len(clean_intersection_points)
     else:
         clean_intersection_count = None

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ CLASSIFIERS = ['Development Status :: 5 - Production/Stable',
                'Topic :: Scientific/Engineering :: Information Analysis',
                'Programming Language :: Python',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
                'Programming Language :: Python :: 3.8']

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -135,6 +135,9 @@ def test_stats():
     # calculate extended stats
     stats4 = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
 
+    # test cleaning and rebuilding graph
+    G_clean = ox.clean_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
+
 
 
 def test_graph_from_file():
@@ -471,28 +474,3 @@ def test_overpass_endpoint():
         G = ox.graph_from_place('Piedmont, California, USA')
 
     ox.config(overpass_endpoint='http://overpass-api.de/api')
-
-def test_coarse_graining():
-    T = nx.MultiDiGraph()
-    T.add_node(1, osmid=1, y=52.528842, x=13.397922)
-    T.add_node(2, osmid=2, y=52.528877, x=13.398594)
-    T.add_node(3, osmid=3, y=52.527467, x=13.399258)
-
-    T.add_edge(1, 2, osmid=100, length=45.5)
-    T.add_edge(2, 3, osmid=101, length=162.82)
-    T.add_edge(1, 3, osmid=102, length=177.60)
-    T.graph['name'] = 'test'
-    T.graph['crs'] = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs'
-
-    S = ox.simplify.coarse_grain_osm_network(T, tolerance=10)
-    # coarse graining should have no effect since tolerance is too low
-    assert S.number_of_nodes() == 3
-    assert S.number_of_edges() == 3
-    S = ox.simplify.coarse_grain_osm_network(T, tolerance=30)
-    # coarse graining should collapse 1 and 2
-    assert S.number_of_nodes() == 2
-    assert S.number_of_edges() == 1
-    S = ox.simplify.coarse_grain_osm_network(T, tolerance=600)
-    # coarse graining should collapse all edges
-    assert S.number_of_nodes() == 1
-    assert S.number_of_edges() == 0


### PR DESCRIPTION
This PR adds functionality to consolidate graph intersections (nodes) and reconstruct the graph topology. It adapts #339 to resolve outstanding issues. See also #249 and #299.

Many real-world street networks feature complex intersections and traffic circles, resulting in a cluster of graph nodes where there is really just one true intersection, as we would think of it in transportation or urban design. Similarly, divided roads are often represented by separate centerline edges: the intersection of two divided roads thus creates 4 nodes, representing where each edge intersects a perpendicular edge, but these 4 nodes represent a single intersection in the real world. Traffic circles similarly create a cluster of nodes where each street's edge intersects the roundabout.

The existing [clean_intersections](https://osmnx.readthedocs.io/en/stable/osmnx.html#osmnx.simplify.clean_intersections) function cleans up these clusters by buffering their points to an arbitrary distance, merging overlapping buffers, and returning a GeoSeries of their centroids. This PR deprecates this function and replaces it with a new `consolidate_intersections` function that accepts a `rebuild_graph` parameter. If `False`, the function operates like `clean_intersections` did, returning a GeoSeries of merged intersections' centroids. If `True`, it hands off the operation to a new `consolidate_intersections_rebuild_graph` function. This new function consolidates intersections comprising clusters of nodes by merging them (within some buffering tolerance) and returning a rebuilt graph (networkx MultiDiGraph) with consolidated intersections and reconnected edge geometries. It follows these steps:

  1. Buffer nodes to provided tolerance then merge overlapping nodes
  2. Attach (spatial join) each node to its cluster of merged nodes
  3. If a cluster's induced subgraph contains multiple components (i.e., it's not connected) move each component to its own cluster (otherwise you may connect nodes together that are not truly connected, e.g., nearby deadends or surface streets with a bridge)
  4. Create a new empty graph
  5. Create a single new node for each cluster of merged nodes
  6. Create an edge in the new graph for each edge in original graph, from cluster to cluster (always add original self-loops, but otherwise only create the edge if we're not connecting the cluster to itself)
  7. For each cluster with more than 1 node merged in it, extend the incident edge geometries to this new node point. Optionally update graph edge lengths.

This gives you a rebuilt graph with consolidated intersections and reconnected edge geometries, like in the figure below. The consolidated graph nodes/edges are black. The old original graph's nodes/edges are red:

![sf-circles](https://user-images.githubusercontent.com/4977197/81841050-b0616b80-94fe-11ea-8b00-9fe37ac76bc9.png)

Notice how the traffic circles' many nodes are merged into a new single centroid node, with edge geometries extended to connect to it. Similar consolidation occurs at the intersection of the divided road in the upper-right. Code to create graph visualized above:

```python
import osmnx as ox
G = ox.project_graph(ox.graph_from_place('San Francisco, California, USA', network_type='drive'))
G2 = ox.clean_intersections(G, tolerance=10, rebuild_graph=True, dead_ends=True)
ox.save_graph_geopackage(G2)
```

For best results, the tolerance argument should be adjusted to approximately match street design standards in the specific street network, and you should always use a projected graph to work in meaningful and consistent units like meters. You can also specify if you do not want dead-ends returned in the list of cleaned intersections.