### PR TITLE
new speed and travel time functionality

### DIFF
--- a/docs/source/osmnx.rst
+++ b/docs/source/osmnx.rst
@@ -113,6 +113,14 @@ osmnx.simplification module
     :undoc-members:
     :show-inheritance:
 
+osmnx.speed module
+------------------
+
+.. automodule:: osmnx.speed
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 osmnx.stats module
 ------------------
 

--- a/osmnx/_api.py
+++ b/osmnx/_api.py
@@ -53,6 +53,9 @@ from .simplification import clean_intersections
 from .simplification import consolidate_intersections
 from .simplification import simplify_graph
 
+from .speed import add_edge_speeds
+from .speed import add_edge_travel_times
+
 from .stats import basic_stats
 from .stats import extended_stats
 

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -45,7 +45,7 @@ def get_bearing(origin_point, destination_point):
 
 def add_edge_bearings(G):
     """
-    Add each bearing attributes to all graph edges.
+    Add bearing attributes to all graph edges.
 
     Calculate the compass bearing from origin node to destination
     node for each edge in the directed graph then add each bearing

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -1,0 +1,176 @@
+"""Calculate graph edge speeds and travel times."""
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import re
+from . import utils_graph
+
+
+def add_edge_speeds(G, hwy_speeds=None, fallback=None):
+    """
+    Add edge speeds (km per hour) to graph as new `speed_kph` edge attributes.
+
+    Imputes free-flow travel speeds for all edges based on mean `maxspeed`
+    value of edges, per highway type. For highway types in graph that have no
+    `maxspeed` value on any edge, function assigns the mean of all `maxspeed`
+    values in graph.
+
+    This mean-imputation can obviously be imprecise, and the caller can
+    override it by passing in `hwy_speeds` and/or `fallback` arguments that
+    correspond to local speed limit standards.
+
+    If edge `maxspeed` attribute has "mph" in it, value will automatically be
+    converted from miles per hour to km per hour. Any other speed units should
+    be manually converted to km per hour prior to running this function,
+    otherwise there could be unexpected results. If "mph" does not appear in
+    the edge's maxspeed attribute string, then function assumes kph, per OSM
+    guidelines: https://wiki.openstreetmap.org/wiki/Map_Features/Units
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+    hwy_speeds : dict
+        dict keys = OSM highway types and values = typical speeds (km per
+        hour) to assign to edges of that highway type for any edges missing
+        speed data. Any edges with highway type not in `hwy_speeds` will be
+        assigned the mean preexisting speed value of all edges of that highway
+        type.
+    fallback : numeric
+        default speed value (km per hour) to assign to edges whose highway
+        type did not appear in `hwy_speeds` and had no preexisting speed
+        values on any edge
+
+    Returns
+    -------
+    G : networkx.MultiDiGraph
+        graph with speed attributes on all edges
+    """
+    if fallback is None:
+        fallback = np.nan
+
+    edges = utils_graph.graph_to_gdfs(G, nodes=False)
+    if "maxspeed" in edges:
+        # create speed_kph by cleaning maxspeed strings and converting mph to kph
+        edges["speed_kph"] = edges["maxspeed"].astype(str).map(_clean_speed).astype(float)
+    else:
+        # if no edges in graph had a maxspeed attribute
+        edges["speed_kph"] = None
+
+    # if user provided hwy_speeds, use them as default values, otherwise
+    # initialize an empty series to populate with values
+    if hwy_speeds is None:
+        hwy_speed_avg = pd.Series(dtype=float)
+    else:
+        hwy_speed_avg = pd.Series(hwy_speeds).dropna()
+
+    # convert any list highway values (can happen during graph simplification)
+    # into string values by simply keeping only the first list element
+    edges["highway"] = edges["highway"].map(lambda x: x[0] if isinstance(x, list) else x)
+
+    # for each highway type that caller did not provide in hwy_speeds, impute
+    # speed of type by taking the mean of the preexisting speed values of that
+    # highway type
+    for hwy, group in edges.groupby("highway"):
+        if hwy not in hwy_speed_avg:
+            hwy_speed_avg.loc[hwy] = group["speed_kph"].mean()
+
+    # if any highway types had no preexisting speed values, impute their speed
+    # with fallback value provided by caller. if fallback=np.nan, impute speed
+    # as the mean speed of all highway types that did have preexisting values
+    hwy_speed_avg = hwy_speed_avg.fillna(fallback).fillna(hwy_speed_avg.mean())
+
+    # for each edge missing speed data, assign it the imputed value for its
+    # highway type
+    speed_kph = (
+        edges[["highway", "speed_kph"]].set_index("highway").iloc[:, 0].fillna(hwy_speed_avg)
+    )
+
+    # all speeds will be null if edges had no preexisting maxspeed data and
+    # caller did not pass in hwy_speeds or fallback arguments
+    if pd.isnull(speed_kph).all():
+        raise ValueError(
+            (
+                "this graph's edges have no preexisting `maxspeed` "
+                "attribute values so you must pass `hwy_speeds` or "
+                "`fallback` arguments."
+            )
+        )
+
+    # add speed kph attribute to graph edges
+    edges["speed_kph"] = speed_kph.values
+    edge_speed_kph = edges[["u", "v", "key", "speed_kph"]].set_index(["u", "v", "key"]).iloc[:, 0]
+    nx.set_edge_attributes(G, values=edge_speed_kph, name="speed_kph")
+
+    return G
+
+
+def add_edge_travel_times(G):
+    """
+    Add edge travel time (seconds) to graph as new `travel_time` edge attributes.
+
+    Calculates free-flow travel time along each edge, based on `length` and
+    `speed_kph` attributes. Note: run `add_edge_speeds` first to generate the
+    `speed_kph` attribute. All edges must have `length` and `speed_kph`
+    attributes and all their values must be non-null.
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+
+    Returns
+    -------
+    G : networkx.MultiDiGraph
+        graph with travel time attributes on all edges
+    """
+    edges = utils_graph.graph_to_gdfs(G, nodes=False)
+
+    # verify edge length and speed_kph attributes exist and contain no nulls
+    if not ("length" in edges.columns and "speed_kph" in edges.columns):
+        raise KeyError("all edges must have `length` and `speed_kph` attributes.")
+    else:
+        if pd.isnull(edges["length"]).any() or pd.isnull(edges["speed_kph"]).any():
+            raise ValueError("edge `length` and `speed_kph` values must be non-null.")
+
+    # convert distance km to meters, and speed km per hour to km per second
+    distance_km = edges["length"] / 1000
+    speed_km_sec = edges["speed_kph"] / (60 * 60)
+
+    # calculate edge travel time in seconds
+    travel_time = distance_km / speed_km_sec
+
+    # add travel time attribute to graph edges
+    edges["travel_time"] = travel_time.values
+    edge_times = edges[["u", "v", "key", "travel_time"]].set_index(["u", "v", "key"]).iloc[:, 0]
+    nx.set_edge_attributes(G, values=edge_times, name="travel_time")
+
+    return G
+
+
+def _clean_speed(speed):
+    """
+    Clean a speed string and convert mph to kph if necessary.
+
+    Parameters
+    ----------
+    speed : string
+        an OSM way maxspeed value
+
+    Returns
+    -------
+    speed_clean : string
+    """
+    MPH_TO_KPH = 1.60934
+    pattern = re.compile(r"[^\d\.,]")
+
+    try:
+        # strip out everything but numbers, periods, and commas
+        speed_clean = float(re.sub(pattern, "", speed).replace(",", "."))
+        if "mph" in speed.lower():
+            speed_clean = speed_clean * MPH_TO_KPH
+        return speed_clean
+
+    except ValueError:
+        return None

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -131,7 +131,6 @@ def test_graph_from_xml():
 
 def test_routing_folium():
 
-    # calculate shortest path and plot as static image and leaflet web map
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 
     # give each node a random elevation then calculate edge grades
@@ -140,13 +139,17 @@ def test_routing_folium():
     nx.set_node_attributes(G, name="elevation", values=elevs)
     G = ox.add_edge_grades(G, add_absolute=True)
 
+    # give each edge speed and travel time attributes
+    G = ox.add_edge_speeds(G)
+    G = ox.add_edge_travel_times(G)
+
     orig_node = list(G.nodes())[5]
     dest_node = list(G.nodes())[-5]
     orig_pt = (G.nodes[orig_node]["y"], G.nodes[orig_node]["x"])
     dest_pt = (G.nodes[dest_node]["y"], G.nodes[dest_node]["x"])
-    route = nx.shortest_path(G, orig_node, dest_node)
+    route = nx.shortest_path(G, orig_node, dest_node, weight="travel_time")
 
-    attributes = ox.utils_graph.get_route_edge_attributes(G, route, "length")
+    attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")
 
     fig, ax = ox.plot_graph_route(G, route, save=True, filename="route", file_format="png")
 


### PR DESCRIPTION
Adds a new `speed.py` module with functions:

  - `add_edge_speeds` - add speed in km/hour to all graph edges via assignment or imputation
  - `add_edge_travel_times` - add travel times to all graph edges as a function of speed and distance