### PR TITLE
Remove deprecated functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: bionic
 language: python
 python:
-  - 3.6
   - 3.7
   - 3.8
 

--- a/osmnx/_api.py
+++ b/osmnx/_api.py
@@ -23,7 +23,6 @@ from .footprints import footprints_from_polygon
 
 from .graph import graph_from_address
 from .graph import graph_from_bbox
-from .graph import graph_from_file
 from .graph import graph_from_place
 from .graph import graph_from_point
 from .graph import graph_from_polygon
@@ -49,7 +48,6 @@ from .pois import pois_from_polygon
 
 from .projection import project_graph
 
-from .simplification import clean_intersections
 from .simplification import consolidate_intersections
 from .simplification import simplify_graph
 
@@ -66,7 +64,6 @@ from .utils import ts
 
 from .utils_geo import geocode
 
-from .utils_graph import gdfs_to_graph
 from .utils_graph import get_undirected
 from .utils_graph import graph_from_gdfs
 from .utils_graph import graph_to_gdfs

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -633,38 +633,6 @@ def graph_from_place(
     return G
 
 
-def graph_from_file(filepath, bidirectional=False, simplify=True, retain_all=False):
-    """
-    Pass-through function just calls graph_from_xml.
-
-    Deprecated, will be removed in future release.
-
-    Parameters
-    ----------
-    filepath : string
-        path to file containing OSM XML data
-    bidirectional : bool
-        if True, create bidirectional edges for one-way streets
-    simplify : bool
-        if True, simplify the graph topology
-    retain_all : bool
-        if True, return the entire graph even if it is not connected
-
-    Returns
-    -------
-    networkx.MultiDiGraph
-    """
-    from warnings import warn
-
-    msg = (
-        "The `graph_from_file` function has been deprecated and will be "
-        "removed in the next release. Use the new `graph_from_xml` "
-        "function instead."
-    )
-    warn(msg)
-    return graph_from_xml(filepath, bidirectional, simplify, retain_all)
-
-
 def graph_from_xml(filepath, bidirectional=False, simplify=True, retain_all=False):
     """
     Create a graph from data in an OSM-formatted XML file.
@@ -694,7 +662,7 @@ def graph_from_xml(filepath, bidirectional=False, simplify=True, retain_all=Fals
     if simplify:
         G = simplification.simplify_graph(G)
 
-    utils.log(f"graph_from_file returned graph with {len(G)} nodes and {len(G.edges())} edges")
+    utils.log(f"graph_from_xml returned graph with {len(G)} nodes and {len(G.edges())} edges")
     return G
 
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -146,7 +146,7 @@ def save_graphml(G, filepath=None, gephi=False, encoding="utf-8"):
         # gephi doesn't handle node attrs named x and y well, so rename
         gdf_nodes["xcoord"] = gdf_nodes["x"]
         gdf_nodes["ycoord"] = gdf_nodes["y"]
-        G_save = utils_graph.gdfs_to_graph(gdf_nodes, gdf_edges)
+        G_save = utils_graph.graph_from_gdfs(gdf_nodes, gdf_edges)
 
         # remove graph attributes as Gephi only accepts node and edge attrs
         G_save.graph = {}

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -303,48 +303,6 @@ def simplify_graph(G, strict=True):
     return G
 
 
-def clean_intersections(
-    G, tolerance=10, dead_ends=False, rebuild_graph=False, update_edge_lengths=False
-):
-    """
-    Pass-through function just calls consolidate_intersections.
-
-    Deprecated: will be removed in future release.
-
-    Parameters
-    ----------
-    G : networkx.MultiDiGraph
-        param for consolidate_intersections
-    tolerance : float
-        param for consolidate_intersections
-    dead_ends : bool
-        param for consolidate_intersections
-    rebuild_graph : bool
-        param for consolidate_intersections
-    update_edge_lengths : bool
-        param for consolidate_intersections
-
-    Returns
-    -------
-    networkx.MultiDiGraph or geopandas.GeoSeries
-    """
-    from warnings import warn
-
-    msg = (
-        "The `clean_intersections` function has been deprecated and will be "
-        "removed in the next release. Use the new `consolidate_intersections` "
-        "function instead."
-    )
-    warn(msg)
-    return consolidate_intersections(
-        G,
-        tolerance=tolerance,
-        dead_ends=dead_ends,
-        rebuild_graph=rebuild_graph,
-        update_edge_lengths=update_edge_lengths,
-    )
-
-
 def consolidate_intersections(
     G, tolerance=10, rebuild_graph=True, dead_ends=False, update_edge_lengths=True
 ):

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -23,14 +23,14 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
     G : networkx.MultiDiGraph
         input graph
     area : numeric
-        the area covered by the street network, in square meters (typically land
-        area); if none, will skip all density-based metrics
+        the area covered by the street network, in square meters (typically
+        land area); if none, will skip all density-based metrics
     clean_intersects : bool
-        if True, calculate clean intersections count (and density, if area is
-        provided)
+        if True, calculate consolidated intersections count (and density, if
+        area is provided) via consolidate_intersections function
     tolerance : numeric
         tolerance value passed along if clean_intersects=True, see
-        clean_intersections function documentation for details and usage
+        consolidate_intersections function documentation for details and usage
     circuity_dist : string
         'gc' or 'euclidean', how to calculate straight-line distances for
         circuity measurement; use former for lat-lng networks and latter for
@@ -136,7 +136,7 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
 
     # calculate clean intersection counts
     if clean_intersects:
-        clean_intersection_points = simplification.clean_intersections(
+        clean_intersection_points = simplification.consolidate_intersections(
             G, tolerance=tolerance, rebuild_graph=False, dead_ends=False
         )
         clean_intersection_count = len(clean_intersection_points)

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -90,34 +90,6 @@ def graph_to_gdfs(G, nodes=True, edges=True, node_geometry=True, fill_edge_geome
         return to_return[0]
 
 
-def gdfs_to_graph(gdf_nodes, gdf_edges):
-    """
-    Pass-through function just calls graph_from_gdfs.
-
-    Deprecated, will be removed in future release.
-
-    Parameters
-    ----------
-    gdf_nodes : geopandas.GeoDataFrame
-        GeoDataFrame of graph nodes
-    gdf_edges : geopandas.GeoDataFrame
-        GeoDataFrame of graph edges
-
-    Returns
-    -------
-    networkx.MultiDiGraph
-    """
-    from warnings import warn
-
-    msg = (
-        "The `gdfs_to_graph` function has been deprecated and will be "
-        "removed in the next release. Use the new `graph_from_gdfs` "
-        "function instead."
-    )
-    warn(msg)
-    return graph_from_gdfs(gdf_nodes, gdf_edges)
-
-
 def graph_from_gdfs(gdf_nodes, gdf_edges):
     """
     Convert node and edge GeoDataFrames into a MultiDiGraph.

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,9 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
 ]
 
-DESC = "Retrieve, model, analyze, and visualize OpenStreetMap street networks and other spatial data"
+DESC = (
+    "Retrieve, model, analyze, and visualize OpenStreetMap street networks and other spatial data"
+)
 
 # only specify install_requires if not in RTD environment
 if os.getenv("READTHEDOCS") == "True":

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.8",
 ]
 
-DESC = """Retrieve, model, analyze, and visualize OpenStreetMap street networks and other spatial data"""
+DESC = "Retrieve, model, analyze, and visualize OpenStreetMap street networks and other spatial data"
 
 # only specify install_requires if not in RTD environment
 if os.getenv("READTHEDOCS") == "True":

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -117,7 +117,7 @@ def test_graph_from_xml():
         os.close(handle)
 
     for filename in ("tests/input_data/West-Oakland.osm.bz2", temp_filename):
-        G = ox.graph_from_file(filename)
+        G = ox.graph_from_xml(filename)
         assert node_id in G.nodes
 
         for neighbor_id in neighbor_ids:
@@ -238,7 +238,7 @@ def test_find_nearest():
     )
     assert len(gdf_nodes) == len(G)
     assert len(gdf_edges) == len(G.edges(keys=True))
-    G = ox.gdfs_to_graph(gdf_nodes, gdf_edges)
+    G = ox.graph_from_gdfs(gdf_nodes, gdf_edges)
     assert len(gdf_nodes) == len(G)
     assert len(gdf_edges) == len(G.edges(keys=True))
 
@@ -420,7 +420,7 @@ def test_stats():
     stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
 
     # test cleaning and rebuilding graph
-    G_clean = ox.clean_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
+    G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
 
 
 def test_footprints():


### PR DESCRIPTION
Remove the previously deprecated functions:

  - `graph_from_file` (replaced in v0.13.0 by `graph_from_xml`)
  - `clean_intersections` (replaced in v0.13.0 by `consolidate_intersections`)
  - `gdfs_to_graph` (replaced in v0.13.0 by `graph_from_gdfs`)