### PR TITLE
remove infrastructure param in favor of custom_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.13.0 (2020-05-25)
 
   - major refactor of entire package
-  - clean up API and namespace
+  - clean up API and namespace (see [documentation](https://osmnx.readthedocs.io/en/stable/) for reference and the updated [usage examples](https://github.com/gboeing/osmnx-examples))
   - new consolidate_intersections function with topological option
   - new speed module to calculate graph edge speeds and travel times
   - generalize POIs module to query with a flexible tags dict

--- a/README.md
+++ b/README.md
@@ -20,23 +20,24 @@ Retrieve, model, analyze, and visualize OpenStreetMap street networks and other 
 
 **OSMnx** is a Python package that lets you download spatial geometries and model, project, visualize, and analyze street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, and network routing.
 
-OSMnx is built on top of geopandas, networkx, and matplotlib and works with OpenStreetMap's APIs to:
+OSMnx is built on top of geopandas, networkx, and matplotlib and interacts with OpenStreetMap's APIs to:
 
   * Download street networks anywhere in the world with a single line of code
   * Download other infrastructure types, place boundaries, building footprints, and points of interest
   * Download by city name, polygon, bounding box, or point/address + network distance
   * Download drivable, walkable, bikeable, or all street networks
-  * Save/load street network to/from a local .osm xml file
-  * Visualize street network as a static image or interactive leaflet web map
-  * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
-  * Save networks to disk as shapefiles, geopackages, and GraphML
-  * Conduct topological and spatial analyses to automatically calculate dozens of indicators
   * Download node elevations and calculate edge grades (inclines)
-  * Calculate and plot shortest-path routes as a static image or leaflet web map
-  * Visualize travel distance and travel time with isoline and isochrone maps
-  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes
-  * Plot figure-ground diagrams of street networks and/or building footprints
+  * Impute missing speeds and calculate graph edge travel times
+  * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
+  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes  
+  * Save networks to disk as shapefiles, geopackages, and GraphML
+  * Save/load street network to/from a local .osm xml file
+  * Conduct topological and spatial analyses to automatically calculate dozens of indicators
   * Calculate and visualize street bearings and orientations
+  * Calculate and visualize shortest-path routes that minimize distance, travel time, elevation, etc
+  * Visualize street network as a static map or interactive leaflet web map
+  * Visualize travel distance and travel time with isoline and isochrone maps
+  * Plot figure-ground diagrams of street networks and/or building footprints
 
 Examples and demonstrations of these features are in the [examples repo](https://github.com/gboeing/osmnx-examples). More feature development details are in the change log.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,23 +22,24 @@ Boeing, G. 2017. "`OSMnx: New Methods for Acquiring, Constructing, Analyzing, an
 Features
 --------
 
-OSMnx is built on top of geopandas, networkx, and matplotlib and works with OpenStreetMap's APIs to:
+OSMnx is built on top of geopandas, networkx, and matplotlib and interacts with OpenStreetMap's APIs to:
 
   * Download street networks anywhere in the world with a single line of code
   * Download other infrastructure types, place boundaries, building footprints, and points of interest
   * Download by city name, polygon, bounding box, or point/address + network distance
   * Download drivable, walkable, bikeable, or all street networks
-  * Save/load street network to/from a local .osm xml file
-  * Visualize street network as a static image or interactive leaflet web map
-  * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
-  * Save networks to disk as shapefiles, geopackages, and GraphML
-  * Conduct topological and spatial analyses to automatically calculate dozens of indicators
   * Download node elevations and calculate edge grades (inclines)
-  * Calculate and plot shortest-path routes as a static image or leaflet web map
-  * Visualize travel distance and travel time with isoline and isochrone maps
-  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes
-  * Plot figure-ground diagrams of street networks and/or building footprints
+  * Impute missing speeds and calculate graph edge travel times
+  * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
+  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes  
+  * Save networks to disk as shapefiles, geopackages, and GraphML
+  * Save/load street network to/from a local .osm xml file
+  * Conduct topological and spatial analyses to automatically calculate dozens of indicators
   * Calculate and visualize street bearings and orientations
+  * Calculate and visualize shortest-path routes that minimize distance, travel time, elevation, etc
+  * Visualize street network as a static map or interactive leaflet web map
+  * Visualize travel distance and travel time with isoline and isochrone maps
+  * Plot figure-ground diagrams of street networks and/or building footprints
 
 Examples and demonstrations of these features are in the GitHub repo (see below). More feature development details are in the `change log`_.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ OSMnx documentation
 
    osmnx
 
-**OSMnx**: retrieve, model, analyze, and visualize street networks from OpenStreetMap. OSMnx is a Python package that lets you download spatial geometries and model, project, visualize, and analyze street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, and network routing.
+**OSMnx**: retrieve, model, analyze, and visualize street networks from OpenStreetMap. OSMnx is a Python package that lets you download spatial geometries and model, project, visualize, and analyze street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, and network routing.
 
 
 Citation info

--- a/osmnx/boundaries.py
+++ b/osmnx/boundaries.py
@@ -29,7 +29,8 @@ def gdf_from_place(query, which_result=1, buffer_dist=None):
     gdf : geopandas.GeoDataFrame
     """
     # ensure query type
-    assert isinstance(query, dict) or isinstance(query, str), "query must be a dict or a string"
+    if not isinstance(query, (str, dict)):
+        raise ValueError("query must be a dict or a string")
 
     # get the data from OSM
     data = downloader._osm_polygon_download(query, limit=which_result)
@@ -108,13 +109,13 @@ def gdf_from_places(queries, which_results=None, buffer_dist=None):
     # checking for the presence of which_results
     gdf = gpd.GeoDataFrame()
     if which_results is not None:
-        assert len(queries) == len(
-            which_results
-        ), "which_results list length must be the same as queries list length"
+
+        if len(queries) != len(which_results):
+            raise ValueError("which_results length must equal queries length")
+
         for query, which_result in zip(queries, which_results):
-            gdf = gdf.append(
-                gdf_from_place(query, buffer_dist=buffer_dist, which_result=which_result)
-            )
+            gdf_tmp = gdf_from_place(query, buffer_dist=buffer_dist, which_result=which_result)
+            gdf = gdf.append(gdf_tmp)
     else:
         for query in queries:
             gdf = gdf.append(gdf_from_place(query, buffer_dist=buffer_dist))

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -34,6 +34,10 @@ def _get_osm_filter(network_type):
     -------
     string
     """
+    # define preset queries to send to the API. specifying way["highway"]
+    # means that all ways returned must have a highway tag. the filters then
+    # remove ways by tag/value. the '>' makes it recurse so we get ways and
+    # the ways' nodes.
     filters = {}
 
     # driving: filter out un-drivable roads, service roads, private ways, and
@@ -41,7 +45,7 @@ def _get_osm_filter(network_type):
     # are tagged as providing parking, driveway, private, or emergency-access
     # services
     filters["drive"] = (
-        f'way["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
         f'elevator|escalator|proposed|construction|bridleway|abandoned|platform|raceway|service"]'
         f'["motor_vehicle"!~"no"]["motorcar"!~"no"]{settings.default_access}'
         f'["service"!~"parking|parking_aisle|driveway|private|emergency_access"]'
@@ -50,7 +54,7 @@ def _get_osm_filter(network_type):
     # drive+service: allow ways tagged 'service' but filter out certain types of
     # service ways
     filters["drive_service"] = (
-        f'way["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|'
         f'corridor|elevator|escalator|proposed|construction|bridleway|abandoned|platform|raceway"]'
         f'["motor_vehicle"!~"no"]["motorcar"!~"no"]{settings.default_access}'
         f'["service"!~"parking|parking_aisle|private|emergency_access"]'
@@ -62,14 +66,14 @@ def _get_osm_filter(network_type):
     # pleasant walks. some cycleways may allow pedestrians, but this filter ignores
     # such cycleways.
     filters["walk"] = (
-        f'way["highway"]["area"!~"yes"]["highway"!~"cycleway|motor|proposed|construction|abandoned|'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|motor|proposed|construction|abandoned|'
         f'platform|raceway"]["foot"!~"no"]["service"!~"private"]{settings.default_access}'
     )
 
     # biking: filter out foot ways, motor ways, private ways, and anything
     # specifying biking=no
     filters["bike"] = (
-        f'way["highway"]["area"!~"yes"]["highway"!~"footway|steps|corridor|elevator|'
+        f'["highway"]["area"!~"yes"]["highway"!~"footway|steps|corridor|elevator|'
         f'escalator|motor|proposed|construction|abandoned|platform|raceway"]'
         f'["bicycle"!~"no"]["service"!~"private"]{settings.default_access}'
     )
@@ -77,7 +81,7 @@ def _get_osm_filter(network_type):
     # to download all ways, just filter out everything not currently in use or
     # that is private-access only
     filters["all"] = (
-        f'way["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
+        f'["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
         f'["service"!~"private"]{settings.default_access}'
     )
 
@@ -85,7 +89,7 @@ def _get_osm_filter(network_type):
     # everything not currently in use
     filters[
         "all_private"
-    ] = 'way["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
+    ] = '["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
 
     if network_type in filters:
         osm_filter = filters[network_type]
@@ -195,7 +199,9 @@ def _get_from_cache(url, check_remark=False):
                     utils.log(f'Found remark, so ignoring cache file "{cache_filepath}"')
                     return None
 
-            utils.log(f'Retrieved response from cache file "{cache_filepath}" for URL "{url}"')
+            utils.log(
+                f'Retrieved response from cache file "{cache_filepath}" for URL "{url[:200]}..."'
+            )
             return response_json
 
 
@@ -265,7 +271,7 @@ def _get_pause(recursive_delay=5, default_duration=10):
         # wait required
         _ = int(status_first_token)  # number of available slots
         pause = 0
-    except Exception:
+    except Exception:  # pragma: no cover
         # if first token is 'Slot', it tells you when your slot will be free
         if status_first_token == "Slot":
             utc_time_str = status.split(" ")[3]
@@ -344,7 +350,7 @@ def _osm_net_download(
     Parameters
     ----------
     polygon : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
-        geographic shape to fetch the street network within
+        geographic boundaries to fetch the street network within
     north : float
         northern latitude of bounding box
     south : float
@@ -396,7 +402,7 @@ def _osm_net_download(
 
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type
-    if custom_filter:
+    if custom_filter is not None:
         osm_filter = custom_filter
     else:
         osm_filter = _get_osm_filter(network_type)
@@ -404,10 +410,6 @@ def _osm_net_download(
 
     overpass_settings = _make_overpass_settings(custom_settings, timeout, memory)
 
-    # define the query to send the API
-    # specifying way["highway"] means that all ways returned must have a highway
-    # key. the {filters} then remove ways by key/value. the '>' makes it recurse
-    # so we get ways and way nodes. maxsize is in bytes.
     if by_bbox:
         # turn bbox into a polygon and project to local UTM
         polygon = Polygon([(west, south), (east, south), (east, north), (west, north)])
@@ -432,7 +434,7 @@ def _osm_net_download(
             west, south, east, north = poly.bounds
             query_str = (
                 f"{overpass_settings};"
-                f"({osm_filter}({south:.6f},{west:.6f},{north:.6f},{east:.6f});>;);out;"
+                f"(way{osm_filter}({south:.6f},{west:.6f},{north:.6f},{east:.6f});>;);out;"
             )
             response_json = overpass_request(data={"data": query_str}, timeout=timeout)
             response_jsons.append(response_json)
@@ -457,9 +459,7 @@ def _osm_net_download(
         # pass each polygon exterior coordinates in the list to the API, one at
         # a time
         for polygon_coord_str in polygon_coord_strs:
-            query_str = (
-                f"{overpass_settings};" f"({osm_filter}(poly:'{polygon_coord_str}');>;);out;"
-            )
+            query_str = f"{overpass_settings};(way{osm_filter}(poly:'{polygon_coord_str}');>;);out;"
             response_json = overpass_request(data={"data": query_str}, timeout=timeout)
             response_jsons.append(response_json)
         utils.log(
@@ -553,9 +553,9 @@ def nominatim_request(params, request_type="search", pause=1, timeout=30, error_
 
     else:
         # if this URL is not already in the cache, pause, then request it
-        utils.log(f"Pausing {pause} seconds before making API GET request")
+        utils.log(f"Pausing {pause} seconds before making HTTP GET request")
         time.sleep(pause)
-        utils.log(f"Requesting {prepared_url} with timeout={timeout}")
+        utils.log(f"Get {prepared_url} with timeout={timeout}")
         response = requests.get(url, params=params, timeout=timeout, headers=_get_http_headers())
 
         # get the response size and the domain, log result
@@ -566,7 +566,7 @@ def nominatim_request(params, request_type="search", pause=1, timeout=30, error_
         try:
             response_json = response.json()
             _save_to_cache(prepared_url, response_json)
-        except Exception:
+        except Exception:  # pragma: no cover
             # 429 is 'too many requests' and 504 is 'gateway timeout' from server
             # overload - handle these errors by recursively calling
             # nominatim_request until we get a valid response
@@ -625,9 +625,9 @@ def overpass_request(data, pause=None, timeout=180, error_pause=None):
         # if this URL is not already in the cache, pause, then request it
         if pause is None:
             this_pause = _get_pause()
-        utils.log(f"Pausing {this_pause} seconds before making API POST request")
+        utils.log(f"Pausing {this_pause} seconds before making HTTP POST request")
         time.sleep(this_pause)
-        utils.log(f'Posting to {url} with timeout={timeout}, "{data}"')
+        utils.log(f"Post {prepared_url} with timeout={timeout}")
         response = requests.post(url, data=data, timeout=timeout, headers=_get_http_headers())
 
         # get the response size and the domain, log result
@@ -644,7 +644,7 @@ def overpass_request(data, pause=None, timeout=180, error_pause=None):
         # 429 is 'too many requests' and 504 is 'gateway timeout' from server
         # overload - handle these errors by recursively calling overpass_request
         # after a pause until we get a valid response
-        except Exception:
+        except Exception:  # pragma: no cover
             sc = response.status_code
             if sc in [429, 504]:
                 if error_pause is None:

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -41,7 +41,7 @@ def _get_osm_filter(network_type):
     # are tagged as providing parking, driveway, private, or emergency-access
     # services
     filters["drive"] = (
-        f'["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
         f'elevator|escalator|proposed|construction|bridleway|abandoned|platform|raceway|service"]'
         f'["motor_vehicle"!~"no"]["motorcar"!~"no"]{settings.default_access}'
         f'["service"!~"parking|parking_aisle|driveway|private|emergency_access"]'
@@ -50,7 +50,7 @@ def _get_osm_filter(network_type):
     # drive+service: allow ways tagged 'service' but filter out certain types of
     # service ways
     filters["drive_service"] = (
-        f'["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|footway|path|pedestrian|steps|track|corridor|'
         f'elevator|escalator|proposed|construction|bridleway|abandoned|platform|raceway"]'
         f'["motor_vehicle"!~"no"]["motorcar"!~"no"]{settings.default_access}'
         f'["service"!~"parking|parking_aisle|private|emergency_access"]'
@@ -62,14 +62,14 @@ def _get_osm_filter(network_type):
     # pleasant walks. some cycleways may allow pedestrians, but this filter ignores
     # such cycleways.
     filters["walk"] = (
-        f'["area"!~"yes"]["highway"!~"cycleway|motor|proposed|construction|abandoned|platform|raceway"]'
-        f'["foot"!~"no"]["service"!~"private"]{settings.default_access}'
+        f'["highway"]["area"!~"yes"]["highway"!~"cycleway|motor|proposed|construction|abandoned|'
+        f'platform|raceway"]["foot"!~"no"]["service"!~"private"]{settings.default_access}'
     )
 
     # biking: filter out foot ways, motor ways, private ways, and anything
     # specifying biking=no
     filters["bike"] = (
-        f'["area"!~"yes"]["highway"!~"footway|steps|corridor|elevator|escalator|motor|proposed|'
+        f'["highway"]["area"!~"yes"]["highway"!~"footway|steps|corridor|elevator|escalator|motor|proposed|'
         f'construction|abandoned|platform|raceway"]'
         f'["bicycle"!~"no"]["service"!~"private"]{settings.default_access}'
     )
@@ -77,7 +77,7 @@ def _get_osm_filter(network_type):
     # to download all ways, just filter out everything not currently in use or
     # that is private-access only
     filters["all"] = (
-        f'["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
+        f'["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
         f'["service"!~"private"]{settings.default_access}'
     )
 
@@ -85,7 +85,7 @@ def _get_osm_filter(network_type):
     # everything not currently in use
     filters[
         "all_private"
-    ] = '["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
+    ] = '["highway"]["area"!~"yes"]["highway"!~"proposed|construction|abandoned|platform|raceway"]'
 
     # no filter, needed for infrastructures other than "highway"
     filters["none"] = ""
@@ -337,7 +337,7 @@ def _osm_net_download(
     timeout=180,
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -368,11 +368,10 @@ def _osm_net_download(
         max area for any part of the geometry in meters: any polygon bigger
         will get divided up for multiple queries to API (default 50km x 50km)
     infrastructure : string
-        download infrastructure of given type. default is streets, ie,
-        'way["highway"]') but other infrastructures may be selected like power
-        grids, ie, 'way["power"~"line"]'
+        do not use
     custom_filter : string
-        a custom network filter to be used instead of the network_type presets
+        a custom network filter to be used instead of the network_type presets,
+        e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
     custom_settings : string
         custom settings to be used in the overpass query instead of defaults
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -368,7 +368,7 @@ def _osm_net_download(
         max area for any part of the geometry in meters: any polygon bigger
         will get divided up for multiple queries to API (default 50km x 50km)
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -379,6 +379,14 @@ def _osm_net_download(
     -------
     response_jsons : list
     """
+    if infrastructure != 'way':
+        from warnings import warn
+        msg = (
+            "The `infrastructure` parameter has been deprecated and will be "
+            "removed in the next release. Use the `custom_filter` parameter instead."
+        )
+        warn(msg)
+
     # check if we're querying by polygon or by bounding box based on which
     # argument(s) where passed into this function
     by_poly = polygon is not None

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -35,7 +35,7 @@ def graph_from_bbox(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure="way",
+    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -189,7 +189,7 @@ def graph_from_point(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure="way",
+    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -288,7 +288,7 @@ def graph_from_address(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure="way",
+    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -379,7 +379,7 @@ def graph_from_polygon(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure="way",
+    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -531,7 +531,7 @@ def graph_from_place(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure="way",
+    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -35,7 +35,7 @@ def graph_from_bbox(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -73,9 +73,7 @@ def graph_from_bbox(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        download infrastructure of given type. the default is streets
-        (ie, 'way["highway"]') but other infrastructures may be selected like
-        power grids (ie, 'way["power"~"line"]').
+        do not use
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -191,7 +189,7 @@ def graph_from_point(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -230,9 +228,7 @@ def graph_from_point(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        download infrastructure of given type. the default is streets
-        (ie, 'way["highway"]') but other infrastructures may be selected like
-        power grids (ie, 'way["power"~"line"]').
+        do not use
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -292,7 +288,7 @@ def graph_from_address(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -335,9 +331,7 @@ def graph_from_address(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        download infrastructure of given type. the default is streets
-        (ie, 'way["highway"]') but other infrastructures may be selected like
-        power grids (ie, 'way["power"~"line"]').
+        do not use
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -385,7 +379,7 @@ def graph_from_polygon(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -418,9 +412,7 @@ def graph_from_polygon(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        download infrastructure of given type (default is streets
-        (ie, 'way["highway"]') but other infrastructures may be selected
-        like power grids (ie, 'way["power"~"line"]'))
+        do not use
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -539,7 +531,7 @@ def graph_from_place(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure='way["highway"]',
+    infrastructure="way",
     custom_filter=None,
     custom_settings=None,
 ):
@@ -585,9 +577,7 @@ def graph_from_place(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        download infrastructure of given type. the default is streets
-        (ie, 'way["highway"]') but other infrastructures may be selected like
-        power grids (ie, 'way["power"~"line"]').
+        do not use
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -587,7 +587,7 @@ def graph_from_place(
     G : networkx.MultiDiGraph
     """
     # create a GeoDataFrame with the spatial boundaries of the place(s)
-    if isinstance(query, str) or isinstance(query, dict):
+    if isinstance(query, (str, dict)):
         # if it is a string (place name) or dict (structured place query), then
         # it is a single place
         gdf_place = boundaries.gdf_from_place(
@@ -597,7 +597,7 @@ def graph_from_place(
         # if it is a list, it contains multiple places to get
         gdf_place = boundaries.gdf_from_places(query, buffer_dist=buffer_dist)
     else:
-        raise TypeError("query must be a string or a list of query strings")
+        raise TypeError("query must be dict, string, or list of strings")
 
     # extract the geometry from the GeoDataFrame to use in API query
     polygon = gdf_place["geometry"].unary_union

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -73,7 +73,7 @@ def graph_from_bbox(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -228,7 +228,7 @@ def graph_from_point(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -331,7 +331,7 @@ def graph_from_address(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -412,7 +412,7 @@ def graph_from_polygon(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string
@@ -577,7 +577,7 @@ def graph_from_place(
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
     infrastructure : string
-        do not use
+        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
     custom_settings : string

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -88,7 +88,8 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
     gdf_proj : geopandas.GeoDataFrame
         the projected GeoDataFrame
     """
-    assert len(gdf) > 0, "You cannot project an empty GeoDataFrame."
+    if len(gdf) < 1:
+        raise ValueError("Cannot project an empty GeoDataFrame")
 
     # if to_crs was passed-in, use this value to project the gdf
     if to_crs is not None:

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -382,6 +382,7 @@ def test_get_network_methods():
 
     # test custom query filter
     cf = (
+        'way["highway"]'
         '["area"!~"yes"]'
         '["highway"!~"motor|proposed|construction|abandoned|platform|raceway"]'
         '["foot"!~"no"]'

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -188,12 +188,9 @@ def test_plots():
     ec = ox.plot.get_edge_colors_by_attr(G, "length")
 
     # plot and save to disk
-    fig, ax = ox.plot_graph(G, save=True, file_format="png")
-
     fig, ax = ox.plot_graph(G, show=False, save=True, close=True, file_format="svg")
-
     fig, ax = ox.plot_graph(
-        ox.project_graph(G),
+        G,
         fig_height=5,
         fig_width=5,
         margin=0.05,
@@ -382,7 +379,7 @@ def test_get_network_methods():
 
     # test custom query filter
     cf = (
-        'way["highway"]'
+        '["highway"]'
         '["area"!~"yes"]'
         '["highway"!~"motor|proposed|construction|abandoned|platform|raceway"]'
         '["foot"!~"no"]'


### PR DESCRIPTION
The old `infrastructure` parameter when creating graphs is redundant with the `custom_filter` parameter, and this redundancy makes their use clunky and unclear. This PR deprecates `infrastructure` to standardize around `custom_filter`.