### PR TITLE
remove deprecated infastructure parameter from graph creation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Retrieve, model, analyze, and visualize OpenStreetMap street networks and other 
 
 ## Features
 
-**OSMnx** is a Python package that lets you download spatial geometries and model, project, visualize, and analyze street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, and network routing.
+**OSMnx** is a Python package that lets you download spatial geometries and model, project, visualize, and analyze real-world street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, speed/travel time, and network routing.
 
 OSMnx is built on top of geopandas, networkx, and matplotlib and interacts with OpenStreetMap's APIs to:
 
@@ -29,7 +29,7 @@ OSMnx is built on top of geopandas, networkx, and matplotlib and interacts with 
   * Download node elevations and calculate edge grades (inclines)
   * Impute missing speeds and calculate graph edge travel times
   * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
-  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes  
+  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes
   * Save networks to disk as shapefiles, geopackages, and GraphML
   * Save/load street network to/from a local .osm xml file
   * Conduct topological and spatial analyses to automatically calculate dozens of indicators

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ OSMnx documentation
 
    osmnx
 
-**OSMnx**: retrieve, model, analyze, and visualize street networks from OpenStreetMap. OSMnx is a Python package that lets you download spatial geometries and model, project, visualize, and analyze street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, and network routing.
+**OSMnx**: retrieve, model, analyze, and visualize street networks from OpenStreetMap. OSMnx is a Python package that lets you download spatial geometries and model, project, visualize, and analyze real-world street networks from OpenStreetMap's APIs. Users can download and model walkable, drivable, or bikeable urban networks with a single line of Python code, and then easily analyze and visualize them. You can just as easily download and work with amenities/points of interest, building footprints, elevation data, street bearings/orientations, speed/travel time, and network routing.
 
 
 Citation info
@@ -31,7 +31,7 @@ OSMnx is built on top of geopandas, networkx, and matplotlib and interacts with 
   * Download node elevations and calculate edge grades (inclines)
   * Impute missing speeds and calculate graph edge travel times
   * Simplify and correct the network's topology to clean-up nodes and consolidate intersections
-  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes  
+  * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes
   * Save networks to disk as shapefiles, geopackages, and GraphML
   * Save/load street network to/from a local .osm xml file
   * Conduct topological and spatial analyses to automatically calculate dozens of indicators

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -342,7 +342,6 @@ def _osm_net_download(
     timeout=180,
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -372,8 +371,6 @@ def _osm_net_download(
     max_query_area_size : float
         max area for any part of the geometry in meters: any polygon bigger
         will get divided up for multiple queries to API (default 50km x 50km)
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -384,15 +381,6 @@ def _osm_net_download(
     -------
     response_jsons : list
     """
-    if infrastructure is not None:
-        from warnings import warn
-
-        msg = (
-            "The `infrastructure` parameter has been deprecated and will be "
-            "removed in the next release. Use the `custom_filter` parameter instead."
-        )
-        warn(msg)
-
     # check if we're querying by polygon or by bounding box based on which
     # argument(s) where passed into this function
     by_poly = polygon is not None

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -37,7 +37,6 @@ def graph_from_bbox(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -74,8 +73,6 @@ def graph_from_bbox(
     clean_periphery : bool
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -107,7 +104,6 @@ def graph_from_bbox(
             timeout=timeout,
             memory=memory,
             max_query_area_size=max_query_area_size,
-            infrastructure=infrastructure,
             custom_filter=custom_filter,
             custom_settings=custom_settings,
         )
@@ -154,7 +150,6 @@ def graph_from_bbox(
             timeout=timeout,
             memory=memory,
             max_query_area_size=max_query_area_size,
-            infrastructure=infrastructure,
             custom_filter=custom_filter,
             custom_settings=custom_settings,
         )
@@ -192,7 +187,6 @@ def graph_from_point(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -230,8 +224,6 @@ def graph_from_point(
     clean_periphery : bool,
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -263,7 +255,6 @@ def graph_from_point(
         memory=memory,
         max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
-        infrastructure=infrastructure,
         custom_filter=custom_filter,
         custom_settings=custom_settings,
     )
@@ -292,7 +283,6 @@ def graph_from_address(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -334,8 +324,6 @@ def graph_from_address(
     clean_periphery : bool,
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -362,7 +350,6 @@ def graph_from_address(
         memory=memory,
         max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
-        infrastructure=infrastructure,
         custom_filter=custom_filter,
         custom_settings=custom_settings,
     )
@@ -384,7 +371,6 @@ def graph_from_polygon(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -416,8 +402,6 @@ def graph_from_polygon(
     clean_periphery : bool
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -457,7 +441,6 @@ def graph_from_polygon(
             timeout=timeout,
             memory=memory,
             max_query_area_size=max_query_area_size,
-            infrastructure=infrastructure,
             custom_filter=custom_filter,
             custom_settings=custom_settings,
         )
@@ -497,7 +480,6 @@ def graph_from_polygon(
             timeout=timeout,
             memory=memory,
             max_query_area_size=max_query_area_size,
-            infrastructure=infrastructure,
             custom_filter=custom_filter,
             custom_settings=custom_settings,
         )
@@ -537,7 +519,6 @@ def graph_from_place(
     memory=None,
     max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
-    infrastructure=None,
     custom_filter=None,
     custom_settings=None,
 ):
@@ -582,8 +563,6 @@ def graph_from_place(
     clean_periphery : bool
         if True (and simplify=True), buffer 0.5km to get a graph larger than
         requested, then simplify, then truncate it to requested spatial extent
-    infrastructure : string
-        deprecated, use custom_filter instead
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
@@ -621,7 +600,6 @@ def graph_from_place(
         memory=memory,
         max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
-        infrastructure=infrastructure,
         custom_filter=custom_filter,
         custom_settings=custom_settings,
     )


### PR DESCRIPTION
The `infrastructure` parameter in graph creation functions was deprecated in favor of the flexible `custom_filter` parameter in a previous release. This PR removes it from the codebase. See also #477.