### PR TITLE
fix config function behavior

### DIFF
--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -778,7 +778,7 @@ def _convert_path(element):
     path["nodes"] = [group[0] for group in grouped_list]
 
     if "tags" in element:
-        for useful_tag in settings.useful_tags_path:
+        for useful_tag in settings.useful_tags_way:
             if useful_tag in element["tags"]:
                 path[useful_tag] = element["tags"][useful_tag]
     return path

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -21,7 +21,7 @@ log_filename = "osmnx"
 # useful osm tags - note that load_graphml expects a consistent set of tag names
 # for parsing
 useful_tags_node = ["ref", "highway"]
-useful_tags_path = [
+useful_tags_way = [
     "bridge",
     "tunnel",
     "oneway",

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -18,8 +18,9 @@ log_level = lg.INFO
 log_name = "osmnx"
 log_filename = "osmnx"
 
-# useful osm tags - note that load_graphml expects a consistent set of tag names
-# for parsing
+# OSM node/way tags to add as graph node/edge attributes when these tags are
+# present in the data retrieved from OSM
+# NOTE: load_graphml function expects a consistent set of tags for parsing
 useful_tags_node = ["ref", "highway"]
 useful_tags_way = [
     "bridge",

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -122,9 +122,9 @@ def config(
         if True, cache HTTP responses locally instead of calling API
         repetitively for the same request
     log_file : bool
-        if true, save log output to a file in logs_folder
+        if True, save log output to a file in logs_folder
     log_console : bool
-        if true, print log output to the console (terminal window)
+        if True, print log output to the console (terminal window)
     log_level : int
         one of the logger.level constants
     log_name : string
@@ -132,9 +132,9 @@ def config(
     log_filename : string
         name of the log file
     useful_tags_node : list
-        OSM "node" tags to add as graph node attributes, if present
+        OSM "node" tags to add as graph node attributes, when present
     useful_tags_way : list
-        OSM "way" tags to add as graph edge attributes, if present
+        OSM "way" tags to add as graph edge attributes, when present
     osm_xml_node_attrs : list
         node attributes for saving .osm XML files with save_graph_xml function
     osm_xml_node_tags : list

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -136,13 +136,13 @@ def config(
     useful_tags_path : list
         OSM "way" tags to add as graph edge attributes, if present
     osm_xml_node_attrs : list
-        node attributes for .osm XML files
+        node attributes for saving .osm XML files with save_graph_xml function
     osm_xml_node_tags : list
-        node tags for .osm XML files
+        node tags for saving .osm XML files with save_graph_xml function
     osm_xml_way_attrs : list
-        edge attributes for .osm XML files
+        edge attributes for saving .osm XML files with save_graph_xml function
     osm_xml_way_tags : list
-        edge tags for .osm XML files
+        edge tags for for saving .osm XML files with save_graph_xml function
     default_access : string
         default filter for OSM "access" key
     default_crs : string

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -181,8 +181,6 @@ def config(
     settings.log_filename = log_filename
     settings.useful_tags_node = useful_tags_node
     settings.useful_tags_path = useful_tags_path
-    settings.useful_tags_node = list(set(useful_tags_node + osm_xml_node_attrs + osm_xml_node_tags))
-    settings.useful_tags_path = list(set(useful_tags_path + osm_xml_way_attrs + osm_xml_way_tags))
     settings.osm_xml_node_attrs = osm_xml_node_attrs
     settings.osm_xml_node_tags = osm_xml_node_tags
     settings.osm_xml_way_attrs = osm_xml_way_attrs

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -88,7 +88,7 @@ def config(
     log_name=settings.log_name,
     log_filename=settings.log_filename,
     useful_tags_node=settings.useful_tags_node,
-    useful_tags_path=settings.useful_tags_path,
+    useful_tags_way=settings.useful_tags_way,
     osm_xml_node_attrs=settings.osm_xml_node_attrs,
     osm_xml_node_tags=settings.osm_xml_node_tags,
     osm_xml_way_attrs=settings.osm_xml_way_attrs,
@@ -133,7 +133,7 @@ def config(
         name of the log file
     useful_tags_node : list
         OSM "node" tags to add as graph node attributes, if present
-    useful_tags_path : list
+    useful_tags_way : list
         OSM "way" tags to add as graph edge attributes, if present
     osm_xml_node_attrs : list
         node attributes for saving .osm XML files with save_graph_xml function
@@ -180,7 +180,7 @@ def config(
     settings.log_name = log_name
     settings.log_filename = log_filename
     settings.useful_tags_node = useful_tags_node
-    settings.useful_tags_path = useful_tags_path
+    settings.useful_tags_way = useful_tags_way
     settings.osm_xml_node_attrs = osm_xml_node_attrs
     settings.osm_xml_node_tags = osm_xml_node_tags
     settings.osm_xml_way_attrs = osm_xml_way_attrs


### PR DESCRIPTION
resolves #489 

Also renames the confusingly-named setting `useful_tags_path` to the more appropriate `useful_tags_way`.

If you're creating a graph to save to .osm XML file later, you can first configure like:

```python
import osmnx as ox
utn = list(set(ox.settings.useful_tags_node + ox.settings.osm_xml_node_attrs + ox.settings.osm_xml_node_tags))
utw = list(set(ox.settings.useful_tags_way + ox.settings.osm_xml_way_attrs + ox.settings.osm_xml_way_tags))
ox.config(use_cache=True, all_oneway=True, useful_tags_node=utn, useful_tags_way=utw)
```