### PR TITLE
improve graph creation

### DIFF
--- a/osmnx/_errors.py
+++ b/osmnx/_errors.py
@@ -7,27 +7,3 @@ class EmptyOverpassResponse(ValueError):  # pragma: no cover
     def __init__(self, *args, **kwargs):
         """Create exception."""
         Exception.__init__(self, *args, **kwargs)
-
-
-class InsufficientNetworkQueryArguments(ValueError):  # pragma: no cover
-    """Exception for insufficient network query args."""
-
-    def __init__(self, *args, **kwargs):
-        """Create exception."""
-        Exception.__init__(self, *args, **kwargs)
-
-
-class InvalidDistanceType(ValueError):  # pragma: no cover
-    """Exception for invalid distance type."""
-
-    def __init__(self, *args, **kwargs):
-        """Create exception."""
-        Exception.__init__(self, *args, **kwargs)
-
-
-class UnknownNetworkType(ValueError):  # pragma: no cover
-    """Exception for unknown network type."""
-
-    def __init__(self, *args, **kwargs):
-        """Create exception."""
-        Exception.__init__(self, *args, **kwargs)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -376,6 +376,10 @@ def test_get_network_methods():
         north, south, east, west, network_type="drive_service", truncate_by_edge=True
     )
 
+    # truncate graph by bounding box
+    north, south, east, west = ox.utils_geo.bbox_from_point(location_point, dist=400)
+    G = ox.truncate.truncate_graph_bbox(G, north, south, east, west)
+
     # graph from address
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 


### PR DESCRIPTION
This PR simplifies the codebase by letting the graph creation/truncation by bounding-box functionality hand off to the graph creation/truncation by polygon functionality. Previously, each had their own fairly redundant code to complete these tasks. This also lets us remove all the "download by bounding box" logic from `osm_net_download` as all bounding boxes are now just converted to polygons. It also:

  - allows periphery cleaning if `clean_periphery=True` even if `simplify=False`
  - removes unnecessary errors in favor of built-in exceptions