### PR TITLE
Deprecate query parameters

### DIFF
--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -32,12 +32,12 @@ def graph_from_bbox(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    timeout=180,
-    memory=None,
-    max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
     custom_filter=None,
+    timeout=None,
+    memory=None,
     custom_settings=None,
+    max_query_area_size=None,
 ):
     """
     Create a graph from OSM within some bounding box.
@@ -55,28 +55,30 @@ def graph_from_bbox(
     network_type : string
         what type of street network to get
     simplify : bool
-        if true, simplify the graph topology
+        if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected
     truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
-    timeout : int
-        the timeout interval for requests and to pass to API
-    memory : int
-        server memory allocation size for the query, in bytes. If none, server
-        will use its default allocation size
-    max_query_area_size : float
-        max area for any part of the geometry in meters: any polygon bigger
-        will get divided up for multiple queries to API (default 50km x 50km)
+        if True, retain node if it's outside bounding box but at least one of
+        node's neighbors are within the bounding box
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
-    custom_settings : string
-        custom settings to be used in overpass query instead of the defaults
+    timeout : None
+        deprecated, use ox.config(timeout=value) instead to configure this
+        setting via the settings module
+    memory : None
+        deprecated, use ox.config(memory=value) instead to configure this
+        setting via the settings module
+    custom_settings : None
+        deprecated, use ox.config(custom_settings=value) instead to configure
+        this setting via the settings module
+    max_query_area_size : None
+        deprecated, use ox.config(max_query_area_size=value) instead to
+        configure this setting via the settings module
 
     Returns
     -------
@@ -92,12 +94,12 @@ def graph_from_bbox(
         simplify=simplify,
         retain_all=retain_all,
         truncate_by_edge=truncate_by_edge,
-        timeout=timeout,
-        memory=memory,
-        max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
         custom_filter=custom_filter,
+        timeout=timeout,
+        memory=memory,
         custom_settings=custom_settings,
+        max_query_area_size=max_query_area_size,
     )
 
     utils.log(f"graph_from_bbox returned graph with {len(G)} nodes and {len(G.edges())} edges")
@@ -112,12 +114,12 @@ def graph_from_point(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    timeout=180,
-    memory=None,
-    max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
     custom_filter=None,
+    timeout=None,
+    memory=None,
     custom_settings=None,
+    max_query_area_size=None,
 ):
     """
     Create a graph from OSM within some distance of some (lat, lng) point.
@@ -136,28 +138,30 @@ def graph_from_point(
     network_type : string
         what type of street network to get
     simplify : bool
-        if true, simplify the graph topology
+        if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected
     truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
-    timeout : int
-        the timeout interval for requests and to pass to API
-    memory : int
-        server memory allocation size for the query, in bytes. If none, server
-        will use its default allocation size
-    max_query_area_size : float
-        max area for any part of the geometry in meters: any polygon bigger
-        will get divided up for multiple queries to API (default 50km x 50km)
+        if True, retain node if it's outside bounding box but at least one of
+        node's neighbors are within bounding box
     clean_periphery : bool,
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
-    custom_settings : string
-        custom settings to be used in overpass query instead of the defaults
+    timeout : None
+        deprecated, use ox.config(timeout=value) instead to configure this
+        setting via the settings module
+    memory : None
+        deprecated, use ox.config(memory=value) instead to configure this
+        setting via the settings module
+    custom_settings : None
+        deprecated, use ox.config(custom_settings=value) instead to configure
+        this setting via the settings module
+    max_query_area_size : None
+        deprecated, use ox.config(max_query_area_size=value) instead to
+        configure this setting via the settings module
 
     Returns
     -------
@@ -180,12 +184,12 @@ def graph_from_point(
         simplify=simplify,
         retain_all=retain_all,
         truncate_by_edge=truncate_by_edge,
-        timeout=timeout,
-        memory=memory,
-        max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
         custom_filter=custom_filter,
+        timeout=timeout,
+        memory=memory,
         custom_settings=custom_settings,
+        max_query_area_size=max_query_area_size,
     )
 
     # if the network dist_type is network, find the node in the graph
@@ -208,12 +212,12 @@ def graph_from_address(
     retain_all=False,
     truncate_by_edge=False,
     return_coords=False,
-    timeout=180,
-    memory=None,
-    max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
     custom_filter=None,
+    timeout=None,
+    memory=None,
     custom_settings=None,
+    max_query_area_size=None,
 ):
     """
     Create a graph from OSM within some distance of some address.
@@ -234,30 +238,32 @@ def graph_from_address(
     network_type : string
         what type of street network to get
     simplify : bool
-        if true, simplify the graph topology
+        if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected
     truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
+        if True, retain node if it's outside bounding box but at least one of
+        node's neighbors are within bounding box
     return_coords : bool
         optionally also return the geocoded coordinates of the address
-    timeout : int
-        the timeout interval for requests and to pass to API
-    memory : int
-        server memory allocation size for the query, in bytes. If none, server
-        will use its default allocation size
-    max_query_area_size
-        float, max size for any part of the geometry, in square degrees: any
-        polygon bigger will get divided up for multiple queries to API
     clean_periphery : bool,
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
-    custom_settings : string
-        custom settings to be used in overpass query instead of the defaults
+    timeout : None
+        deprecated, use ox.config(timeout=value) instead to configure this
+        setting via the settings module
+    memory : None
+        deprecated, use ox.config(memory=value) instead to configure this
+        setting via the settings module
+    custom_settings : None
+        deprecated, use ox.config(custom_settings=value) instead to configure
+        this setting via the settings module
+    max_query_area_size : None
+        deprecated, use ox.config(max_query_area_size=value) instead to
+        configure this setting via the settings module
 
     Returns
     -------
@@ -275,12 +281,12 @@ def graph_from_address(
         simplify=simplify,
         retain_all=retain_all,
         truncate_by_edge=truncate_by_edge,
-        timeout=timeout,
-        memory=memory,
-        max_query_area_size=max_query_area_size,
         clean_periphery=clean_periphery,
         custom_filter=custom_filter,
+        timeout=timeout,
+        memory=memory,
         custom_settings=custom_settings,
+        max_query_area_size=max_query_area_size,
     )
     utils.log(f"graph_from_address returned graph with {len(G)} nodes and {len(G.edges())} edges")
 
@@ -290,18 +296,121 @@ def graph_from_address(
         return G
 
 
+def graph_from_place(
+    query,
+    network_type="all_private",
+    simplify=True,
+    retain_all=False,
+    truncate_by_edge=False,
+    which_result=1,
+    buffer_dist=None,
+    clean_periphery=True,
+    custom_filter=None,
+    timeout=None,
+    memory=None,
+    custom_settings=None,
+    max_query_area_size=None,
+):
+    """
+    Create graph from OSM within the boundaries of some geocodable place(s).
+
+    The query must be geocodable and OSM must have polygon boundaries for the
+    geocode result. If OSM does not have a polygon for this place, you can
+    instead get its street network using the graph_from_address function, which
+    geocodes the place name to a point and gets the network within some distance
+    of that point. Alternatively, you might try to vary the which_result
+    parameter to use a different geocode result. For example, the first geocode
+    result (ie, the default) might resolve to a point geometry, but the second
+    geocode result for this query might resolve to a polygon, in which case you
+    can use graph_from_place with which_result=2.
+
+    Parameters
+    ----------
+    query : string or dict or list
+        the place(s) to geocode/download data for
+    network_type : string
+        what type of street network to get
+    simplify : bool
+        if True, simplify the graph topology
+    retain_all : bool
+        if True, return the entire graph even if it is not connected
+    truncate_by_edge : bool
+        if True, retain node if it's outside polygon but at least one of
+        node's neighbors are within bbox
+    which_result : int
+        max number of results to return and which to process upon receipt
+    buffer_dist : float
+        distance to buffer around the place geometry, in meters
+    clean_periphery : bool
+        if True, buffer 500m to get a graph larger than requested, then
+        simplify, then truncate it to requested spatial boundaries
+    custom_filter : string
+        a custom network filter to be used instead of the network_type presets,
+        e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
+    timeout : None
+        deprecated, use ox.config(timeout=value) instead to configure this
+        setting via the settings module
+    memory : None
+        deprecated, use ox.config(memory=value) instead to configure this
+        setting via the settings module
+    custom_settings : None
+        deprecated, use ox.config(custom_settings=value) instead to configure
+        this setting via the settings module
+    max_query_area_size : None
+        deprecated, use ox.config(max_query_area_size=value) instead to
+        configure this setting via the settings module
+    Returns
+    -------
+    G : networkx.MultiDiGraph
+    """
+    # create a GeoDataFrame with the spatial boundaries of the place(s)
+    if isinstance(query, (str, dict)):
+        # if it is a string (place name) or dict (structured place query), then
+        # it is a single place
+        gdf_place = boundaries.gdf_from_place(
+            query, which_result=which_result, buffer_dist=buffer_dist
+        )
+    elif isinstance(query, list):
+        # if it is a list, it contains multiple places to get
+        gdf_place = boundaries.gdf_from_places(query, buffer_dist=buffer_dist)
+    else:
+        raise TypeError("query must be dict, string, or list of strings")
+
+    # extract the geometry from the GeoDataFrame to use in API query
+    polygon = gdf_place["geometry"].unary_union
+    utils.log("Constructed place geometry polygon(s) to query API")
+
+    # create graph using this polygon(s) geometry
+    G = graph_from_polygon(
+        polygon,
+        network_type=network_type,
+        simplify=simplify,
+        retain_all=retain_all,
+        truncate_by_edge=truncate_by_edge,
+        clean_periphery=clean_periphery,
+        custom_filter=custom_filter,
+        timeout=timeout,
+        memory=memory,
+        custom_settings=custom_settings,
+        max_query_area_size=max_query_area_size,
+    )
+
+    utils.log(f"graph_from_place returned graph with {len(G)} nodes and {len(G.edges())} edges")
+    return G
+
+
 def graph_from_polygon(
     polygon,
     network_type="all_private",
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    timeout=180,
-    memory=None,
-    max_query_area_size=50 * 1000 * 50 * 1000,
     clean_periphery=True,
     custom_filter=None,
+    timeout=None,
+    memory=None,
     custom_settings=None,
+    max_query_area_size=None,
 ):
     """
     Create a graph from OSM within the boundaries of some shapely polygon.
@@ -314,33 +423,42 @@ def graph_from_polygon(
     network_type : string
         what type of street network to get
     simplify : bool
-        if true, simplify the graph topology
+        if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected
     truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
-    timeout : int
-        the timeout interval for requests and to pass to API
-    memory : int
-        server memory allocation size for the query, in bytes. If none, server
-        will use its default allocation size
-    max_query_area_size : float
-        max area for any part of the geometry in meters: any polygon bigger
-        will get divided up for multiple queries to API (default 50km x 50km)
+        if True, retain node if it's outside polygon but at least one of
+        node's neighbors are within polygon
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
     custom_filter : string
         a custom network filter to be used instead of the network_type presets,
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
-    custom_settings : string
-        custom settings to be used in overpass query instead of the defaults
+    timeout : None
+        deprecated, use ox.config(timeout=value) instead to configure this
+        setting via the settings module
+    memory : None
+        deprecated, use ox.config(memory=value) instead to configure this
+        setting via the settings module
+    custom_settings : None
+        deprecated, use ox.config(custom_settings=value) instead to configure
+        this setting via the settings module
+    max_query_area_size : None
+        deprecated, use ox.config(max_query_area_size=value) instead to
+        configure this setting via the settings module
 
     Returns
     -------
     G : networkx.MultiDiGraph
     """
+    utils._handle_deprecated_params(
+        timeout=timeout,
+        memory=memory,
+        custom_settings=custom_settings,
+        max_query_area_size=max_query_area_size,
+    )
+
     # verify that the geometry is valid and is a shapely Polygon/MultiPolygon
     # before proceeding
     if not polygon.is_valid:
@@ -361,15 +479,7 @@ def graph_from_polygon(
         poly_buff, _ = projection.project_geometry(poly_proj_buff, crs=crs_utm, to_latlong=True)
 
         # download the network data from OSM
-        response_jsons = downloader._osm_net_download(
-            polygon=poly_buff,
-            network_type=network_type,
-            timeout=timeout,
-            memory=memory,
-            max_query_area_size=max_query_area_size,
-            custom_filter=custom_filter,
-            custom_settings=custom_settings,
-        )
+        response_jsons = downloader._osm_net_download(poly_buff, network_type, custom_filter)
 
         # create buffered graph from the downloaded data
         G_buff = _create_graph(
@@ -405,15 +515,7 @@ def graph_from_polygon(
     # if clean_periphery=False, just use the polygon as provided
     else:
         # download the network data from OSM
-        response_jsons = downloader._osm_net_download(
-            polygon=polygon,
-            network_type=network_type,
-            timeout=timeout,
-            memory=memory,
-            max_query_area_size=max_query_area_size,
-            custom_filter=custom_filter,
-            custom_settings=custom_settings,
-        )
+        response_jsons = downloader._osm_net_download(polygon, network_type, custom_filter)
 
         # create graph from the downloaded data
         G = _create_graph(
@@ -435,107 +537,6 @@ def graph_from_polygon(
             G = simplification.simplify_graph(G)
 
     utils.log(f"graph_from_polygon returned graph with {len(G)} nodes and {len(G.edges())} edges")
-    return G
-
-
-def graph_from_place(
-    query,
-    network_type="all_private",
-    simplify=True,
-    retain_all=False,
-    truncate_by_edge=False,
-    which_result=1,
-    buffer_dist=None,
-    timeout=180,
-    memory=None,
-    max_query_area_size=50 * 1000 * 50 * 1000,
-    clean_periphery=True,
-    custom_filter=None,
-    custom_settings=None,
-):
-    """
-    Create graph from OSM within the boundaries of some geocodable place(s).
-
-    The query must be geocodable and OSM must have polygon boundaries for the
-    geocode result. If OSM does not have a polygon for this place, you can
-    instead get its street network using the graph_from_address function, which
-    geocodes the place name to a point and gets the network within some distance
-    of that point. Alternatively, you might try to vary the which_result
-    parameter to use a different geocode result. For example, the first geocode
-    result (ie, the default) might resolve to a point geometry, but the second
-    geocode result for this query might resolve to a polygon, in which case you
-    can use graph_from_place with which_result=2.
-
-    Parameters
-    ----------
-    query : string or dict or list
-        the place(s) to geocode/download data for
-    network_type : string
-        what type of street network to get
-    simplify : bool
-        if true, simplify the graph topology
-    retain_all : bool
-        if True, return the entire graph even if it is not connected
-    truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
-    which_result : int
-        max number of results to return and which to process upon receipt
-    buffer_dist : float
-        distance to buffer around the place geometry, in meters
-    timeout : int
-        the timeout interval for requests and to pass to API
-    memory : int
-        server memory allocation size for the query, in bytes. If none, server
-        will use its default allocation size
-    max_query_area_size : float
-        max area for any part of the geometry in meters: any polygon bigger
-        will get divided up for multiple queries to API (default 50km x 50km)
-    clean_periphery : bool
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
-        a custom network filter to be used instead of the network_type presets,
-        e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'
-    custom_settings : string
-        custom settings to be used in overpass query instead of the defaults
-    Returns
-    -------
-    G : networkx.MultiDiGraph
-    """
-    # create a GeoDataFrame with the spatial boundaries of the place(s)
-    if isinstance(query, (str, dict)):
-        # if it is a string (place name) or dict (structured place query), then
-        # it is a single place
-        gdf_place = boundaries.gdf_from_place(
-            query, which_result=which_result, buffer_dist=buffer_dist
-        )
-    elif isinstance(query, list):
-        # if it is a list, it contains multiple places to get
-        gdf_place = boundaries.gdf_from_places(query, buffer_dist=buffer_dist)
-    else:
-        raise TypeError("query must be dict, string, or list of strings")
-
-    # extract the geometry from the GeoDataFrame to use in API query
-    polygon = gdf_place["geometry"].unary_union
-    utils.log("Constructed place geometry polygon(s) to query API")
-
-    # create graph using this polygon(s) geometry
-    G = graph_from_polygon(
-        polygon,
-        network_type=network_type,
-        simplify=simplify,
-        retain_all=retain_all,
-        truncate_by_edge=truncate_by_edge,
-        timeout=timeout,
-        memory=memory,
-        max_query_area_size=max_query_area_size,
-        clean_periphery=clean_periphery,
-        custom_filter=custom_filter,
-        custom_settings=custom_settings,
-    )
-
-    utils.log(f"graph_from_place returned graph with {len(G)} nodes and {len(G.edges())} edges")
     return G
 
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -46,6 +46,21 @@ osm_xml_node_tags = ["highway"]
 osm_xml_way_attrs = ["id", "timestamp", "uid", "user", "version", "changeset"]
 osm_xml_way_tags = ["highway", "lanes", "maxspeed", "name", "oneway"]
 
+# default settings string for overpass queries: timeout and maxsize need to
+# be dynamically set where used
+overpass_settings = "[out:json][timeout:{timeout}]{maxsize}"
+
+# the timeout interval for the HTTP request and for API to use while running
+# the query
+timeout = 180
+
+# overpass server memory allocation size for the query, in bytes. If None,
+# server will use its default allocation size
+memory = None
+
+# maximum area for any part of the geometry in meters: any polygon bigger than
+# this will get divided up for multiple queries to API (default 50km x 50km)
+max_query_area_size = 50 * 1000 * 50 * 1000
 
 # default filter for OSM "access" key. filtering out "access=no" ways prevents
 # including transit-only bridges like tilikum crossing from appearing in drivable
@@ -58,10 +73,6 @@ default_access = '["access"!~"private"]'
 
 # The network types for which a bidirectional graph will be created
 bidirectional_network_types = ["walk"]
-
-# default settings string for overpass queries: timeout and maxsize need to
-# be dynamically set where used
-default_overpass_query_settings = "[out:json][timeout:{timeout}]{maxsize}"
 
 # all one-way mode to maintain original OSM node order when creating graphs
 # specifically to save to .osm xml file with save_graph_xml function

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -207,13 +207,16 @@ def config(
     osm_xml_way_tags : list
         edge tags for for saving .osm XML files with save_graph_xml function
     overpass_settings : string
-        settings for overpass queries
+        Settings string for overpass queries. For example, to query historical
+        OSM data as of a certain date:
+        `'[out:json][timeout:90][date:"2019-10-28T19:20:00Z"]'`.
+        Use with caution.
     timeout : int
         the timeout interval for the HTTP request and for API to use while
         running the query
     memory : int
-        overpass server memory allocation size for the query, in bytes. If
-        None, server will use its default allocation size
+        Overpass server memory allocation size for the query, in bytes. If
+        None, server will use its default allocation size. Use with caution.
     max_query_area_size : int
         maximum area for any part of the geometry in meters: any polygon
         bigger than this will get divided up for multiple queries to API

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -9,6 +9,64 @@ import unicodedata
 from . import settings
 
 
+def _handle_deprecated_params(
+    timeout=None, memory=None, max_query_area_size=None, custom_settings=None
+):
+    """
+    Pass deprecated function parameters into the global settings.
+
+    Parameters
+    ----------
+    timeout : int
+        timeout setting
+    memory : int
+        memory setting
+    max_query_area_size : float
+        max_query_area_size setting
+    custom_settings : string
+        custom_settings setting
+
+    Returns
+    -------
+    None
+    """
+    params = []
+
+    # if any params are not None, set the corresponding setting in the
+    # settings module to that parameters value
+    if timeout is not None:
+        params.append("timeout")
+        settings.timeout = timeout
+
+    if memory is not None:
+        params.append("memory")
+        settings.memory = memory
+
+    if max_query_area_size is not None:
+        params.append("max_query_area_size")
+        settings.max_query_area_size = max_query_area_size
+
+    if custom_settings is not None:
+        params.append("custom_settings")
+        settings.overpass_settings = custom_settings
+
+    # warn user of the deprecation
+    if len(params) > 0:
+        from warnings import warn
+
+        param_str = ",".join([f'"{p}"' for p in params])
+        param_str = f"[{param_str}]"
+        msg = (
+            f"The parameters {param_str} have been deprecated and will be "
+            f"removed in the next release. All of these parameters have been "
+            f"replaced by settings in the settings module, which you can set "
+            f"via ox.config(setting_name=value). Also note that the old "
+            f"custom_settings parameter has been renamed overpass_settings "
+            f"in the settings module."
+        )
+        warn(msg)
+
+
 def citation():
     """
     Print the OSMnx package's citation information.
@@ -93,6 +151,10 @@ def config(
     osm_xml_node_tags=settings.osm_xml_node_tags,
     osm_xml_way_attrs=settings.osm_xml_way_attrs,
     osm_xml_way_tags=settings.osm_xml_way_tags,
+    overpass_settings=settings.overpass_settings,
+    timeout=settings.timeout,
+    memory=settings.memory,
+    max_query_area_size=settings.max_query_area_size,
     default_access=settings.default_access,
     default_crs=settings.default_crs,
     default_user_agent=settings.default_user_agent,
@@ -106,7 +168,8 @@ def config(
     """
     Configure OSMnx by setting the default global settings' values.
 
-    Any parameters not passed by the caller are set to their default values.
+    Any parameters not passed by the caller are set to their original default
+    values.
 
     Parameters
     ----------
@@ -143,6 +206,18 @@ def config(
         edge attributes for saving .osm XML files with save_graph_xml function
     osm_xml_way_tags : list
         edge tags for for saving .osm XML files with save_graph_xml function
+    overpass_settings : string
+        settings for overpass queries
+    timeout : int
+        the timeout interval for the HTTP request and for API to use while
+        running the query
+    memory : int
+        overpass server memory allocation size for the query, in bytes. If
+        None, server will use its default allocation size
+    max_query_area_size : int
+        maximum area for any part of the geometry in meters: any polygon
+        bigger than this will get divided up for multiple queries to API
+        (default 50km x 50km)
     default_access : string
         default filter for OSM "access" key
     default_crs : string
@@ -168,7 +243,7 @@ def config(
     -------
     None
     """
-    # set each global variable to the passed-in parameter value
+    # set each global setting to the passed-in value
     settings.use_cache = use_cache
     settings.cache_folder = cache_folder
     settings.data_folder = data_folder
@@ -185,6 +260,10 @@ def config(
     settings.osm_xml_node_tags = osm_xml_node_tags
     settings.osm_xml_way_attrs = osm_xml_way_attrs
     settings.osm_xml_way_tags = osm_xml_way_tags
+    settings.overpass_settings = overpass_settings
+    settings.timeout = timeout
+    settings.memory = memory
+    settings.max_query_area_size = max_query_area_size
     settings.default_access = default_access
     settings.default_crs = default_crs
     settings.default_user_agent = default_user_agent

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -15,6 +15,7 @@ from shapely.ops import split
 
 from . import downloader
 from . import projection
+from . import settings
 from . import utils
 
 
@@ -40,7 +41,7 @@ def geocode(query):
         "dedupe"
     ] = 0  # prevent OSM from deduping results so we get precisely 'limit' # of results
     params["q"] = query
-    response_json = downloader.nominatim_request(params=params, timeout=30)
+    response_json = downloader.nominatim_request(params=params)
 
     # if results were returned, parse lat and long out of the result
     if len(response_json) > 0 and "lat" in response_json[0] and "lon" in response_json[0]:
@@ -246,20 +247,18 @@ def round_geometry_coords(shape, precision):
         raise TypeError(f"cannot round coordinates of unhandled geometry type: {type(shape)}")
 
 
-def _consolidate_subdivide_geometry(geometry, max_query_area_size):
+def _consolidate_subdivide_geometry(geometry):
     """
     Consolidate and subdivide some geometry.
 
     Consolidate a geometry into a convex hull, then subdivide it into smaller
-    sub-polygons if its area exceeds max size (in geometry's units).
+    sub-polygons if its area exceeds max size (in geometry's units). Configure
+    the max size via max_query_area_size in the settings module.
 
     Parameters
     ----------
     geometry : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
         the geometry to consolidate and subdivide
-    max_query_area_size : float
-        max area for any part of the geometry in geometry's units:
-        any polygon bigger will get divided up for multiple queries to API
 
     Returns
     -------
@@ -267,7 +266,7 @@ def _consolidate_subdivide_geometry(geometry, max_query_area_size):
     """
     # let the linear length of the quadrats (with which to subdivide the
     # geometry) be the square root of max area size
-    quadrat_width = math.sqrt(max_query_area_size)
+    quadrat_width = math.sqrt(settings.max_query_area_size)
 
     if not isinstance(geometry, (Polygon, MultiPolygon)):
         raise TypeError("Geometry must be a shapely Polygon or MultiPolygon")
@@ -275,12 +274,12 @@ def _consolidate_subdivide_geometry(geometry, max_query_area_size):
     # if geometry is a MultiPolygon OR a single Polygon whose area exceeds the
     # max size, get the convex hull around the geometry
     if isinstance(geometry, MultiPolygon) or (
-        isinstance(geometry, Polygon) and geometry.area > max_query_area_size
+        isinstance(geometry, Polygon) and geometry.area > settings.max_query_area_size
     ):
         geometry = geometry.convex_hull
 
     # if geometry area exceeds max size, subdivide it into smaller sub-polygons
-    if geometry.area > max_query_area_size:
+    if geometry.area > settings.max_query_area_size:
         geometry = _quadrat_cut_geometry(geometry, quadrat_width=quadrat_width)
 
     if isinstance(geometry, Polygon):

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -269,17 +269,8 @@ def test_find_nearest():
 def test_pois():
 
     tags = {"amenity": True, "landuse": ["retail", "commercial"], "highway": "bus_stop"}
-
     gdf = ox.pois_from_place(place1, tags=tags)
-
-    gdf = ox.pois_from_polygon(polygon, tags={"amenity": "library"})
-
-    cs = '[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.pois_from_address(address, tags={"amenity": "school"}, custom_settings=cs)
-
-    gdf = ox.pois_from_point(
-        location_point, dist=500, tags={"amenity": "restaurant"}, timeout=200, memory=100000
-    )
+    gdf = ox.pois_from_address(address, tags={"amenity": "school"})
 
 
 def test_api_endpoints():
@@ -402,14 +393,8 @@ def test_get_network_methods():
         location_point, dist=500, custom_filter=cf, dist_type="bbox", network_type="all"
     )
 
-    # test custom settings
-    cs = '[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]'
     G = ox.graph_from_point(
-        location_point,
-        dist=500,
-        custom_settings=cs,
-        dist_type="network",
-        network_type="all_private",
+        location_point, dist=500, dist_type="network", network_type="all_private",
     )
 
 
@@ -436,8 +421,8 @@ def test_stats():
 def test_footprints():
 
     # download footprints and plot them
-    cs = '[out:json][timeout:180][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.footprints_from_place(place2, custom_settings=cs)
+    ox.settings.overpass_settings = '[out:json][timeout:200][date:"2019-10-28T19:20:00Z"]'
+    gdf = ox.footprints_from_place(place2)
     gdf = ox.footprints_from_polygon(polygon)
     gdf = ox.footprints_from_address(address, dist=300)
     fig, ax = ox.plot_footprints(gdf)
@@ -482,9 +467,6 @@ def test_footprints():
     # test plotting multipolygon
     fig, ax = ox.plot_footprints(clapham_common_gdf)
 
-    # should raise an exception
-    # polygon or -north, south, east, west- should be provided
+    # should raise an exception: polygon or responses must be provided
     with pytest.raises(ValueError):
-        ox.footprints._create_footprints_gdf(
-            polygon=None, north=None, south=None, east=None, west=None
-        )
+        ox.footprints._create_footprints_gdf(polygon=None, responses=None)


### PR DESCRIPTION
This PR deprecates the `timeout`, `memory`, `custom_settings`, and `max_query_area_size` parameters in graph creation, POI GeoDataFrame creation, and footprints GeoDataFrame creation functions. These parameters are seldom used and clutter the function signatures.

They have been moved to the `settings` module instead, where they can be configured via `ox.config(setting_name=value)` or accessed via `ox.settings.setting_name`.

This PR also simplifies the codebase by letting the POI/footprints creation by bounding-box functionality hand off to the creation by polygon functionality (as #491 already did for graph creation). This streamlines a lot of relatively redundant code.