### PR TITLE
Enable simplification of long (rural) roads

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -113,10 +113,19 @@ def _build_path(G, node, endpoints, path):
             # if this successor is already in the path, ignore it, otherwise add
             # it to the path
             path.append(successor)
-            if successor not in endpoints:
-                # if this successor is not an endpoint, recursively call
-                # build_path until you find an endpoint
-                path = _build_path(G, successor, endpoints, path)
+            while successor not in endpoints:
+                nodes = [n for n in G.successors(successor) if n not in path]
+                # If nodes is empty, we should be on a self contained ring
+                # If nodes is longer than one, we fork into two paths
+                if len(nodes) == 1:
+                    successor = nodes[0]
+                    path.append(successor)
+                else:
+                    # if this successor is not an endpoint, recursively call
+                    # build_path until you find an endpoint
+                    return _build_path(G, successor, endpoints, path)
+
+            # We only enter this else statement if the while loop finishes properly!
             else:
                 # if this successor is an endpoint, we've completed the path,
                 # so return it

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -143,12 +143,10 @@ def _build_path(G, node, endpoints, path):
 
 def _get_paths_to_simplify(G, strict=True):
     """
-    Create a list of all the paths to be simplified between endpoint nodes.
+    Generate all the paths to be simplified between endpoint nodes.
 
     The path is ordered from the first endpoint, through the interstitial nodes,
-    to the second endpoint. If your street network is in a rural area with many
-    interstitial nodes between true edge endpoints, you may want to increase
-    your system's recursion limit to avoid recursion errors.
+    to the second endpoint.
 
     Parameters
     ----------
@@ -158,15 +156,13 @@ def _get_paths_to_simplify(G, strict=True):
         if False, allow nodes to be end points even if they fail all other rules
         but have edges with different OSM IDs
 
-    Returns
-    -------
-    paths_to_simplify : list
+    Yields
+    ------
+    path_to_simplify : list
     """
     # first identify all the nodes that are endpoints
     endpoints = set([node for node in G.nodes() if _is_endpoint(G, node, strict=strict)])
     utils.log(f"Identified {len(endpoints)} edge endpoints")
-
-    paths_to_simplify = []
 
     # for each endpoint node, look at each of its successor nodes
     for node in endpoints:
@@ -175,8 +171,7 @@ def _get_paths_to_simplify(G, strict=True):
                 # if the successor is not an endpoint, build a path from the
                 # endpoint node to the next endpoint node
                 try:
-                    path = _build_path(G, successor, endpoints, path=[node, successor])
-                    paths_to_simplify.append(path)
+                    yield _build_path(G, successor, endpoints, path=[node, successor])
                 except RecursionError:
                     utils.log(
                         "Exceeded max depth, moving on to next endpoint successor", level=lg.WARNING
@@ -187,9 +182,6 @@ def _get_paths_to_simplify(G, strict=True):
                     # rural areas) with too many nodes between true endpoints.
                     # handle it by just ignoring that component and letting its
                     # topology remain intact (this should be a rare occurrence)
-
-    utils.log("Constructed all paths to simplify")
-    return paths_to_simplify
 
 
 def _is_simplified(G):


### PR DESCRIPTION
The recursive nature of ```simplification._build_path``` is reduced to only those cases where either a self loop is imminent or the road forks. Path building of long roads is done in a while-loop that substitutes the prior if-statement checking for an endpoint.

So the logics stay the same except for the simple and usual case of a single successor (a road that neither forks nor loops).

#### Memory
In addition, ```_get_paths_to_simplify``` has been turned into a generator in order to reduce the memory footprint.

#### Note
To my understanding the ```RecursionError``` should now be extremely rare. After a recursive call self-loops are filtered by ```successor not in path```. On the other hand a road would need to have an immense amount of forks not classified as endpoints. Of course, the safe way to go is to keep checking for the error.