### PR TITLE
Enable simplification of long (rural) roads 

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -227,10 +227,8 @@ def simplify_graph(G, strict=True, remove_rings=True):
     all_nodes_to_remove = []
     all_edges_to_add = []
 
-    # construct a list of all the paths that need to be simplified
-    paths = _get_paths_to_simplify(G, strict=strict)
-
-    for path in paths:
+    # generate each path that needs to be simplified
+    for path in _get_paths_to_simplify(G, strict=strict):
 
         # add the interstitial edges we're removing to a list so we can retain
         # their spatial geometry

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -193,7 +193,7 @@ def _is_simplified(G):
     return "simplified" in G.graph and G.graph["simplified"]
 
 
-def simplify_graph(G, strict=True, rings=False):
+def simplify_graph(G, strict=True, remove_rings=True):
     """
     Simplify a graph's topology by removing interstitial nodes.
 
@@ -211,8 +211,8 @@ def simplify_graph(G, strict=True, rings=False):
         rules but have incident edges with different OSM IDs. Lets you keep
         nodes at elbow two-way intersections, but sometimes individual blocks
         have multiple OSM IDs within them too.
-    rings : bool
-        if False, remove isolated self-contained rings without any endpoints
+    remove_rings : bool
+        if True, remove isolated self-contained rings that have no endpoints
 
     Returns
     -------
@@ -291,7 +291,7 @@ def simplify_graph(G, strict=True, rings=False):
     # finally remove all the interstitial nodes between the new edges
     G.remove_nodes_from(set(all_nodes_to_remove))
 
-    if not rings:
+    if remove_rings:
         # remove any connected components that form a self-contained ring
         # without any endpoints
         wccs = nx.weakly_connected_components(G)
@@ -301,7 +301,7 @@ def simplify_graph(G, strict=True, rings=False):
                 nodes_in_rings.update(wcc)
         G.remove_nodes_from(nodes_in_rings)
 
-    # mark graph as simplified
+    # mark graph as having been simplified
     G.graph["simplified"] = True
 
     msg = (

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -1,7 +1,5 @@
 """Simplify, correct, and consolidate network topology."""
 
-import logging as lg
-
 import geopandas as gpd
 import networkx as nx
 from shapely.geometry import LineString

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -114,31 +114,26 @@ def _build_path(G, node, endpoints, path):
             # it to the path
             path.append(successor)
             while successor not in endpoints:
-                nodes = [n for n in G.successors(successor) if n not in path]
-                # If nodes is empty, we should be on a self contained ring
-                # If nodes is longer than one, we fork into two paths
-                if len(nodes) == 1:
-                    successor = nodes[0]
+                # find successors (of current successor) not in path
+                successors = [n for n in G.successors(successor) if n not in path]
+                if len(successors) == 1:
+                    successor = successors[0]
                     path.append(successor)
                 else:
-                    # if this successor is not an endpoint, recursively call
-                    # build_path until you find an endpoint
-                    return _build_path(G, successor, endpoints, path)
+                    if len(successors) == 0:
+                        # we are coming to the end of a self-looping edge, so
+                        # add path's first node to end of path to close it,
+                        # then return
+                        return path + [path[0]]
+                    else:
+                        # if len successors > 1, then successor must have been
+                        # an endpoint because you can go in 2 new directions.
+                        # this should never occur in practice
+                        raise Exception("Should never hit this point.")
 
-            # We only enter this else statement if the while loop finishes properly!
-            else:
-                # if this successor is an endpoint, we've completed the path,
-                # so return it
-                return path
-
-    if (path[-1] not in endpoints) and (path[0] in G.successors(path[-1])):
-        # if the end of the path is not actually an endpoint and the path's
-        # first node is a successor of the path's final node, then this is
-        # actually a self loop, so add path's first node to end of path to
-        # close it
-        path.append(path[0])
-
-    return path
+            # if this successor is an endpoint, we've completed the path,
+            # so return it
+            return path
 
 
 def _get_paths_to_simplify(G, strict=True):

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -138,8 +138,8 @@ def _build_path(G, endpoint, endpoint_successor, endpoints):
             # if this successor is an endpoint, we've completed the path
             return path
 
-    # if endpoint_successor has no successors (usually due to a digitization
-    # issue on OSM), return the path
+    # if endpoint_successor has no successors not already in the path, return
+    # the current path. this is usually due to a digitization quirk on OSM.
     return path
 
 

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -138,6 +138,10 @@ def _build_path(G, endpoint, endpoint_successor, endpoints):
             # if this successor is an endpoint, we've completed the path
             return path
 
+    # if endpoint_successor has no successors (usually due to a digitization
+    # issue on OSM), return the path
+    return path
+
 
 def _get_paths_to_simplify(G, strict=True):
     """

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -257,7 +257,7 @@ def simplify_graph(G, strict=True, remove_rings=True):
             # usually happens if OSM has duplicate ways digitized for just one
             # street... we will keep only one of the edges (see below)
             if not G.number_of_edges(u, v) == 1:
-                utils.log(f'Multiple edges between "{u}" and "{v}" found when simplifying')
+                utils.log(f"Found multiple edges between {u} and {v} when simplifying")
 
             # get edge between these nodes: if multiple edges exist between
             # them (see above), we retain only one in the simplified graph

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -205,9 +205,9 @@ def simplify_graph(G, strict=True, rings=False):
         if False, allow nodes to be end points even if they fail all other
         rules but have incident edges with different OSM IDs. Lets you keep
         nodes at elbow two-way intersections, but sometimes individual blocks
-        have multiple OSM IDs within them.
+        have multiple OSM IDs within them too.
     rings : bool
-        if False, remove isolated self-contained rings without endpoints
+        if False, remove isolated self-contained rings without any endpoints
 
     Returns
     -------

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -240,16 +240,13 @@ def simplify_graph(G, strict=True, remove_rings=True):
         for u, v in zip(path[:-1], path[1:]):
 
             # there should rarely be multiple edges between interstitial nodes
-            # e.g., if the nodes are connected by both a bike lane and a street
+            # usually happens if OSM has duplicate ways digitized for just one
+            # street... we will keep only one of the edges (see below)
             if not G.number_of_edges(u, v) == 1:
-                utils.log(
-                    f'Multiple edges between "{u}" and "{v}" found when simplifying',
-                    level=lg.WARNING,
-                )
+                utils.log(f'Multiple edges between "{u}" and "{v}" found when simplifying')
 
-            # the only element in this list as long as above check is True
-            # (MultiGraphs use keys (the 0 here), indexed with ints from 0 and
-            # up)
+            # get edge between these nodes: if multiple edges exist between
+            # them (see above), we retain only one in the simplified graph
             edge = G.edges[u, v, 0]
             for key in edge:
                 if key in edge_attributes:

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -163,20 +163,10 @@ def _get_paths_to_simplify(G, strict=True):
     for node in endpoints:
         for successor in G.successors(node):
             if successor not in endpoints:
-                # if the successor is not an endpoint, build a path from the
-                # endpoint node to the next endpoint node
-                try:
-                    yield _build_path(G, successor, endpoints, path=[node, successor])
-                except RecursionError:
-                    utils.log(
-                        "Exceeded max depth, moving on to next endpoint successor", level=lg.WARNING
-                    )
-                    # recursion errors occur if some connected component is a
-                    # self-contained ring in which all nodes are not end points.
-                    # could also occur in extremely long street segments (eg, in
-                    # rural areas) with too many nodes between true endpoints.
-                    # handle it by just ignoring that component and letting its
-                    # topology remain intact (this should be a rare occurrence)
+                # if endpoint node's successor is not an endpoint, build a path
+                # from the endpoint node, through the successor, and on to the
+                # next endpoint node
+                yield _build_path(G, successor, endpoints, path=[node, successor])
 
 
 def _is_simplified(G):
@@ -244,7 +234,8 @@ def simplify_graph(G, strict=True, rings=False):
         edge_attributes = {}
         for u, v in zip(path[:-1], path[1:]):
 
-            # there shouldn't be multiple edges between interstitial nodes
+            # there should rarely be multiple edges between interstitial nodes
+            # e.g., if the nodes are connected by both a bike lane and a street
             if not G.number_of_edges(u, v) == 1:
                 utils.log(
                     f'Multiple edges between "{u}" and "{v}" found when simplifying',

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -120,7 +120,7 @@ def _build_path(G, node, endpoints, path):
                     successor = successors[0]
                     path.append(successor)
                 else:
-                    if len(successors) == 0:
+                    if len(successors) == 0 and path[0] in G.successors(successor):
                         # we are coming to the end of a self-looping edge, so
                         # add path's first node to end of path to close it,
                         # then return


### PR DESCRIPTION
Enhancement contributed by @pinselimo in #493. Merged into this feature branch for more testing before merging into master. Resolves #488.

This PR:

  - removes recursion from the simplify_graph path building, allowing it to correctly simplify very long road segments (previously, this exceeded the system recursion depth and left such segments unsimplified)
  - reduces memory footprint by using a generator
  - removes disconnected, self-contained rings by default when simplifying graph (and adds parameter `remove_rings` to optionally turn this off)
  - changes "multiple edges found" log warning to info level instead, as this is not uncommon (happens when OSM has duplicate ways digitized for a single street)