### PR TITLE
add shortest path solvers

### DIFF
--- a/osmnx/_api.py
+++ b/osmnx/_api.py
@@ -52,3 +52,5 @@ from .utils import ts
 from .utils_graph import get_undirected
 from .utils_graph import graph_from_gdfs
 from .utils_graph import graph_to_gdfs
+from .utils_graph import k_shortest_paths
+from .utils_graph import shortest_path

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -478,7 +478,7 @@ def plot_figure_ground(
         raise ValueError("You must pass an address or lat-lng point or graph.")
 
     # we need an undirected graph to find every edge incident to a node
-    G_undir = G.to_undirected()
+    G_undir = utils_graph.get_undirected(G)
 
     # for each edge, get a linewidth according to street type
     edge_linewidths = []

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -300,15 +300,14 @@ def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=Fal
     """
     stats = {}
 
-    # create a DiGraph from the MultiDiGraph, for those metrics that require it
-    G_dir = nx.DiGraph(G)
+    # create DiGraph from the MultiDiGraph, for those metrics that need it
+    G_dir = utils_graph.get_digraph(G, weight="length")
 
-    # create an undirected Graph from the MultiDiGraph, for those metrics that
-    # require it
-    G_undir = nx.Graph(G)
+    # create undirected Graph from the DiGraph, for those metrics that need it
+    G_undir = nx.Graph(D)
 
-    # get the largest strongly connected component, for those metrics that
-    # require strongly connected graphs
+    # get largest strongly connected component, for those metrics that require
+    # strongly connected graphs
     G_strong = utils_graph.get_largest_component(G, strongly=True)
 
     # average degree of the neighborhood of each node, and average for the graph
@@ -316,8 +315,7 @@ def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=Fal
     stats["avg_neighbor_degree"] = avg_neighbor_degree
     stats["avg_neighbor_degree_avg"] = sum(avg_neighbor_degree.values()) / len(avg_neighbor_degree)
 
-    # average weighted degree of the neighborhood of each node, and average for
-    # the graph
+    # avg weighted degree of neighborhood of each node, and average for graph
     avg_wtd_nbr_deg = nx.average_neighbor_degree(G, weight="length")
     stats["avg_weighted_neighbor_degree"] = avg_wtd_nbr_deg
     stats["avg_weighted_neighbor_degree_avg"] = sum(avg_wtd_nbr_deg.values()) / len(avg_wtd_nbr_deg)

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -129,7 +129,7 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
     # calculate the total and average street segment lengths (so, edges without
     # double-counting two-way streets)
     if Gu is None:
-        Gu = G.to_undirected(reciprocal=False)
+        Gu = utils_graph.get_undirected(G)
     street_length_total = sum([d["length"] for u, v, d in Gu.edges(data=True)])
     street_segments_count = len(Gu.edges(keys=True))
     street_length_avg = street_length_total / street_segments_count

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -145,6 +145,8 @@ def shortest_path(G, orig, dest, weight='length'):
     """
     Get shortest path from origin node to destination node.
 
+    See also `k_shortest_paths` to get multiple shortest paths.
+
     Parameters
     ----------
     G : networkx.MultiDiGraph
@@ -170,6 +172,8 @@ def k_shortest_paths(G, orig, dest, k, weight='length'):
     """
     Get k shortest paths from origin node to destination node.
 
+    See also `shortest_path` to get just the one shortest path.
+
     Parameters
     ----------
     G : networkx.MultiDiGraph
@@ -187,8 +191,8 @@ def k_shortest_paths(G, orig, dest, k, weight='length'):
     Returns
     -------
     generator
-        a generator of k shortest paths ordered by length. each path is a list
-        of node IDs.
+        a generator of k shortest paths ordered by total weight. each path is
+        a list of node IDs.
     """
     paths_gen = nx.shortest_simple_paths(get_digraph(G, weight), orig, dest, weight)
     for path in itertools.islice(paths_gen, 0, k):

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -593,7 +593,7 @@ def get_undirected(G):
     """
     Convert MultiDiGraph to MultiGraph.
 
-    Maintains parallel edges if their geometries differ. Note: see also
+    Maintains parallel edges only if their geometries differ. Note: see also
     `get_digraph` to convert MultiDiGraph to DiGraph.
 
     Parameters

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -1,7 +1,7 @@
 """Graph utility functions."""
 
-from collections import Counter
 import itertools
+from collections import Counter
 
 import geopandas as gpd
 import networkx as nx
@@ -141,7 +141,7 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
     return G
 
 
-def shortest_path(G, orig, dest, weight='length'):
+def shortest_path(G, orig, dest, weight="length"):
     """
     Get shortest path from origin node to destination node.
 
@@ -168,7 +168,7 @@ def shortest_path(G, orig, dest, weight='length'):
     return path
 
 
-def k_shortest_paths(G, orig, dest, k, weight='length'):
+def k_shortest_paths(G, orig, dest, k, weight="length"):
     """
     Get k shortest paths from origin node to destination node.
 
@@ -318,6 +318,7 @@ def get_route_edge_attributes(
         function called with the edge nodes as parameters to retrieve a
         default value, if the edge does not contain the given attribute
         (otherwise a `KeyError` is raised)
+
     Returns
     -------
     attribute_values : list
@@ -554,7 +555,7 @@ def _update_edge_keys(G):
     return G
 
 
-def get_digraph(G, weight='length'):
+def get_digraph(G, weight="length"):
     """
     Convert MultiDiGraph to DiGraph.
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -1,7 +1,7 @@
 """Graph utility functions."""
 
 from collections import Counter
-from itertools import chain
+import itertools
 
 import geopandas as gpd
 import networkx as nx
@@ -141,6 +141,60 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
     return G
 
 
+def shortest_path(G, orig, dest, weight='length'):
+    """
+    Get shortest path from origin node to destination node.
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+    orig : int
+        origin node ID
+    dest : int
+        destination node ID
+    weight : string
+        edge attribute to minimize when solving shortest path. default is edge
+        length in meters.
+
+    Returns
+    -------
+    path : list
+        list of node IDs consituting the shortest path
+    """
+    path = nx.shortest_path(G, orig, dest, weight=weight)
+    return path
+
+
+def k_shortest_paths(G, orig, dest, k, weight='length'):
+    """
+    Get k shortest paths from origin node to destination node.
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+    orig : int
+        origin node ID
+    dest : int
+        destination node ID
+    k : int
+        number of shortest paths to get
+    weight : string
+        edge attribute to minimize when solving shortest paths. default is
+        edge length in meters.
+
+    Returns
+    -------
+    generator
+        a generator of k shortest paths ordered by length. each path is a list
+        of node IDs.
+    """
+    paths_gen = nx.shortest_simple_paths(get_digraph(G, weight), orig, dest, weight)
+    for path in itertools.islice(paths_gen, 0, k):
+        yield path
+
+
 def induce_subgraph(G, node_subset):
     """
     Induce a subgraph of G.
@@ -249,17 +303,17 @@ def get_route_edge_attributes(
     G : networkx.MultiDiGraph
         input graph
     route : list
-        list of nodes in the path
+        list of nodes IDs constituting the path
     attribute : string
-        the name of the attribute to get the value of for each edge.
-        If not specified, the complete data dict is returned for each edge.
+        the name of the attribute to get the value of for each edge. If None,
+        the complete data dict is returned for each edge.
     minimize_key : string
         if there are parallel edges between two nodes, select the one with the
         lowest value of minimize_key
     retrieve_default : Callable[Tuple[Any, Any], Any]
-        Function called with the edge nodes as parameters to retrieve a
-        default value, if the edge does not contain the given attribute. Per
-        default, a `KeyError` is raised
+        function called with the edge nodes as parameters to retrieve a
+        default value, if the edge does not contain the given attribute
+        (otherwise a `KeyError` is raised)
     Returns
     -------
     attribute_values : list
@@ -334,7 +388,7 @@ def count_streets_per_node(G, nodes=None):
     edges = non_self_loop_edges + self_loop_edges
 
     # flatten the list of (u,v) tuples
-    edges_flat = list(chain.from_iterable(edges))
+    edges_flat = list(itertools.chain.from_iterable(edges))
 
     # count how often each node appears in the list of flattened edge endpoints
     counts = Counter(edges_flat)
@@ -350,14 +404,14 @@ def remove_isolated_nodes(G):
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        graph from which to remove nodes
+        graph from which to remove isolated nodes
 
     Returns
     -------
     G : networkx.MultiDiGraph
         graph with all isolated nodes removed
     """
-    isolated_nodes = [node for node, degree in dict(G.degree()).items() if degree < 1]
+    isolated_nodes = [node for node, degree in G.degree() if degree < 1]
     G.remove_nodes_from(isolated_nodes)
     utils.log(f"Removed {len(isolated_nodes)} isolated nodes")
     return G
@@ -496,11 +550,46 @@ def _update_edge_keys(G):
     return G
 
 
+def get_digraph(G, weight='length'):
+    """
+    Convert MultiDiGraph to DiGraph.
+
+    Chooses between parallel edges by minimizing `weight` attribute value.
+    Note: see also `get_undirected` to convert MultiDiGraph to MultiGraph.
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+    weight : string
+        attribute value to minimize when choosing between parallel edges
+
+    Returns
+    -------
+    networkx.DiGraph
+    """
+    # make a copy to not edit the original graph object the caller passed in
+    G = G.copy()
+    to_remove = []
+
+    # identify all the parallel edges in the MultiDiGraph
+    parallels = ((u, v) for u, v, k in G.edges(keys=True) if k > 0)
+
+    # remove the parallel edge with greater "weight" attribute value
+    for u, v in set(parallels):
+        k, d = max(G.get_edge_data(u, v).items(), key=lambda x: x[1][weight])
+        to_remove.append((u, v, k))
+
+    G.remove_edges_from(to_remove)
+    return nx.DiGraph(G)
+
+
 def get_undirected(G):
     """
     Convert MultiDiGraph to MultiGraph.
 
-    Maintains parallel edges if their geometries differ.
+    Maintains parallel edges if their geometries differ. Note: see also
+    `get_digraph` to convert MultiDiGraph to DiGraph.
 
     Parameters
     ----------
@@ -509,10 +598,12 @@ def get_undirected(G):
 
     Returns
     -------
-    H : networkx.MultiGraph
+    networkx.MultiGraph
     """
-    # set from/to nodes before making graph undirected
+    # make a copy to not edit the original graph object the caller passed in
     G = G.copy()
+
+    # set from/to nodes before making graph undirected
     for u, v, k, data in G.edges(keys=True, data=True):
         G.edges[u, v, k]["from"] = u
         G.edges[u, v, k]["to"] = v

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -134,7 +134,7 @@ def test_graph_from_xml():
     os.remove(temp_filename)
 
 
-def test_routing_folium():
+def test_routing():
 
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 
@@ -152,7 +152,7 @@ def test_routing_folium():
     dest_node = list(G.nodes())[-5]
     orig_pt = (G.nodes[orig_node]["y"], G.nodes[orig_node]["x"])
     dest_pt = (G.nodes[dest_node]["y"], G.nodes[dest_node]["x"])
-    route = nx.shortest_path(G, orig_node, dest_node, weight="travel_time")
+    route = ox.shortest_path(G, orig_node, dest_node, weight="travel_time")
 
     attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")
 
@@ -161,7 +161,8 @@ def test_routing_folium():
     fig, ax = ox.plot_graph_route(G, route, save=True)
 
     # test multiple routes
-    fig, ax = ox.plot_graph_routes(G, [route, route])
+    routes = ox.k_shortest_paths(G, orig_node, dest_node, k=2, weight="travel_time")
+    fig, ax = ox.plot_graph_routes(G, list(routes))
 
     # test folium
     gm = ox.plot_graph_folium(G, popup_attribute="name")


### PR DESCRIPTION
This PR adds two new shortest path solvers:

  - `shortest_path`, essentially a wrapper function around networkx.shortest_path as a convenience
  - `k_shortest_paths`, to return *k* shortest paths between an origin and destination node as a generator

This PR also adds a new helper function `get_digraph` to convert MultiDiGraphs to DiGraphs while choosing between parallel edges by minimizing a weight attribute value.