### PR TITLE
auto-select first multi/polygon when which_result=None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.16.0 (T.B.D.)
 
+  - auto-select first Polygon/MultiPolygon when geocoding with which_result=None
   - new k_shortest_paths function to solve *k* shortest paths from origin to destination
   - new shortest_path convenience function
   - new get_digraph function to correctly convert MultiDiGraph to DiGraph

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -461,7 +461,7 @@ def footprints_from_place(
         if False discard any footprints with an invalid geometry
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        multi/polygon or throw an error if OSM doesn't return one.
+        multi/polygon or raise an error if OSM doesn't return one.
 
     Returns
     -------

--- a/osmnx/footprints.py
+++ b/osmnx/footprints.py
@@ -438,7 +438,9 @@ def footprints_from_address(address, dist=1000, footprint_type="building", retai
     return footprints_from_point(point, dist, footprint_type, retain_invalid)
 
 
-def footprints_from_place(place, footprint_type="building", retain_invalid=False, which_result=1):
+def footprints_from_place(
+    place, footprint_type="building", retain_invalid=False, which_result=None
+):
     """
     Get footprints within the boundaries of some place.
 
@@ -451,14 +453,15 @@ def footprints_from_place(place, footprint_type="building", retain_invalid=False
     Parameters
     ----------
     place : string
-        the query to geocode to get geojson boundary polygon
+        the query to geocode to get place boundary polygon
     footprint_type : string
         type of footprint to be downloaded. OSM tag key e.g. 'building',
         'landuse', 'place', etc.
     retain_invalid : bool
         if False discard any footprints with an invalid geometry
     which_result : int
-        max number of results to return and which to process upon receipt
+        which geocoding result to use. if None, auto-select the first
+        multi/polygon or throw an error if OSM doesn't return one.
 
     Returns
     -------

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -44,28 +44,29 @@ def geocode(query):
         raise Exception(f'Nominatim geocoder returned no results for query "{query}"')
 
 
-def geocode_to_gdf(query, which_result=1, buffer_dist=None):
+def geocode_to_gdf(query, which_result=None, buffer_dist=None):
     """
     Geocode a query or queries to a GeoDataFrame with the Nominatim geocoder.
 
     Geometry column contains place boundaries if they exist in OpenStreetMap.
     Query can be a string or dict, or a list of strings/dicts to send to the
-    geocoder. If query is a list, then which_result should be a list of the
-    same length.
+    geocoder. If query is a list, then which_result should be a scalar or a
+    list of the same length.
 
     Parameters
     ----------
-    query : string or dict or list
-        query string or structured dict to geocode/download
-    which_result : int or list
-        max number of results to return and which to process upon receipt; if
-        passing a list then it must be same length as query list
+    query : string or dict
+        query string or structured dict to geocode
+    which_result : int
+        which geocoding result to use. if None, auto-select the first
+        multi/polygon or throw an error if OSM doesn't return one.
     buffer_dist : float
         distance to buffer around the place geometry, in meters
 
     Returns
     -------
     gdf : geopandas.GeoDataFrame
+        a GeoDataFrame with one row for each query
     """
     if not isinstance(query, (str, dict, list)):
         raise ValueError("query must be a string or dict or list")
@@ -111,51 +112,94 @@ def geocode_to_gdf(query, which_result=1, buffer_dist=None):
     return gdf
 
 
-def _geocode_query_to_gdf(query, which_result=1):
+def _geocode_query_to_gdf(query, which_result):
     """
     Geocode a single place query to a GeoDataFrame.
 
     Parameters
     ----------
     query : string or dict
-        query string or structured dict to geocode/download
+        query string or structured dict to geocode
     which_result : int
-        max number of results to return and which to process upon receipt
+        which geocoding result to use. if None, auto-select the first
+        multi/polygon or throw an error if OSM doesn't return one.
 
     Returns
     -------
     gdf : geopandas.GeoDataFrame
+        a GeoDataFrame with one row containing the result of the geocoder
     """
-    data = downloader._osm_polygon_download(query, limit=which_result)
-
-    if len(data) >= which_result:
-        # extract data elements from the JSON response
-        result = data[which_result - 1]
-        bbox_south, bbox_north, bbox_west, bbox_east = [float(x) for x in result["boundingbox"]]
-        geometry = result["geojson"]
-        place = result["display_name"]
-        features = [
-            {
-                "type": "Feature",
-                "geometry": geometry,
-                "properties": {
-                    "place_name": place,
-                    "bbox_north": bbox_north,
-                    "bbox_south": bbox_south,
-                    "bbox_east": bbox_east,
-                    "bbox_west": bbox_west,
-                },
-            }
-        ]
-
-        # if we got an unexpected geometry type (like a point), log a warning
-        if geometry["type"] not in {"Polygon", "MultiPolygon"}:
-            utils.log(f'OSM returned a {geometry["type"]} as the geometry', level=lg.WARNING)
-
-        # create the GeoDataFrame
-        return gpd.GeoDataFrame.from_features(features)
+    if which_result is None:
+        limit = 50
     else:
-        # if no data returned (or fewer results than which_result)
-        msg = f'OSM returned no results (or fewer than which_result) for query "{query}"'
+        limit = which_result
+
+    results = downloader._osm_polygon_download(query, limit=limit)
+
+    # choose the right result from the JSON response
+    if len(results) == 0:
+        # if no results were returned, raise error
+        raise ValueError(f'OSM returned no results for query "{query}"')
+
+    elif which_result is None:
+        # else, if which_result=None, auto-select the first multi/polygon
+        result = _get_first_polygon(results, query)
+
+    elif len(results) >= which_result:
+        # else, if we got at least which_result results, choose that one
+        result = results[which_result - 1]
+
+    else:
+        # else, we got fewer results than which_result, raise error
+        msg = f'OSM returned fewer than `which_result={which_result}` results for query "{query}"'
+        raise ValueError(msg)
+
+    # build the geojson features from the chosen result
+    south, north, west, east = [float(x) for x in result["boundingbox"]]
+    place = result["display_name"]
+    geometry = result["geojson"]
+    features = [
+        {
+            "type": "Feature",
+            "geometry": geometry,
+            "properties": {
+                "place_name": place,
+                "bbox_north": north,
+                "bbox_south": south,
+                "bbox_east": east,
+                "bbox_west": west,
+            },
+        }
+    ]
+
+    # if we got a non multi/polygon geometry type (like a point), log warning
+    if geometry["type"] not in {"Polygon", "MultiPolygon"}:
+        msg = f'OSM returned a {geometry["type"]} as the geometry for query "{query}"'
         utils.log(msg, level=lg.WARNING)
-        return gpd.GeoDataFrame()
+
+    # create the GeoDataFrame
+    return gpd.GeoDataFrame.from_features(features)
+
+
+def _get_first_polygon(results, query):
+    """
+    Choose first result of geometry type multi/polygon in list of results.
+
+    Parameters
+    ----------
+    results : list
+        list of results from downloader._osm_polygon_download
+    query : str
+        the query string or structured dict that was geocoded
+
+    Returns
+    -------
+    result : dict
+        the chosen result
+    """
+    for result in results:
+        if result["geojson"]["type"] in {"Polygon", "MultiPolygon"}:
+            return result
+
+    # if we never found a polygon, throw an error
+    raise ValueError(f'OSM did not return any polygonal geometries for query "{query}"')

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -50,8 +50,8 @@ def geocode_to_gdf(query, which_result=None, buffer_dist=None):
 
     Geometry column contains place boundaries if they exist in OpenStreetMap.
     Query can be a string or dict, or a list of strings/dicts to send to the
-    geocoder. If query is a list, then which_result should be a scalar or a
-    list of the same length.
+    geocoder. If query is a list, then which_result should be either a single
+    value or a list of the same length as query.
 
     Parameters
     ----------

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -55,11 +55,11 @@ def geocode_to_gdf(query, which_result=None, buffer_dist=None):
 
     Parameters
     ----------
-    query : string or dict
-        query string or structured dict to geocode
+    query : string or dict or list
+        query string(s) or structured dict(s) to geocode
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        multi/polygon or throw an error if OSM doesn't return one.
+        multi/polygon or raise an error if OSM doesn't return one.
     buffer_dist : float
         distance to buffer around the place geometry, in meters
 
@@ -122,12 +122,12 @@ def _geocode_query_to_gdf(query, which_result):
         query string or structured dict to geocode
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        multi/polygon or throw an error if OSM doesn't return one.
+        multi/polygon or raise an error if OSM doesn't return one.
 
     Returns
     -------
     gdf : geopandas.GeoDataFrame
-        a GeoDataFrame with one row containing the result of the geocoder
+        a GeoDataFrame with one row containing the result of geocoding
     """
     if which_result is None:
         limit = 50
@@ -154,7 +154,7 @@ def _geocode_query_to_gdf(query, which_result):
         msg = f'OSM returned fewer than `which_result={which_result}` results for query "{query}"'
         raise ValueError(msg)
 
-    # build the geojson features from the chosen result
+    # build the geojson feature from the chosen result
     south, north, west, east = [float(x) for x in result["boundingbox"]]
     place = result["display_name"]
     geometry = result["geojson"]
@@ -177,13 +177,13 @@ def _geocode_query_to_gdf(query, which_result):
         msg = f'OSM returned a {geometry["type"]} as the geometry for query "{query}"'
         utils.log(msg, level=lg.WARNING)
 
-    # create the GeoDataFrame
+    # create and return the GeoDataFrame
     return gpd.GeoDataFrame.from_features(features)
 
 
 def _get_first_polygon(results, query):
     """
-    Choose first result of geometry type multi/polygon in list of results.
+    Choose first result with geometry type multi/polygon from list of results.
 
     Parameters
     ----------

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -54,7 +54,8 @@ def graph_from_bbox(
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True, retain node if it's outside bounding box but at least one of
         node's neighbors are within the bounding box
@@ -125,7 +126,8 @@ def graph_from_point(
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True, retain node if it's outside bounding box but at least one of
         node's neighbors are within bounding box
@@ -213,7 +215,8 @@ def graph_from_address(
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True, retain node if it's outside bounding box but at least one of
         node's neighbors are within bounding box
@@ -266,7 +269,7 @@ def graph_from_place(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    which_result=1,
+    which_result=None,
     buffer_dist=None,
     clean_periphery=True,
     custom_filter=None,
@@ -282,24 +285,27 @@ def graph_from_place(
     parameter to use a different geocode result. For example, the first geocode
     result (ie, the default) might resolve to a point geometry, but the second
     geocode result for this query might resolve to a polygon, in which case you
-    can use graph_from_place with which_result=2.
+    can use graph_from_place with which_result=2. which_result=None will
+    auto-select the first multi/polygon among the geocoding results.
 
     Parameters
     ----------
     query : string or dict or list
-        the place(s) to geocode/download data for
+        the query or queries to geocode to get place boundary polygon(s)
     network_type : string
         what type of street network to get if custom_filter is None. One of
         'walk', 'bike', 'drive', 'drive_service', 'all', or 'all_private'.
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True, retain node if it's outside polygon but at least one of
-        node's neighbors are within bbox
+        node's neighbors are within polygon
     which_result : int
-        max number of results to return and which to process upon receipt
+        which geocoding result to use. if None, auto-select the first
+        multi/polygon or throw an error if OSM doesn't return one.
     buffer_dist : float
         distance to buffer around the place geometry, in meters
     clean_periphery : bool
@@ -375,7 +381,8 @@ def graph_from_polygon(
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True, retain node if it's outside polygon but at least one of
         node's neighbors are within polygon
@@ -493,7 +500,8 @@ def graph_from_xml(filepath, bidirectional=False, simplify=True, retain_all=Fals
     simplify : bool
         if True, simplify the graph topology
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
 
     Returns
     -------
@@ -551,7 +559,8 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     response_jsons : list
         list of dicts of JSON responses from from the Overpass API
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     bidirectional : bool
         if True, create bidirectional edges for one-way streets
 

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -170,9 +170,8 @@ def graph_from_point(
         custom_filter=custom_filter,
     )
 
-    # if the network dist_type is network, find the node in the graph
-    # nearest to the center point, and truncate the graph by network distance
-    # from this node
+    # if network dist_type is network, find the node in the graph nearest to
+    # the center point, and truncate the graph by network distance from node
     if dist_type == "network":
         centermost_node = distance.get_nearest_node(G, center_point)
         G = truncate.truncate_graph_dist(G, centermost_node, max_dist=dist)
@@ -411,9 +410,9 @@ def graph_from_polygon(
     if not isinstance(polygon, (Polygon, MultiPolygon)):
         raise TypeError(
             "Geometry must be a shapely Polygon or MultiPolygon. If you requested "
-            "graph from place name or address, make sure your query resolves to a "
-            "Polygon or MultiPolygon, and not some other geometry, like a Point. "
-            "See OSMnx documentation for details."
+            "graph from place name, make sure your query resolves to a Polygon or "
+            "MultiPolygon, and not some other geometry, like a Point. See OSMnx "
+            "documentation for details."
         )
 
     if clean_periphery:
@@ -425,21 +424,16 @@ def graph_from_polygon(
 
         # download the network data from OSM within buffered polygon
         response_jsons = downloader._osm_net_download(poly_buff, network_type, custom_filter)
+        bidirectional = network_type in settings.bidirectional_network_types
 
         # create buffered graph from the downloaded data
-        G_buff = _create_graph(
-            response_jsons,
-            retain_all=True,
-            bidirectional=network_type in settings.bidirectional_network_types,
-        )
+        G_buff = _create_graph(response_jsons, retain_all=True, bidirectional=bidirectional)
 
         # truncate buffered graph to the buffered polygon and retain_all for
         # now. needed because overpass returns entire ways that also include
         # nodes outside the poly if the way (that is, a way with a single OSM
         # ID) has a node inside the poly at some point.
-        G_buff = truncate.truncate_graph_polygon(
-            G_buff, poly_buff, retain_all=True, truncate_by_edge=truncate_by_edge
-        )
+        G_buff = truncate.truncate_graph_polygon(G_buff, poly_buff, True, truncate_by_edge)
 
         # simplify the graph topology
         if simplify:
@@ -450,9 +444,7 @@ def graph_from_polygon(
         # intersections along the street that may now only connect 2 street
         # segments in the network, but in reality also connect to an
         # intersection just outside the polygon
-        G = truncate.truncate_graph_polygon(
-            G_buff, polygon, retain_all=retain_all, truncate_by_edge=truncate_by_edge
-        )
+        G = truncate.truncate_graph_polygon(G_buff, polygon, retain_all, truncate_by_edge)
 
         # count how many street segments in buffered graph emanate from each
         # intersection in un-buffered graph, to retain true counts for each
@@ -463,23 +455,17 @@ def graph_from_polygon(
     else:
         # download the network data from OSM
         response_jsons = downloader._osm_net_download(polygon, network_type, custom_filter)
+        bidirectional = network_type in settings.bidirectional_network_types
 
         # create graph from the downloaded data
-        G = _create_graph(
-            response_jsons,
-            retain_all=True,
-            bidirectional=network_type in settings.bidirectional_network_types,
-        )
+        G = _create_graph(response_jsons, retain_all=True, bidirectional=bidirectional)
 
         # truncate the graph to the extent of the polygon
-        G = truncate.truncate_graph_polygon(
-            G, polygon, retain_all=retain_all, truncate_by_edge=truncate_by_edge
-        )
+        G = truncate.truncate_graph_polygon(G, polygon, retain_all, truncate_by_edge)
 
         # simplify the graph topology as the last step. don't truncate after
         # simplifying or you may have simplified out to an endpoint beyond the
-        # truncation distance, in which case you will then strip out your entire
-        # edge
+        # truncation distance, which would strip out the entire edge
         if simplify:
             G = simplification.simplify_graph(G)
 
@@ -513,7 +499,7 @@ def graph_from_xml(filepath, bidirectional=False, simplify=True, retain_all=Fals
     # create graph using this response JSON
     G = _create_graph(response_jsons, bidirectional=bidirectional, retain_all=retain_all)
 
-    # simplify the graph topology as the last step.
+    # simplify the graph topology as the last step
     if simplify:
         G = simplification.simplify_graph(G)
 
@@ -538,10 +524,9 @@ def _overpass_json_from_file(filepath):
     def _opener(filepath):
         _, ext = os.path.splitext(filepath)
         if ext == ".bz2":
-            # Use Python 2/3 compatible BZ2File()
             return bz2.BZ2File(filepath)
         else:
-            # Assume an unrecognized file extension is just XML
+            # assume an unrecognized file extension is just XML
             return open(filepath, mode="rb")
 
     with _opener(filepath) as file:
@@ -599,15 +584,13 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     # add each osm way (ie, a path of edges) to the graph
     G = _add_paths(G, paths, bidirectional=bidirectional)
 
-    # retain only the largest connected component, if caller did not
-    # set retain_all=True
+    # retain only the largest connected component, if retain_all is not True
     if not retain_all:
         G = utils_graph.get_largest_component(G)
 
     utils.log(f"Created graph with {len(G)} nodes and {len(G.edges())} edges")
 
-    # add length (great circle distance between nodes) attribute to each edge to
-    # use as weight
+    # add length (great circle distance between nodes) attribute to each edge
     if len(G.edges) > 0:
         G = utils_graph.add_edge_lengths(G)
 
@@ -704,7 +687,7 @@ def _add_path(G, data, one_way):
     data : dict
         the attributes of the path
     one_way : bool
-        if this path is one-way or if it is bi-directional
+        if this path is one-way or if it is bidirectional
 
     Returns
     -------
@@ -722,15 +705,13 @@ def _add_path(G, data, one_way):
     if not settings.all_oneway:
         data["oneway"] = one_way
 
-    # zip together the path nodes so you get tuples like (0,1), (1,2), (2,3)
-    # and so on
+    # zip together the path nodes so you get tuples like [(0,1), (1,2), (2,3)]
     path_edges = list(zip(path_nodes[:-1], path_nodes[1:]))
     G.add_edges_from(path_edges, **data)
 
-    # if the path is NOT one-way
     if not one_way:
-        # reverse the direction of each edge and add this path going the
-        # opposite direction
+        # if the path is NOT one-way, reverse the direction of each edge and
+        # add this path going the opposite direction
         path_edges_opposite_direction = [(v, u) for u, v in path_edges]
         G.add_edges_from(path_edges_opposite_direction, **data)
 
@@ -754,33 +735,35 @@ def _add_paths(G, paths, bidirectional=False):
     """
     # the list of values OSM uses in its 'oneway' tag to denote True
     # https://www.geofabrik.de/de/data/geofabrik-osm-gis-standard-0.7.pdf
-    osm_oneway_values = ["yes", "true", "1", "-1", "T", "F"]
+    osm_oneway_values = {"yes", "true", "1", "-1", "T", "F"}
 
     for data in paths.values():
 
         if settings.all_oneway is True:
+            # see all_oneway comments in settings.py
             _add_path(G, data, one_way=True)
-        # if this path is tagged as one-way and if it is not a walking network,
-        # then we'll add the path in one direction only
+
         elif ("oneway" in data and data["oneway"] in osm_oneway_values) and not bidirectional:
+            # if this path is tagged as one-way and if it is not a walking
+            # network, then we'll add the path in one direction only
             if data["oneway"] == "-1" or data["oneway"] == "T":
-                # paths with a one-way value of -1 or T are one-way, but in the
-                # reverse direction of the nodes' order, see osm documentation
+                # paths with a one-way value of -1 or T are one-way, but in
+                # the reverse direction of nodes' order, see OSM documentation
                 data["nodes"] = list(reversed(data["nodes"]))
             # add this path (in only one direction) to the graph
             _add_path(G, data, one_way=True)
 
         elif ("junction" in data and data["junction"] == "roundabout") and not bidirectional:
-            # roundabout are also oneway but not tagged as is
+            # roundabouts are also oneway but not explicitly tagged as such
             _add_path(G, data, one_way=True)
 
-        # else, this path is not tagged as one-way or it is a walking network
-        # (you can walk both directions on a one-way street)
         else:
-            # add this path (in both directions) to the graph and set its
-            # 'oneway' attribute to False. if this is a walking network, this
-            # may very well be a one-way street (as cars/bikes go), but in a
-            # walking-only network it is a bi-directional edge
+            # else, this path is not tagged as one-way or it is a walking
+            # network (you can walk both directions on a one-way street). add
+            # this path (in both directions) to the graph and set its 'oneway'
+            # attribute to False. if this is a walking network, this may very
+            # well be a one-way street (as cars/bikes go), but in a walking-
+            # only network it is a bidirectional edge
             _add_path(G, data, one_way=False)
 
     return G

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -55,10 +55,10 @@ def graph_from_bbox(
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True, retain node if it's outside bounding box but at least one of
-        node's neighbors are within the bounding box
+        if True, retain nodes outside bounding box if at least one of node's
+        neighbors is within the bounding box
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
@@ -127,10 +127,10 @@ def graph_from_point(
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True, retain node if it's outside bounding box but at least one of
-        node's neighbors are within bounding box
+        if True, retain nodes outside bounding box if at least one of node's
+        neighbors is within the bounding box
     clean_periphery : bool,
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
@@ -216,10 +216,10 @@ def graph_from_address(
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True, retain node if it's outside bounding box but at least one of
-        node's neighbors are within bounding box
+        if True, retain nodes outside bounding box if at least one of node's
+        neighbors is within the bounding box
     return_coords : bool
         optionally also return the geocoded coordinates of the address
     clean_periphery : bool,
@@ -299,13 +299,13 @@ def graph_from_place(
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True, retain node if it's outside polygon but at least one of
-        node's neighbors are within polygon
+        if True, retain nodes outside boundary polygon if at least one of
+        node's neighbors is within the polygon
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        multi/polygon or throw an error if OSM doesn't return one.
+        multi/polygon or raise an error if OSM doesn't return one.
     buffer_dist : float
         distance to buffer around the place geometry, in meters
     clean_periphery : bool
@@ -382,10 +382,10 @@ def graph_from_polygon(
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True, retain node if it's outside polygon but at least one of
-        node's neighbors are within polygon
+        if True, retain nodes outside boundary polygon if at least one of
+        node's neighbors is within the polygon
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
@@ -501,7 +501,7 @@ def graph_from_xml(filepath, bidirectional=False, simplify=True, retain_all=Fals
         if True, simplify the graph topology
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
 
     Returns
     -------
@@ -560,7 +560,7 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
         list of dicts of JSON responses from from the Overpass API
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     bidirectional : bool
         if True, create bidirectional edges for one-way streets
 

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -470,7 +470,7 @@ def pois_from_place(place, tags, which_result=None):
         landuse=commercial, and highway=bus_stop.
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        multi/polygon or throw an error if OSM doesn't return one.
+        multi/polygon or raise an error if OSM doesn't return one.
 
     Returns
     -------

--- a/osmnx/pois.py
+++ b/osmnx/pois.py
@@ -449,14 +449,14 @@ def pois_from_address(address, tags, dist=1000):
     return pois_from_point(point=point, tags=tags, dist=dist)
 
 
-def pois_from_place(place, tags, which_result=1):
+def pois_from_place(place, tags, which_result=None):
     """
     Get points of interest (POIs) within the boundaries of some place.
 
     Parameters
     ----------
     place : string
-        the query to geocode to get boundary polygon
+        the query to geocode to get place boundary polygon
     tags : dict
         Dict of tags used for finding POIs from the selected area. Results
         returned are the union, not intersection of each individual tag.
@@ -469,7 +469,8 @@ def pois_from_place(place, tags, which_result=1):
         'highway':'bus_stop'}` would return all amenities, landuse=retail,
         landuse=commercial, and highway=bus_stop.
     which_result : int
-        max number of geocoding results to return and which to process
+        which geocoding result to use. if None, auto-select the first
+        multi/polygon or throw an error if OSM doesn't return one.
 
     Returns
     -------

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -28,7 +28,8 @@ def truncate_graph_dist(G, source_node, max_dist=1000, weight="length", retain_a
         how to weight the graph when measuring distance (default 'length' is
         how many meters long the edge is)
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
 
     Returns
     -------
@@ -84,7 +85,8 @@ def truncate_graph_bbox(
         if True retain node if it's outside bbox but at least one of node's
         neighbors are within bbox
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     quadrat_width : numeric
         passed on to intersect_index_quadrats: the linear length (in degrees) of
         the quadrats with which to cut up the geometry (default = 0.05, approx
@@ -127,7 +129,8 @@ def truncate_graph_polygon(
     polygon : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
         only retain nodes in graph that lie within this geometry
     retain_all : bool
-        if True, return the entire graph even if it is not connected
+        if True, return the entire graph even if it is not connected.
+        otherwise, retain only the largest connected component.
     truncate_by_edge : bool
         if True retain node if it's outside polygon but at least one of node's
         neighbors are within polygon

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -29,7 +29,7 @@ def truncate_graph_dist(G, source_node, max_dist=1000, weight="length", retain_a
         how many meters long the edge is)
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
 
     Returns
     -------
@@ -82,11 +82,11 @@ def truncate_graph_bbox(
     west : float
         western longitude of bounding box
     truncate_by_edge : bool
-        if True retain node if it's outside bbox but at least one of node's
-        neighbors are within bbox
+        if True, retain nodes outside bounding box if at least one of node's
+        neighbors is within the bounding box
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     quadrat_width : numeric
         passed on to intersect_index_quadrats: the linear length (in degrees) of
         the quadrats with which to cut up the geometry (default = 0.05, approx
@@ -130,14 +130,14 @@ def truncate_graph_polygon(
         only retain nodes in graph that lie within this geometry
     retain_all : bool
         if True, return the entire graph even if it is not connected.
-        otherwise, retain only the largest connected component.
+        otherwise, retain only the largest weakly connected component.
     truncate_by_edge : bool
-        if True retain node if it's outside polygon but at least one of node's
-        neighbors are within polygon
+        if True, retain nodes outside boundary polygon if at least one of
+        node's neighbors is within the polygon
     quadrat_width : numeric
-        passed on to intersect_index_quadrats: the linear length (in degrees) of
-        the quadrats with which to cut up the geometry (default = 0.05, approx
-        4km at NYC's latitude)
+        passed on to intersect_index_quadrats: the linear length (in degrees)
+        of the quadrats with which to cut up the geometry (default = 0.05,
+        approx 4km at NYC's latitude)
     min_num : int
         passed on to intersect_index_quadrats: the minimum number of linear
         quadrat lines (e.g., min_num=3 would produce a quadrat grid of 4

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -36,13 +36,14 @@ def truncate_graph_dist(G, source_node, max_dist=1000, weight="length", retain_a
     G : networkx.MultiDiGraph
         the truncated graph
     """
+    # get the shortest distance between the node and every other node
+    distances = nx.shortest_path_length(G, source=source_node, weight=weight)
+
+    # then identify every node further than max_dist away
+    distant_nodes = {k: v for k, v in distances.items() if v > max_dist}
+
     # make a copy to not edit the original graph object the caller passed in
     G = G.copy()
-
-    # get the shortest distance between the node and every other node, then
-    # remove every node further than max_dist away
-    distances = nx.shortest_path_length(G, source=source_node, weight=weight)
-    distant_nodes = {k: v for k, v in distances.items() if v > max_dist}
     G.remove_nodes_from(distant_nodes)
 
     # remove any isolated nodes and retain only the largest component (if
@@ -148,8 +149,6 @@ def truncate_graph_polygon(
     G : networkx.MultiDiGraph
         the truncated graph
     """
-    # make a copy to not edit the original graph object the caller passed in
-    G = G.copy()
     utils.log("Identifying all nodes that lie outside the polygon...")
 
     # identify all the nodes that lie outside the polygon
@@ -170,6 +169,8 @@ def truncate_graph_polygon(
         nodes_to_remove = nodes_outside_geom
 
     # now remove from the graph all those nodes that lie outside the polygon
+    # make a copy to not edit the original graph object the caller passed in
+    G = G.copy()
     G.remove_nodes_from(nodes_to_remove)
     utils.log(f"Removed {len(nodes_to_remove)} nodes outside polygon")
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -107,7 +107,7 @@ def test_geometry_coords_rounding():
 
 def test_geocode_to_gdf():
     # test loading spatial boundaries and plotting
-    city = ox.geocode_to_gdf(place1, buffer_dist=100)
+    city = ox.geocode_to_gdf(place1, which_result=1, buffer_dist=100)
     city_projected = ox.project_gdf(city, to_crs="epsg:3395")
 
 


### PR DESCRIPTION
This PR adds new functionality to auto-select the first multi/polygon when `which_result=None` while geocoding. This affects the `geocode_to_gdf` function and all the `*_from_place` functions which use it. If `which_result` equals an int, the functionality remains the same as before. This PR sets `which_result=None` by default for all functions that take a `which_result` argument.

Resolves #320.