### PR TITLE
Proposed fix for TopologyException intersecting invalid geometries with the query polygon

### DIFF
--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -860,7 +860,7 @@ def _buffer_invalid_geometries(GDF):
     if not GDF.empty:
 
         # create a filter for rows with invalid geometries
-        invalid_geometry_filter = ~GDF['geometry'].is_valid
+        invalid_geometry_filter = ~GDF["geometry"].is_valid
 
         # if there are invalid geometries
         if sum(invalid_geometry_filter) > 0:
@@ -873,7 +873,8 @@ def _buffer_invalid_geometries(GDF):
                 "Some invalid geometries were created and included in the GeoDataFrame. "
                 "A buffer of 0 has been applied to try to make them valid "
                 f"and their unique ids have been logged. {invalid_geometry_ids}",
-                stacklevel=2)
+                stacklevel=2,
+            )
 
             # create a list of their urls and log them
             osm_url = "https://www.openstreetmap.org/"
@@ -881,7 +882,9 @@ def _buffer_invalid_geometries(GDF):
             utils.log(f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}")
 
             # apply .buffer(0)
-            GDF.loc[invalid_geometry_filter, 'geometry'] = GDF.loc[invalid_geometry_filter, 'geometry'].buffer(0)
+            GDF.loc[invalid_geometry_filter, "geometry"] = GDF.loc[
+                invalid_geometry_filter, "geometry"
+            ].buffer(0)
 
     return GDF
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -50,7 +50,7 @@ def gdf_from_bbox(north, south, east, west, tags):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
 
     Notes
     -----
@@ -61,10 +61,10 @@ def gdf_from_bbox(north, south, east, west, tags):
     polygon = utils_geo.bbox_to_poly(north, south, east, west)
 
     # create geodataframe of geometries within this polygon
-    GDF = gdf_from_polygon(polygon, tags)
+    gdf = gdf_from_polygon(polygon, tags)
 
-    utils.log(f"gdf_from_bbox returned a geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_bbox returned a geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def gdf_from_point(center_point, tags, dist=1000):
@@ -91,7 +91,7 @@ def gdf_from_point(center_point, tags, dist=1000):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
 
     Notes
     -----
@@ -106,10 +106,10 @@ def gdf_from_point(center_point, tags, dist=1000):
     polygon = utils_geo.bbox_to_poly(north, south, east, west)
 
     # create geodataframe of geometries within this polygon
-    GDF = gdf_from_polygon(polygon, tags)
+    gdf = gdf_from_polygon(polygon, tags)
 
-    utils.log(f"gdf_from_point returned a geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_point returned a geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def gdf_from_address(address, tags, dist=1000):
@@ -137,7 +137,7 @@ def gdf_from_address(address, tags, dist=1000):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
 
     Notes
     -----
@@ -148,10 +148,10 @@ def gdf_from_address(address, tags, dist=1000):
     center_point = geocoder.geocode(query=address)
 
     # create geodataframe of geometries around this point
-    GDF = gdf_from_point(center_point, tags, dist=dist)
+    gdf = gdf_from_point(center_point, tags, dist=dist)
 
-    utils.log(f"gdf_from_address returned a geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_address returned a geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def gdf_from_place(query, tags, which_result=None, buffer_dist=None):
@@ -181,7 +181,7 @@ def gdf_from_place(query, tags, which_result=None, buffer_dist=None):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
 
     Notes
     -----
@@ -206,10 +206,10 @@ def gdf_from_place(query, tags, which_result=None, buffer_dist=None):
     utils.log("Constructed place geometry polygon(s) to query API")
 
     # create geodataframe using this polygon(s) geometry
-    GDF = gdf_from_polygon(polygon, tags)
+    gdf = gdf_from_polygon(polygon, tags)
 
-    utils.log(f"gdf_from_place returned geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_place returned geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def gdf_from_polygon(polygon, tags):
@@ -234,7 +234,7 @@ def gdf_from_polygon(polygon, tags):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
 
     Notes
     -----
@@ -257,10 +257,10 @@ def gdf_from_polygon(polygon, tags):
     response_jsons = downloader._osm_geometry_download(polygon, tags)
 
     # create geodataframe from the downloaded data
-    GDF = _create_gdf(response_jsons, polygon, tags)
+    gdf = _create_gdf(response_jsons, polygon, tags)
 
-    utils.log(f"gdf_from_polygon returned geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_polygon returned geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def gdf_from_xml(filepath, polygon=None, tags=None):
@@ -294,16 +294,16 @@ def gdf_from_xml(filepath, polygon=None, tags=None):
 
     Returns
     -------
-    GDF : geopandas.GeoDataFrame
+    gdf : geopandas.GeoDataFrame
     """
     # transmogrify file of OSM XML data into JSON
     response_jsons = [downloader._overpass_json_from_file(filepath)]
 
     # create geodataframe using this response JSON
-    GDF = _create_gdf(response_jsons, polygon=polygon, tags=tags)
+    gdf = _create_gdf(response_jsons, polygon=polygon, tags=tags)
 
-    utils.log(f"gdf_from_xml returned a geodataframe with {len(GDF)} geometries")
-    return GDF
+    utils.log(f"gdf_from_xml returned a geodataframe with {len(gdf)} geometries")
+    return gdf
 
 
 def _create_gdf(response_jsons, polygon, tags):
@@ -398,29 +398,29 @@ def _create_gdf(response_jsons, polygon, tags):
         geometries.pop(untagged_element_id, None)
 
     # Create GeoDataFrame
-    GDF = gpd.GeoDataFrame.from_dict(geometries, orient="index")
+    gdf = gpd.GeoDataFrame.from_dict(geometries, orient="index")
 
-    # ensure GDF has a geometry col before assigning crs
-    if "geometry" not in GDF.columns:
+    # ensure gdf has a geometry col before assigning crs
+    if "geometry" not in gdf.columns:
         # if there is no geometry column, create a null column
-        GDF["geometry"] = np.nan
-    GDF.set_geometry("geometry")
+        gdf["geometry"] = np.nan
+    gdf.set_geometry("geometry")
 
     # Set default crs
-    GDF.crs = settings.default_crs
+    gdf.crs = settings.default_crs
 
     # Apply .buffer(0) to any invalid geometries
-    GDF = _buffer_invalid_geometries(GDF)
+    gdf = _buffer_invalid_geometries(gdf)
 
     # Filter final gdf to requested tags and bounding polygon
-    GDF = _filter_gdf_by_polygon_and_tags(GDF, polygon=polygon, tags=tags)
+    gdf = _filter_gdf_by_polygon_and_tags(gdf, polygon=polygon, tags=tags)
 
     # bug in geopandas <=0.8.1 raises a TypeError if trying to plot empty geometries
     # but missing geometries (gdf['geometry'] = None) cannot be projected e.g. gdf.to_crs()
     # don't see any option other than to drop rows with missing/empty geometries
-    GDF = GDF[~(GDF["geometry"].isna() | GDF["geometry"].is_empty)].copy()
+    gdf = gdf[~(gdf["geometry"].isna() | gdf["geometry"].is_empty)].copy()
 
-    return GDF
+    return gdf
 
 
 def _parse_node_to_coord(element):
@@ -833,7 +833,7 @@ def _subtract_inner_polygons_from_outer_polygons(element, outer_polygons, inner_
     return geometry
 
 
-def _buffer_invalid_geometries(GDF):
+def _buffer_invalid_geometries(gdf):
     """
     Buffer any invalid geometries remaining in the GeoDataFrame.
 
@@ -848,25 +848,25 @@ def _buffer_invalid_geometries(GDF):
 
     Parameters
     ----------
-    GDF : GeoDataFrame
+    gdf : GeoDataFrame
         the GeoDataFrame with potential invalid geometries
 
     Returns
     -------
-    GDF : GeoDataFrame
+    gdf : GeoDataFrame
         the GeoDataFrame with .buffer(0) applied to invalid geometries
     """
     # only apply the filters if the GeoDataFrame is not empty
-    if not GDF.empty:
+    if not gdf.empty:
 
         # create a filter for rows with invalid geometries
-        invalid_geometry_filter = ~GDF["geometry"].is_valid
+        invalid_geometry_filter = ~gdf["geometry"].is_valid
 
         # if there are invalid geometries
         if sum(invalid_geometry_filter) > 0:
 
             # get their unique_ids from the index
-            invalid_geometry_ids = GDF.loc[invalid_geometry_filter].index.to_list()
+            invalid_geometry_ids = gdf.loc[invalid_geometry_filter].index.to_list()
 
             # show a warning
             warnings.warn(
@@ -882,14 +882,14 @@ def _buffer_invalid_geometries(GDF):
             utils.log(f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}")
 
             # apply .buffer(0)
-            GDF.loc[invalid_geometry_filter, "geometry"] = GDF.loc[
+            gdf.loc[invalid_geometry_filter, "geometry"] = gdf.loc[
                 invalid_geometry_filter, "geometry"
             ].buffer(0)
 
-    return GDF
+    return gdf
 
 
-def _filter_gdf_by_polygon_and_tags(GDF, polygon, tags):
+def _filter_gdf_by_polygon_and_tags(gdf, polygon, tags):
     """
     Filter the GeoDataFrame to the requested bounding polygon and tags.
 
@@ -900,7 +900,7 @@ def _filter_gdf_by_polygon_and_tags(GDF, polygon, tags):
 
     Parameters
     ----------
-    GDF : GeoDataFrame
+    gdf : GeoDataFrame
         the GeoDataFrame to filter
     polygon : Polygon
         Shapely polygon defining the boundary of the requested area
@@ -909,23 +909,23 @@ def _filter_gdf_by_polygon_and_tags(GDF, polygon, tags):
 
     Returns
     -------
-    GDF : GeoDataFrame
+    gdf : GeoDataFrame
         final, filtered GeoDataFrame
     """
     # only apply the filters if the GeoDataFrame is not empty
-    if not GDF.empty:
+    if not gdf.empty:
 
         # create two filters, initially all True
-        polygon_filter = pd.Series(True, index=GDF.index)
-        combined_tag_filter = pd.Series(True, index=GDF.index)
+        polygon_filter = pd.Series(True, index=gdf.index)
+        combined_tag_filter = pd.Series(True, index=gdf.index)
 
         # if a polygon was supplied, create a filter that is True for geometries
         # that intersect with the polygon
         if polygon:
             # get a set of index labels of the geometries that intersect the polygon
-            gdf_indices_in_polygon = utils_geo._intersect_index_quadrats(GDF, polygon)
+            gdf_indices_in_polygon = utils_geo._intersect_index_quadrats(gdf, polygon)
             # create a boolean series, True for geometries whose index is in the set
-            polygon_filter = GDF.index.isin(gdf_indices_in_polygon)
+            polygon_filter = gdf.index.isin(gdf_indices_in_polygon)
 
         # if tags were supplied, create a filter that is True for geometries that have
         # at least one of the requested tags
@@ -934,27 +934,27 @@ def _filter_gdf_by_polygon_and_tags(GDF, polygon, tags):
             combined_tag_filter[:] = False
 
             # reduce the tags to those that are actually present in the GeoDataFrame columns
-            tags_in_columns = {key: tags[key] for key in tags if key in GDF.columns}
+            tags_in_columns = {key: tags[key] for key in tags if key in gdf.columns}
 
             for key, value in tags_in_columns.items():
                 if value is True:
-                    tag_filter = GDF[key].notna()
+                    tag_filter = gdf[key].notna()
                 elif isinstance(value, str):
-                    tag_filter = GDF[key] == value
+                    tag_filter = gdf[key] == value
                 elif isinstance(value, list):
-                    tag_filter = GDF[key].isin(value)
+                    tag_filter = gdf[key].isin(value)
 
                 combined_tag_filter = combined_tag_filter | tag_filter
 
         # apply the filters
-        GDF = GDF[polygon_filter & combined_tag_filter].copy()
+        gdf = gdf[polygon_filter & combined_tag_filter].copy()
 
         # remove columns of all nulls (created by discarded component geometries)
-        GDF.dropna(axis="columns", how="all", inplace=True)
+        gdf.dropna(axis="columns", how="all", inplace=True)
 
         # reset the index keeping the unique ids
-        GDF.reset_index(inplace=True)
+        gdf.reset_index(inplace=True)
         # rename the new 'index' column to 'unique_id'
-        GDF.rename(columns={"index": "unique_id"}, inplace=True)
+        gdf.rename(columns={"index": "unique_id"}, inplace=True)
 
-    return GDF
+    return gdf

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -1,7 +1,6 @@
 """Download geometries from OpenStreetMap."""
 
-import warnings
-
+import logging as lg
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -868,18 +867,10 @@ def _buffer_invalid_geometries(gdf):
             # get their unique_ids from the index
             invalid_geometry_ids = gdf.loc[invalid_geometry_filter].index.to_list()
 
-            # show a warning
-            warnings.warn(
-                "Some invalid geometries were created and included in the GeoDataFrame. "
-                "A buffer of 0 has been applied to try to make them valid "
-                f"and their unique ids have been logged. {invalid_geometry_ids}",
-                stacklevel=2,
-            )
-
             # create a list of their urls and log them
             osm_url = "https://www.openstreetmap.org/"
             invalid_geom_urls = [osm_url + unique_id for unique_id in invalid_geometry_ids]
-            utils.log(f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}")
+            utils.log(f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}.", level=lg.WARNING)
 
             # apply .buffer(0)
             gdf.loc[invalid_geometry_filter, "geometry"] = gdf.loc[

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -1,6 +1,7 @@
 """Download geometries from OpenStreetMap."""
 
 import logging as lg
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -870,7 +871,10 @@ def _buffer_invalid_geometries(gdf):
             # create a list of their urls and log them
             osm_url = "https://www.openstreetmap.org/"
             invalid_geom_urls = [osm_url + unique_id for unique_id in invalid_geometry_ids]
-            utils.log(f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}.", level=lg.WARNING)
+            utils.log(
+                f"Invalid geometries that had .buffer(0) applied: {invalid_geom_urls}.",
+                level=lg.WARNING,
+            )
 
             # apply .buffer(0)
             gdf.loc[invalid_geometry_filter, "geometry"] = gdf.loc[


### PR DESCRIPTION
Proposed fix for TopologyException encountered when trying to intersect invalid geometries with the query polygon as discussed in #549.

Identifies rows with invalid geometries, logs their ids and applies a `.buffer(0)`

Also makes use of `gdf` or `GDF` more consistent.