### PR TITLE
suppress geopandas warning when calling gdf[geometry].isna() on empty geometry

### DIFF
--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -2,6 +2,11 @@
 
 import logging as lg
 
+# suppress GeoPandas warning caused by calling
+# gdf["geometry"].isna() on GeoDataFrame with empty geometries
+import warnings
+warnings.filterwarnings('ignore', 'GeoSeries.isna', UserWarning)
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -430,9 +435,9 @@ def _create_gdf(response_jsons, polygon, tags):
 
         # bug in geopandas <0.9 raises a TypeError if trying to plot empty
         # geometries but missing geometries (gdf['geometry'] = None) cannot be
-        # projected e.g. gdf.to_crs(). don't see any option other than to drop
-        # rows with missing/empty geometries
-        gdf = gdf[~(gdf["geometry"].isna() | gdf["geometry"].is_empty)].copy()
+        # projected e.g. gdf.to_crs().
+        # Remove rows with empty (e.g. Point()) or missing (e.g. None) geometry
+        gdf = gdf[~(gdf["geometry"].is_empty | gdf["geometry"].isna())].copy()
 
         utils.log(f"{len(gdf)} geometries in the final GeoDataFrame")
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -1,11 +1,7 @@
 """Download geospatial objects' geometries from OpenStreetMap."""
 
 import logging as lg
-
-# suppress GeoPandas warning caused by calling
-# gdf["geometry"].isna() on GeoDataFrame with empty geometries
 import warnings
-warnings.filterwarnings('ignore', 'GeoSeries.isna', UserWarning)
 
 import geopandas as gpd
 import numpy as np
@@ -24,6 +20,10 @@ from . import settings
 from . import utils
 from . import utils_geo
 from ._polygon_features import _polygon_features
+
+# suppress GeoPandas warning caused by calling
+# gdf["geometry"].isna() on GeoDataFrame with empty geometries
+warnings.filterwarnings("ignore", "GeoSeries.isna", UserWarning)
 
 
 def geometries_from_bbox(north, south, east, west, tags):


### PR DESCRIPTION
This pull request actively suppresses the geopandas warning that is created when calling `isna()` on GeoDataFrames that contain empty geometries (e.g. `Point()`).

I've moved the reasoning to #549 for clarity