### PR TITLE
Fix #568

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -395,22 +395,29 @@ def consolidate_intersections(
         G.remove_nodes_from(dead_end_nodes)
 
     if rebuild_graph:
-        return _consolidate_intersections_rebuild_graph(
-            G=G, tolerance=tolerance, reconnect_edges=reconnect_edges
-        )
+        if len(G) == 0 or len(G.edges) == 0:
+            # cannot rebuild a graph with no nodes or no edges, just return it
+            return G
+        else:
+            return _consolidate_intersections_rebuild_graph(
+                G=G, tolerance=tolerance, reconnect_edges=reconnect_edges
+            )
 
     else:
-        # create a GeoDataFrame of nodes, buffer to passed-in distance, merge overlaps
-        gdf_nodes = utils_graph.graph_to_gdfs(G, edges=False)
-        buffered_nodes = gdf_nodes.buffer(tolerance).unary_union
-        if isinstance(buffered_nodes, Polygon):
-            # if only a single node results, make iterable to convert to GeoSeries
-            buffered_nodes = [buffered_nodes]
+        if len(G) == 0:
+            # if graph has no nodes, just return empty GeoSeries
+            return gpd.GeoSeries()
+        else:
+            # create nodes gdf, buffer to passed-in distance, merge overlaps
+            gdf_nodes = utils_graph.graph_to_gdfs(G, edges=False)
+            buffered_nodes = gdf_nodes.buffer(tolerance).unary_union
+            if isinstance(buffered_nodes, Polygon):
+                # if only a single node results, make iterable to convert to GeoSeries
+                buffered_nodes = [buffered_nodes]
 
-        # get the centroids of the merged intersection polygons
-        unified_intersections = gpd.GeoSeries(list(buffered_nodes))
-        intersection_centroids = unified_intersections.centroid
-        return intersection_centroids
+            # get the centroids of the merged intersection polygons
+            intersection_centroids = gpd.GeoSeries(list(buffered_nodes)).centroid
+            return intersection_centroids
 
 
 def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=True):

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -404,19 +404,20 @@ def consolidate_intersections(
             )
 
     else:
+        crs = G.graph["crs"]
         if len(G) == 0:
             # if graph has no nodes, just return empty GeoSeries
-            return gpd.GeoSeries()
+            return gpd.GeoSeries(crs=crs)
         else:
             # create nodes gdf, buffer to passed-in distance, merge overlaps
             gdf_nodes = utils_graph.graph_to_gdfs(G, edges=False)
-            buffered_nodes = gdf_nodes.buffer(tolerance).unary_union
-            if isinstance(buffered_nodes, Polygon):
+            merged_nodes = gdf_nodes.buffer(tolerance).unary_union
+            if isinstance(merged_nodes, Polygon):
                 # if only a single node results, make iterable to convert to GeoSeries
-                buffered_nodes = [buffered_nodes]
+                merged_nodes = [merged_nodes]
 
             # get the centroids of the merged intersection polygons
-            intersection_centroids = gpd.GeoSeries(list(buffered_nodes)).centroid
+            intersection_centroids = gpd.GeoSeries(list(merged_nodes), crs=crs).centroid
             return intersection_centroids
 
 

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -24,8 +24,8 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
     G : networkx.MultiDiGraph
         input graph
     area : numeric
-        the area covered by the street network, in square meters (typically
-        land area); if none, will skip all density-based metrics
+        the land area of this study site, in square meters. must be greater
+        than 0. if None, will skip all density-based metrics.
     clean_intersects : bool
         if True, calculate consolidated intersections count (and density, if
         area is provided) via consolidate_intersections function


### PR DESCRIPTION
Fixes #568:

  - improves `basic_stats` docstring to make it clear that the `area` argument must be greater than zero.
  - handles graphs with no intersections in `consolidate_intersections`
  - assigns CRS value to the GeoSeries returned by `consolidate_intersections` when `rebuild_graph=False`