### PR TITLE
improve graph_from_gdfs efficiency and speed

### DIFF
--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -130,9 +130,13 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
     attr_values = zip(*[gdf_edges[col] for col in attr_names])
 
     # add edges and their attributes to graph
-    for u, v, k, values in zip(gdf_edges["u"], gdf_edges["v"], gdf_edges["key"], attr_values):
-        G.add_edge(u, v, key=k)
-        G[u][v][k].update(zip(attr_names, values))
+    for u, v, values in zip(gdf_edges["u"], gdf_edges["v"], attr_values):
+        data = {
+            a: b
+            for a, b in dict(zip(attr_names, values)).items()
+            if isinstance(b, list) or pd.notnull(b)
+        }
+        G.add_edge(u, v, **data)
 
     # add nodes' attributes to graph
     for col in gdf_nodes.columns:

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -125,18 +125,15 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
         graph_attrs = {"crs": gdf_edges.crs}
     G = nx.MultiDiGraph(**graph_attrs)
 
-    # assemble edges' attribute data and keys
-    attr_names = [c for c in gdf_edges.columns if c not in {"u", "v"}]
+    # assemble edges' attribute names and values
+    attr_names = [c for c in gdf_edges.columns if c not in {"u", "v", "key"}]
     attr_values = zip(*[gdf_edges[col] for col in attr_names])
 
     # add edges and their attributes to graph
-    for u, v, values in zip(gdf_edges["u"], gdf_edges["v"], attr_values):
-        data = {
-            a: b
-            for a, b in dict(zip(attr_names, values)).items()
-            if isinstance(b, list) or pd.notnull(b)
-        }
-        G.add_edge(u, v, **data)
+    for u, v, k, values in zip(gdf_edges["u"], gdf_edges["v"], gdf_edges["key"], attr_values):
+        edge_attrs = zip(attr_names, values)
+        data = {a: b for a, b in dict(edge_attrs).items() if isinstance(b, list) or pd.notnull(b)}
+        G.add_edge(u, v, key=k, **data)
 
     # add nodes' attributes to graph
     for col in gdf_nodes.columns:

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -129,9 +129,10 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
     attr_names = [c for c in gdf_edges.columns if c not in {"u", "v", "key"}]
     attr_values = zip(*[gdf_edges[col] for col in attr_names])
 
-    # add edges and their attributes to graph
-    for u, v, k, values in zip(gdf_edges["u"], gdf_edges["v"], gdf_edges["key"], attr_values):
-        edge_attrs = zip(attr_names, values)
+    # add edges and their attributes to graph. filter out null attribute
+    # values so that edges only get attributes with non-null values.
+    for u, v, k, edge_vals in zip(gdf_edges["u"], gdf_edges["v"], gdf_edges["key"], attr_values):
+        edge_attrs = zip(attr_names, edge_vals)
         data = {a: b for a, b in dict(edge_attrs).items() if isinstance(b, list) or pd.notnull(b)}
         G.add_edge(u, v, key=k, **data)
 


### PR DESCRIPTION
Resolves #576 to improve `graph_from_gdfs` speed and revises #577 to improve memory efficiency by not creating null node/edge attributes given sparse OSM data.