### PR TITLE
Update utils_graph.py

### DIFF
--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -58,7 +58,12 @@ def graph_to_gdfs(G, nodes=True, edges=True, node_geometry=True, fill_edge_geome
         if len(G.edges) < 1:
             raise ValueError("Graph has no edges, cannot convert to a GeoDataFrame.")
 
-        u, v, k, data = zip(*G.edges(keys=True, data=True))
+        try:
+            # if graph has keys
+            u, v, k, data = zip(*G.edges(keys=True, data=True))
+        except:
+            k = None
+            u, v, data = zip(*G.edges(data=True))
 
         if fill_edge_geometry:
 
@@ -87,7 +92,8 @@ def graph_to_gdfs(G, nodes=True, edges=True, node_geometry=True, fill_edge_geome
         # add u, v, key attributes as columns
         gdf_edges["u"] = u
         gdf_edges["v"] = v
-        gdf_edges["key"] = k
+        if k is not None:
+            gdf_edges["key"] = k
 
         utils.log("Created edges GeoDataFrame from graph")
 


### PR DESCRIPTION
I ran into an error when I tried to plot my graph after running betweeness centrality and trying to plot my graph. Before running betweeness centrality I had to convert my MultiDiGraph to a DiGraph, and when I did this, there were no longer any keys. Therefore ox.plot_graph did not work for me, because it calls ox.utils_graph.graph_to_gdfs and within this file it expects the graph to have keys, and if it doesn't it results in this error: TypeError: __call__() got an unexpected keyword argument 'keys'

inclusions:

  - not sure if there is a related issue(s)
  - a description of the changes proposed in the pull request: see above
  - an example code snippet illustrating usage of the new functionality: the function inputs will not change
