### PR TITLE
Custom Type Conversion - load_graphml

### DIFF
--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -273,7 +273,7 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
         Defaults to {"length": float, "grade": float,
         "grade_abs": float, "bearing": float,
         "speed_kph": float,"travel_time": float} if None
-        
+
     Returns
     -------
     G : networkx.MultiDiGraph

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -377,15 +377,15 @@ def _stringify_nonnumeric_cols(gdf):
 
 
 def save_graph_xml(
-        data,
-        filepath=None,
-        node_tags=settings.osm_xml_node_tags,
-        node_attrs=settings.osm_xml_node_attrs,
-        edge_tags=settings.osm_xml_way_tags,
-        edge_attrs=settings.osm_xml_way_attrs,
-        oneway=False,
-        merge_edges=True,
-        edge_tag_aggs=None,
+    data,
+    filepath=None,
+    node_tags=settings.osm_xml_node_tags,
+    node_attrs=settings.osm_xml_node_attrs,
+    edge_tags=settings.osm_xml_way_tags,
+    edge_attrs=settings.osm_xml_way_attrs,
+    oneway=False,
+    merge_edges=True,
+    edge_tag_aggs=None,
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -183,8 +183,11 @@ def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
         convert node ids to this data type
     node_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
+        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float} if None
     edge_dtypes : dict of attribute name -> data type
-        identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes
+        identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
+        to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
+       "travel_time": float} if None
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -227,7 +230,7 @@ def _convert_node_attr_types(G, node_type, node_dtypes=None):
         convert node ID (osmid) to this type
     node_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
-        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float}
+        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float} if None
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -259,7 +262,7 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
     edge_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
         to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
-                       "travel_time": float}
+                       "travel_time": float} if None
     Returns
     -------
     G : networkx.MultiDiGraph

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -182,11 +182,15 @@ def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
     node_type : type
         convert node ids to this data type
     node_dtypes : dict of attribute name -> data type
-        identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
-        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float} if None
+        identifies additional is a numpy.dtype or Python type to
+         cast one or more additional node attributes defaults to
+         {"elevation":float, "elevation_res":float, "lat":float,
+         "lon":float, "x":float, "y":float} if None
     edge_dtypes : dict of attribute name -> data type
-        identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
-        to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
+        identifies additional is a numpy.dtype or Python type to
+         cast one or more additional edge attributes. Defaults
+        to {"length": float, "grade": float, "grade_abs":
+        float, "bearing": float, "speed_kph": float,
         "travel_time": float} if None
     Returns
     -------
@@ -229,8 +233,10 @@ def _convert_node_attr_types(G, node_type, node_dtypes=None):
     node_type : type
         convert node ID (osmid) to this type
     node_dtypes : dict of attribute name -> data type
-        identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
-        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float} if None
+        identifies additional is a numpy.dtype or Python type
+        to cast one or more additional node attributes
+        defaults to {"elevation":float, "elevation_res":float,
+        "lat":float, "lon":float, "x":float, "y":float} if None
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -260,9 +266,11 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
     node_type : type
         convert osmid to this type
     edge_dtypes : dict of attribute name -> data type
-        identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
-        to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
-        "travel_time": float} if None
+        identifies additional is a numpy.dtype or Python
+        type to cast one or more additional edge attributes.
+        Defaults to {"length": float, "grade": float,
+         "grade_abs": float, "bearing": float,
+         "speed_kph": float,"travel_time": float} if None
     Returns
     -------
     G : networkx.MultiDiGraph

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -276,9 +276,10 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
     G : networkx.MultiDiGraph
     """
     if edge_dtypes is None:
-        edge_dtypes = {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
-                       "travel_time": float}
-    # convert numeric, bool, and list edge attributes from string to correct data types
+        edge_dtypes = {"length": float, "grade": float, "grade_abs": float,
+                       "bearing": float, "speed_kph": float, "travel_time": float}
+    # convert numeric, bool, and list edge attributes from string
+    # to correct data types
     for _, _, data in G.edges(data=True, keys=False):
         try:
             data["oneway"] = ast.literal_eval(data["oneway"])

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -215,7 +215,7 @@ def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
     return G
 
 
-def _convert_node_attr_types(G, node_type,edge_dtypes=None):
+def _convert_node_attr_types(G, node_type, node_dtypes=None):
     """
     Convert graph nodes' attributes' types from string to numeric.
 
@@ -227,21 +227,22 @@ def _convert_node_attr_types(G, node_type,edge_dtypes=None):
         convert node ID (osmid) to this type
     node_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
-
+        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float}
     Returns
     -------
     G : networkx.MultiDiGraph
     """
+    if node_dtypes is None:
+        node_dtypes = {"elevation": float, "elevation_res": float, "lat": float, "lon": float,
+                       "x": float, "y": float}
     for _, data in G.nodes(data=True):
-
         # convert node ID to user-requested type
         data["osmid"] = node_type(data["osmid"])
-
         # convert numeric node attributes from string to float
-        for attr in {"elevation", "elevation_res", "lat", "lon", "x", "y"}:
+        for attr in node_dtypes:
             if attr in data:
-                data[attr] = float(data[attr])
-
+                dtype = node_dtypes[attr]
+                data[attr] = dtype(data[attr])
     return G
 
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -187,7 +187,7 @@ def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
     edge_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
         to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
-       "travel_time": float} if None
+        "travel_time": float} if None
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -262,7 +262,7 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
     edge_dtypes : dict of attribute name -> data type
         identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
         to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
-                       "travel_time": float} if None
+        "travel_time": float} if None
     Returns
     -------
     G : networkx.MultiDiGraph

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -192,6 +192,7 @@ def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
         to {"length": float, "grade": float, "grade_abs":
         float, "bearing": float, "speed_kph": float,
         "travel_time": float} if None
+
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -237,6 +238,7 @@ def _convert_node_attr_types(G, node_type, node_dtypes=None):
         to cast one or more additional node attributes
         defaults to {"elevation":float, "elevation_res":float,
         "lat":float, "lon":float, "x":float, "y":float} if None
+
     Returns
     -------
     G : networkx.MultiDiGraph
@@ -269,8 +271,9 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
         identifies additional is a numpy.dtype or Python
         type to cast one or more additional edge attributes.
         Defaults to {"length": float, "grade": float,
-         "grade_abs": float, "bearing": float,
-         "speed_kph": float,"travel_time": float} if None
+        "grade_abs": float, "bearing": float,
+        "speed_kph": float,"travel_time": float} if None
+        
     Returns
     -------
     G : networkx.MultiDiGraph


### PR DESCRIPTION
This PR addresses issue #575, and willl enable edges and nodes imported with load_graphml to be able to do type conversions for attributes beyond the default attributes currently being converted to floats. This enables users who build graphs with additional edge weights or node attributes that can be properly saved and then loaded based on the desired attribute data type. 

Relevant Code Snippets

```
def load_graphml(filepath, node_type=int, node_dtypes=None, edge_dtypes=None):
    """
    Load an OSMnx-saved GraphML file from disk.

    Converts the node/edge attributes to appropriate data types.

    Parameters
    ----------
    filepath : string
        path to the GraphML file
    node_type : type
        convert node ids to this data type
    node_dtypes : dict of attribute name -> data type
        identifies additional is a numpy.dtype or Python type to cast one or more additional node attributes
        defaults to {"elevation":float, "elevation_res":float, "lat":float, "lon":float, "x":float, "y":float} if None
    edge_dtypes : dict of attribute name -> data type
        identifies additional is a numpy.dtype or Python type to cast one or more additional edge attributes. Defaults
        to {"length": float, "grade": float, "grade_abs": float, "bearing": float, "speed_kph": float,
       "travel_time": float} if None
    Returns
    -------
    G : networkx.MultiDiGraph
    """
    # read the graph from disk
    G = nx.MultiDiGraph(nx.read_graphml(filepath, node_type=node_type))

    # convert node/edge attribute data types
    utils.log("Converting node and edge attribute data types")
    G = _convert_node_attr_types(G, node_type, node_dtypes)
    G = _convert_edge_attr_types(G, node_type, edge_dtypes)
```
