### PR TITLE
speed-up - plot_route_folium 

### DIFF
--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -199,7 +199,7 @@ def plot_route_folium(
         raise ImportError("The folium package must be installed to use this optional feature.")
 
     # create gdf of the route edges
-    gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
+    gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False, fill_edge_geometry=True)
     route_nodes = list(zip(route[:-1], route[1:]))
     index = [
         gdf_edges[(gdf_edges["u"] == u) & (gdf_edges["v"] == v)].index[0] for u, v in route_nodes


### PR DESCRIPTION
The PR addresses issue #586. It will replace `graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)` by   `graph_to_gdfs(G.subgraph(route), nodes=False, fill_edge_geometry=True)`  as only the edges from the path are required to plot the route.

The speed is significantly improved, the computation time for a graph with 90000 edges and a path of 430 nodes is:

Current version: `23.7146 s`
Enhanced version: `0.9569 s`
