### PR TITLE
Customizable data type specification when loading GraphML file

### DIFF
--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -244,8 +244,14 @@ def _convert_node_attr_types(G, node_type, node_dtypes=None):
     G : networkx.MultiDiGraph
     """
     if node_dtypes is None:
-        node_dtypes = {"elevation": float, "elevation_res": float, "lat": float, "lon": float,
-                       "x": float, "y": float}
+        node_dtypes = {
+            "elevation": float,
+            "elevation_res": float,
+            "lat": float,
+            "lon": float,
+            "x": float,
+            "y": float,
+        }
     for _, data in G.nodes(data=True):
         # convert node ID to user-requested type
         data["osmid"] = node_type(data["osmid"])
@@ -279,8 +285,14 @@ def _convert_edge_attr_types(G, node_type, edge_dtypes=None):
     G : networkx.MultiDiGraph
     """
     if edge_dtypes is None:
-        edge_dtypes = {"length": float, "grade": float, "grade_abs": float,
-                       "bearing": float, "speed_kph": float, "travel_time": float}
+        edge_dtypes = {
+            "length": float,
+            "grade": float,
+            "grade_abs": float,
+            "bearing": float,
+            "speed_kph": float,
+            "travel_time": float,
+        }
     # convert numeric, bool, and list edge attributes from string
     # to correct data types
     for _, _, data in G.edges(data=True, keys=False):
@@ -600,7 +612,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
             else:
                 for tag in edge_tags:
                     if (tag in all_way_edges.columns) and (
-                            tag not in (t for t, agg in edge_tag_aggs)
+                        tag not in (t for t, agg in edge_tag_aggs)
                     ):
                         etree.SubElement(edge, "tag", attrib={"k": tag, "v": first[tag]})
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -220,8 +220,14 @@ def load_graphml(filepath, node_type=None, node_dtypes=None, edge_dtypes=None):
     edge_dtypes = default_edge_dtypes
 
     if node_type is not None:
-        # TODO: add deprecation warning: use node_dtypes instead
         # for now add to node_dtypes, remove in next release
+        import warnings
+
+        msg = (
+            "The node_type argument has been deprecated and will be removed"
+            " in a future release. Use node_dtypes instead."
+        )
+        warnings.warn(msg)
         node_dtypes.update({"osmid": node_type})
 
     # read the graph from disk
@@ -295,7 +301,7 @@ def _convert_edge_attr_types(G, dtypes=None):
         for attr, value in data.items():
             if value.startswith("[") and value.endswith("]"):
                 try:
-                    data[attr] = ast.literal_eval(data[attr])
+                    data[attr] = ast.literal_eval(value)
                 except Exception:
                     pass
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -20,7 +20,6 @@ log_filename = "osmnx"
 
 # OSM node/way tags to add as graph node/edge attributes when these tags are
 # present in the data retrieved from OSM
-# NOTE: load_graphml function expects a consistent set of tags for parsing
 useful_tags_node = ["ref", "highway"]
 useful_tags_way = [
     "bridge",

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -307,7 +307,32 @@ def test_network_saving_loading():
     ox.save_graphml(G, gephi=True)
     ox.save_graphml(G, gephi=False)
     filepath = os.path.join(ox.settings.data_folder, "graph.graphml")
-    G = ox.load_graphml(filepath, node_type=str)
+    G2 = ox.load_graphml(filepath)
+
+    # verify everything in G is equivalent in G2
+    for (n1, d1), (n2, d2) in zip(G.nodes(data=True), G2.nodes(data=True)):
+        assert n1 == n2
+        assert d1 == d2
+    for (u1, v1, k1, d1), (u2, v2, k2, d2) in zip(
+        G.edges(keys=True, data=True), G2.edges(keys=True, data=True)
+    ):
+        assert u1 == u2
+        assert v1 == v2
+        assert k1 == k2
+        assert tuple(d1.keys()) == tuple(d2.keys())
+        assert tuple(d1.values()) == tuple(d2.values())
+    for (k1, v1), (k2, v2) in zip(G.graph.items(), G2.graph.items()):
+        assert k1 == k2
+        assert v1 == v2
+    assert tuple(G.graph["streets_per_node"].keys()) == tuple(G2.graph["streets_per_node"].keys())
+    assert tuple(G.graph["streets_per_node"].values()) == tuple(
+        G2.graph["streets_per_node"].values()
+    )
+
+    # test custom data types
+    nd = {"osmid": str}
+    ed = {"length": str, "osmid": float}
+    G2 = ox.load_graphml(filepath, node_dtypes=nd, edge_dtypes=ed)
 
     # test osm xml output
     default_all_oneway = ox.settings.all_oneway


### PR DESCRIPTION
Revises #584 to satisfy CI tests.
Resolves #575.
  - adds customizable node/edge attribute data type arguments
  - deprecates old `node_type` argument with warning; to remove in a future release
  - fixes gephi graphml compatibility and streamlines gephi-compatible saving (see https://github.com/networkx/networkx/issues/4347)