### PR TITLE
make graph_to_gdfs set gdf_edges' index to ['u', 'v', 'key']

### DIFF
--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -199,7 +199,7 @@ def plot_route_folium(
 
     # create gdf of the route edges in order
     node_pairs = zip(route[:-1], route[1:])
-    uvk = ((u, v, min(G[u][v], key=G[u][v].get("length"))) for u, v in node_pairs)
+    uvk = [(u, v, min(G[u][v], key=lambda k: G[u][v][k]["length"])) for u, v in node_pairs]
     gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
 
     # get route centroid

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -117,7 +117,7 @@ def plot_graph_folium(
         raise ImportError("The folium package must be installed to use this optional feature.")
 
     # create gdf of the graph edges
-    gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
+    gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False)
 
     # get graph centroid
     x, y = gdf_edges.unary_union.centroid.xy
@@ -143,8 +143,7 @@ def plot_graph_folium(
     # list of lat-lng points as [southwest, northeast]
     if fit_bounds and isinstance(graph_map, folium.Map):
         tb = gdf_edges.total_bounds
-        bounds = [[tb[1], tb[0]], [tb[3], tb[2]]]
-        graph_map.fit_bounds(bounds)
+        graph_map.fit_bounds([(tb[1], tb[0]), (tb[3], tb[2])])
 
     return graph_map
 
@@ -198,16 +197,13 @@ def plot_route_folium(
     if not folium:
         raise ImportError("The folium package must be installed to use this optional feature.")
 
-    # create gdf of the route edges
-    gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False, fill_edge_geometry=True)
-    route_nodes = list(zip(route[:-1], route[1:]))
-    index = [
-        gdf_edges[(gdf_edges["u"] == u) & (gdf_edges["v"] == v)].index[0] for u, v in route_nodes
-    ]
-    gdf_route_edges = gdf_edges.loc[index]
+    # create gdf of the route edges in order
+    node_pairs = zip(route[:-1], route[1:])
+    uvk = ((u, v, min(G[u][v], key=G[u][v].get("length"))) for u, v in node_pairs)
+    gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
 
     # get route centroid
-    x, y = gdf_route_edges.unary_union.centroid.xy
+    x, y = gdf_edges.unary_union.centroid.xy
     route_centroid = (y[0], x[0])
 
     # create the folium web map if one wasn't passed-in
@@ -215,7 +211,7 @@ def plot_route_folium(
         route_map = folium.Map(location=route_centroid, zoom_start=zoom, tiles=tiles)
 
     # add each route edge to the map
-    for _, row in gdf_route_edges.iterrows():
+    for _, row in gdf_edges.iterrows():
         pl = _make_folium_polyline(
             edge=row,
             edge_color=route_color,
@@ -229,8 +225,7 @@ def plot_route_folium(
     # if fit_bounds is True, fit the map to the bounds of the route by passing
     # list of lat-lng points as [southwest, northeast]
     if fit_bounds and isinstance(route_map, folium.Map):
-        tb = gdf_route_edges.total_bounds
-        bounds = [(tb[1], tb[0]), (tb[3], tb[2])]
-        route_map.fit_bounds(bounds)
+        tb = gdf_edges.total_bounds
+        route_map.fit_bounds([(tb[1], tb[0]), (tb[3], tb[2])])
 
     return route_map

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -433,7 +433,7 @@ def save_graph_xml(
     if "uniqueid" in gdf_edges.columns:
         gdf_edges = gdf_edges.rename(columns={"uniqueid": "id"})
     else:
-        gdf_edges = gdf_edges.reset_index().rename(columns={"index": "id"})
+        gdf_edges = gdf_edges.reset_index().reset_index().rename(columns={"index": "id"})
 
     # add default values for required attributes
     for table in (gdf_nodes, gdf_edges):
@@ -530,6 +530,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
     root : ElementTree.Element
         xml tree with edges appended
     """
+    gdf_edges.reset_index(inplace=True)
     if merge_edges:
 
         for e in gdf_edges["id"].unique():
@@ -606,6 +607,7 @@ def _get_unique_nodes_ordered_from_way(df_way_edges):
         it is not explicitly forbidden in the OSM XML design schema.
     """
     G = nx.MultiDiGraph()
+    df_way_edges.reset_index(inplace=True)
     all_nodes = list(df_way_edges["u"].values) + list(df_way_edges["v"].values)
 
     G.add_nodes_from(all_nodes)

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -537,7 +537,7 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
 
     # STEP 6
     # create new edge from cluster to cluster for each edge in original graph
-    gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False).set_index(["u", "v", "key"])
+    gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False)
     for u, v, k, data in G.edges(keys=True, data=True):
         u2 = gdf.loc[u, "cluster"]
         v2 = gdf.loc[v, "cluster"]
@@ -554,7 +554,7 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
     # STEP 7
     # for every group of merged nodes with more than 1 node in it, extend the
     # edge geometries to reach the new node point
-    new_edges = utils_graph.graph_to_gdfs(H, nodes=False)
+    new_edges = utils_graph.graph_to_gdfs(H, nodes=False).reset_index()
     for cluster_label, nodes_subset in groups:
 
         # but only if there were multiple nodes merged together,

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -110,8 +110,7 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=1):
 
     # add speed kph attribute to graph edges
     edges["speed_kph"] = speed_kph.round(precision).values
-    edge_speed_kph = edges[["u", "v", "key", "speed_kph"]].set_index(["u", "v", "key"]).iloc[:, 0]
-    nx.set_edge_attributes(G, values=edge_speed_kph, name="speed_kph")
+    nx.set_edge_attributes(G, values=edges["speed_kph"], name="speed_kph")
 
     return G
 
@@ -155,8 +154,7 @@ def add_edge_travel_times(G, precision=1):
 
     # add travel time attribute to graph edges
     edges["travel_time"] = travel_time.round(precision).values
-    edge_times = edges[["u", "v", "key", "travel_time"]].set_index(["u", "v", "key"]).iloc[:, 0]
-    nx.set_edge_attributes(G, values=edge_times, name="travel_time")
+    nx.set_edge_attributes(G, values=edges["travel_time"], name="travel_time")
 
     return G
 


### PR DESCRIPTION
Makes the `graph_to_gdfs` function set `gdf_edges`'s index to `['u', 'v', 'key']` before returning it, and updates throughout package to accommodate this new index structure. Resolves #579.