### PR TITLE
Use pathlib instead of os.path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,14 +15,14 @@ serve to show the default.
 
 If extensions (or modules to document with autodoc) are in another directory,
 add these directories to sys.path here. If the directory is relative to the
-documentation root, use os.path.abspath to make it absolute, like shown here.
+documentation root, use Path.resolve() to make it absolute, like shown here.
 """
 
-import os
 import sys
+from pathlib import Path
 
 # go up two levels from /docs/source to the package root
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, str(Path().resolve().parents[1]))
 
 # mock import these packages because readthedocs doesn't have them installed
 autodoc_mock_imports = [

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -8,6 +8,7 @@ GeoDataFrame of them.
 
 import logging as lg
 import warnings
+from pathlib import Path
 
 import geopandas as gpd
 import numpy as np

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -1,7 +1,7 @@
 """Serialize graphs to/from files on disk."""
 
 import ast
-import os
+from pathlib import Path
 
 import networkx as nx
 import pandas as pd
@@ -37,12 +37,11 @@ def save_graph_geopackage(G, filepath=None, encoding="utf-8", directed=False):
     """
     # default filepath if none was provided
     if filepath is None:
-        filepath = os.path.join(settings.data_folder, "graph.gpkg")
+        filepath = Path(settings.data_folder) / "graph.gpkg"
+    filepath = filepath.resolve()
 
     # if save folder does not already exist, create it
-    folder, filename = os.path.split(filepath)
-    if not folder == "" and not os.path.exists(folder):
-        os.makedirs(folder)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
 
     # convert graph to gdfs and stringify non-numeric columns
     if directed:
@@ -86,14 +85,14 @@ def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
     """
     # default filepath if none was provided
     if filepath is None:
-        filepath = os.path.join(settings.data_folder, "graph_shapefile")
+        filepath = Path(settings.data_folder) / "graph_shapefile"
+    filepath = filepath.resolve()
 
     # if save folder does not already exist, create it (shapefiles
     # get saved as set of files)
-    if not filepath == "" and not os.path.exists(filepath):
-        os.makedirs(filepath)
-    filepath_nodes = os.path.join(filepath, "nodes.shp")
-    filepath_edges = os.path.join(filepath, "edges.shp")
+    filepath.mkdir(parents=True, exist_ok=True)
+    filepath_nodes = filepath / "nodes.shp"
+    filepath_edges = filepath / "edges.shp"
 
     # convert graph to gdfs and stringify non-numeric columns
     if directed:
@@ -132,12 +131,11 @@ def save_graphml(G, filepath=None, gephi=False, encoding="utf-8"):
     """
     # default filepath if none was provided
     if filepath is None:
-        filepath = os.path.join(settings.data_folder, "graph.graphml")
+        filepath = Path(settings.data_folder) / "graph.graphml"
+    filepath = filepath.resolve()
 
     # if save folder does not already exist, create it
-    folder, filename = os.path.split(filepath)
-    if not folder == "" and not os.path.exists(folder):
-        os.makedirs(folder)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
 
     if gephi:
         # for gephi compatibility, each edge's key must be unique as an id

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -1,6 +1,6 @@
 """Plot spatial geometries, street networks, and routes."""
 
-import os
+from pathlib import Path
 
 import matplotlib.cm as cm
 import matplotlib.colors as colors
@@ -705,16 +705,13 @@ def _save_and_show(fig, ax, save=False, show=True, close=True, filepath=None, dp
 
         # default filepath, if none provided
         if filepath is None:
-            filepath = os.path.join(settings.imgs_folder, "image.png")
+            filepath = Path(settings.imgs_folder) / "image.png"
 
         # if save folder does not already exist, create it
-        folder, _ = os.path.split(filepath)
-        if not folder == "" and not os.path.exists(folder):
-            os.makedirs(folder)
+        filepath.parent.mkdir(parents=True, exist_ok=True)
 
         # get the file extension and figure facecolor
-        _, ext = os.path.splitext(filepath)
-        ext = ext.strip(".")
+        ext = filepath.suffix.strip(".")
         fc = fig.get_facecolor()
 
         if ext == "svg":

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -1,6 +1,7 @@
 """Global settings, can be configured by user with utils.config()."""
 
 import logging as lg
+from pathlib import Path
 
 # locations to save data, logs, images, and cache
 data_folder = "data"

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -2,9 +2,9 @@
 
 import datetime as dt
 import logging as lg
-import os
 import sys
 import unicodedata
+from pathlib import Path
 
 from . import settings
 
@@ -323,11 +323,10 @@ def _get_logger(level=None, name=None, filename=None):
     if not getattr(logger, "handler_set", None):
 
         # get today's date and construct a log filename
-        log_filename = os.path.join(settings.logs_folder, f'{filename}_{ts(style="date")}.log')
+        log_filename = Path(settings.logs_folder) / f'{filename}_{ts(style="date")}.log'
 
         # if the logs folder does not already exist, create it
-        if not os.path.exists(settings.logs_folder):
-            os.makedirs(settings.logs_folder)
+        log_filename.parent.mkdir(parents=True, exist_ok=True)
 
         # create file handler and log formatter and set them up
         handler = lg.FileHandler(log_filename, encoding="utf-8")

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import tempfile
 from collections import OrderedDict
+from pathlib import Path
 
 import folium
 import networkx as nx
@@ -31,10 +32,10 @@ import osmnx as ox
 
 # remove the .temp folder and .coverage file if they already
 # exist so we start fresh with these tests
-if os.path.exists(".temp"):
+if Path(".temp").exists():
     shutil.rmtree(".temp")
-if os.path.exists(".coverage"):
-    os.remove(".coverage")
+if Path(".coverage").exists():
+    Path(".coverage").unlink()
 
 ox.config(
     log_console=True,
@@ -185,7 +186,7 @@ def test_plots():
     ec = ox.plot.get_edge_colors_by_attr(G, "length", num_bins=5)
 
     # plot and save to disk
-    filepath = os.path.join(ox.settings.data_folder, "test.svg")
+    filepath = Path(ox.settings.data_folder) / "test.svg"
     fig, ax = ox.plot_graph(G, show=False, save=True, close=True, filepath=filepath)
     fig, ax = ox.plot_graph(
         G,
@@ -306,7 +307,7 @@ def test_network_saving_loading():
     # save/load graph as graphml file
     ox.save_graphml(G, gephi=True)
     ox.save_graphml(G, gephi=False)
-    filepath = os.path.join(ox.settings.data_folder, "graph.graphml")
+    filepath = Path(ox.settings.data_folder) / "graph.graphml"
     G2 = ox.load_graphml(filepath)
 
     # verify everything in G is equivalent in G2


### PR DESCRIPTION
Replace `os.path.*` with `pathlib.Path` to simplify the code and use individual objects for files and directories.

This changes only internal code and private methods. Next steps would be to update the public methods to accepts both `str` and `Path` objects.