### PR TITLE
update config function and remove internal _is_simplified function

### DIFF
--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -6,7 +6,6 @@ import geopandas as gpd
 from pyproj import CRS
 
 from . import settings
-from . import simplification
 from . import utils
 from . import utils_graph
 
@@ -139,7 +138,7 @@ def project_graph(G, to_crs=None):
     gdf_nodes_proj = gdf_nodes_proj.drop(columns=["geometry"])
 
     # STEP 2: PROJECT THE EDGES
-    if simplification._is_simplified(G):
+    if "simplified" in G.graph and G.graph["simplified"]:
         # if graph has previously been simplified, project the edge geometries
         gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
         gdf_edges_proj = project_gdf(gdf_edges, to_crs=gdf_nodes_proj.crs)

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -190,22 +190,6 @@ def _get_paths_to_simplify(G, strict=True):
                 yield _build_path(G, endpoint, successor, endpoints)
 
 
-def _is_simplified(G):
-    """
-    Determine if a graph has already had its topology simplified.
-
-    Parameters
-    ----------
-    G : networkx.MultiDiGraph
-        input graph
-
-    Returns
-    -------
-    bool
-    """
-    return "simplified" in G.graph and G.graph["simplified"]
-
-
 def simplify_graph(G, strict=True, remove_rings=True):
     """
     Simplify a graph's topology by removing interstitial nodes.
@@ -236,7 +220,7 @@ def simplify_graph(G, strict=True, remove_rings=True):
         topologically simplified graph, with a new `geometry` attribute on
         each simplified edge
     """
-    if _is_simplified(G):
+    if "simplified" in G.graph and G.graph["simplified"]:
         raise Exception("This graph has already been simplified, cannot simplify it again.")
 
     utils.log("Begin topologically simplifying the graph...")

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -1,4 +1,4 @@
-"""Calculate graph-theoretic network measures."""
+"""Calculate geometric and topological network measures."""
 
 import networkx as nx
 import numpy as np
@@ -12,7 +12,7 @@ from . import utils_graph
 
 def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dist="gc"):
     """
-    Calculate basic descriptive metric and topological stats for a graph.
+    Calculate basic descriptive geometric and topological stats for a graph.
 
     For an unprojected lat-lng graph, tolerance and graph units should be in
     degrees, and circuity_dist should be 'gc'. For a projected graph,
@@ -223,7 +223,7 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
 
 def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=False):
     """
-    Calculate extended topological stats and metrics for a graph.
+    Calculate extended topological measures for a graph.
 
     Many of these algorithms have an inherently high time complexity. Global
     topological analysis of large complex networks is extremely time consuming

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -6,6 +6,7 @@ import os
 import sys
 import unicodedata
 
+from . import _version
 from . import settings
 
 
@@ -228,7 +229,8 @@ def config(
     settings.useful_tags_node = useful_tags_node
     settings.useful_tags_way = useful_tags_way
 
-    log("Configured OSMnx")
+    log(f"Configured OSMnx {_version.__version__}")
+    log(f"HTTP response caching is {'on' if settings.use_cache else 'off'}")
 
 
 def log(message, level=None, name=None, filename=None):

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -77,37 +77,37 @@ def ts(style="datetime", template=None):
 
 
 def config(
-    use_cache=settings.use_cache,
+    all_oneway=settings.all_oneway,
+    bidirectional_network_types=settings.bidirectional_network_types,
     cache_folder=settings.cache_folder,
     data_folder=settings.data_folder,
+    default_accept_language=settings.default_accept_language,
+    default_access=settings.default_access,
+    default_crs=settings.default_crs,
+    default_referer=settings.default_referer,
+    default_user_agent=settings.default_user_agent,
+    elevation_provider=settings.elevation_provider,
     imgs_folder=settings.imgs_folder,
-    logs_folder=settings.logs_folder,
-    log_file=settings.log_file,
     log_console=settings.log_console,
+    log_file=settings.log_file,
+    log_filename=settings.log_filename,
     log_level=settings.log_level,
     log_name=settings.log_name,
-    log_filename=settings.log_filename,
-    useful_tags_node=settings.useful_tags_node,
-    useful_tags_way=settings.useful_tags_way,
-    bidirectional_network_types=settings.bidirectional_network_types,
+    logs_folder=settings.logs_folder,
+    max_query_area_size=settings.max_query_area_size,
+    memory=settings.memory,
+    nominatim_endpoint=settings.nominatim_endpoint,
+    nominatim_key=settings.nominatim_key,
     osm_xml_node_attrs=settings.osm_xml_node_attrs,
     osm_xml_node_tags=settings.osm_xml_node_tags,
     osm_xml_way_attrs=settings.osm_xml_way_attrs,
     osm_xml_way_tags=settings.osm_xml_way_tags,
-    all_oneway=settings.all_oneway,
+    overpass_endpoint=settings.overpass_endpoint,
     overpass_settings=settings.overpass_settings,
     timeout=settings.timeout,
-    memory=settings.memory,
-    max_query_area_size=settings.max_query_area_size,
-    default_access=settings.default_access,
-    default_crs=settings.default_crs,
-    default_user_agent=settings.default_user_agent,
-    default_referer=settings.default_referer,
-    default_accept_language=settings.default_accept_language,
-    nominatim_endpoint=settings.nominatim_endpoint,
-    nominatim_key=settings.nominatim_key,
-    overpass_endpoint=settings.overpass_endpoint,
-    elevation_provider=settings.elevation_provider,
+    use_cache=settings.use_cache,
+    useful_tags_node=settings.useful_tags_node,
+    useful_tags_way=settings.useful_tags_way,
 ):
     """
     Configure OSMnx by setting the default global settings' values.
@@ -117,33 +117,54 @@ def config(
 
     Parameters
     ----------
-    use_cache : bool
-        if True, cache HTTP responses locally instead of calling API
-        repeatedly for the same request
+    all_oneway : bool
+        Only use if specifically saving to .osm XML file with save_graph_xml
+        function. if True, forces all ways to be loaded as oneway ways,
+        preserving the original order of nodes stored in the OSM way XML.
+    bidirectional_network_types : list
+        network types for which a fully bidirectional graph will be created
     cache_folder : string
         path to folder in which to save/load HTTP response cache
     data_folder : string
         path to folder in which to save/load graph files by default
+    default_accept_language : string
+        HTTP header accept-language
+    default_access : string
+        default filter for OSM "access" key
+    default_crs : string
+        default coordinate reference system to set when creating graphs
+    default_referer : string
+        HTTP header referer
+    default_user_agent : string
+        HTTP header user-agent
+    elevation_provider : string
+        the API provider to use for adding node elevations, can be either
+        "google" or "airmap"
     imgs_folder : string
         path to folder in which to save plot images by default
-    logs_folder : string
-        path to folder in which to save log files
     log_file : bool
         if True, save log output to a file in logs_folder
+    log_filename : string
+        name of the log file, without file extension
     log_console : bool
         if True, print log output to the console (terminal window)
     log_level : int
         one of Python's logger.level constants
     log_name : string
         name of the logger
-    log_filename : string
-        name of the log file, without file extension
-    useful_tags_node : list
-        OSM "node" tags to add as graph node attributes, when present
-    useful_tags_way : list
-        OSM "way" tags to add as graph edge attributes, when present
-    bidirectional_network_types : list
-        network types for which a fully bidirectional graph will be created
+    logs_folder : string
+        path to folder in which to save log files
+    max_query_area_size : int
+        maximum area for any part of the geometry in meters: any polygon
+        bigger than this will get divided up for multiple queries to API
+        (default 50km x 50km)
+    memory : int
+        Overpass server memory allocation size for the query, in bytes. If
+        None, server will use its default allocation size. Use with caution.
+    nominatim_endpoint : string
+        the API endpoint to use for nominatim queries
+    nominatim_key : string
+        your API key, if you are using an endpoint that requires one
     osm_xml_node_attrs : list
         node attributes for saving .osm XML files with save_graph_xml function
     osm_xml_node_tags : list
@@ -152,10 +173,8 @@ def config(
         edge attributes for saving .osm XML files with save_graph_xml function
     osm_xml_way_tags : list
         edge tags for for saving .osm XML files with save_graph_xml function
-    all_oneway : bool
-        if True, forces all ways to be loaded as oneway ways, preserving
-        the original order of nodes stored in the OSM way XML. Only use if
-        specifically saving to .osm XML file with save_graph_xml function.
+    overpass_endpoint : string
+        the API endpoint to use for overpass queries
     overpass_settings : string
         Settings string for overpass queries. For example, to query historical
         OSM data as of a certain date:
@@ -164,69 +183,50 @@ def config(
     timeout : int
         the timeout interval for the HTTP request and for API to use while
         running the query
-    memory : int
-        Overpass server memory allocation size for the query, in bytes. If
-        None, server will use its default allocation size. Use with caution.
-    max_query_area_size : int
-        maximum area for any part of the geometry in meters: any polygon
-        bigger than this will get divided up for multiple queries to API
-        (default 50km x 50km)
-    default_access : string
-        default filter for OSM "access" key
-    default_crs : string
-        default coordinate reference system to set when creating graphs
-    default_user_agent : string
-        HTTP header user-agent
-    default_referer : string
-        HTTP header referer
-    default_accept_language : string
-        HTTP header accept-language
-    nominatim_endpoint : string
-        the API endpoint to use for nominatim queries
-    nominatim_key : string
-        your API key, if you are using an endpoint that requires one
-    overpass_endpoint : string
-        the API endpoint to use for overpass queries
-    elevation_provider : string
-        the API provider to use for adding node elevations, can be either
-        "google" or "airmap"
+    use_cache : bool
+        if True, cache HTTP responses locally instead of calling API
+        repeatedly for the same request
+    useful_tags_node : list
+        OSM "node" tags to add as graph node attributes, when present
+    useful_tags_way : list
+        OSM "way" tags to add as graph edge attributes, when present
 
     Returns
     -------
     None
     """
-    # set each global setting to the passed-in value
-    settings.use_cache = use_cache
+    # set each global setting to the argument value
+    settings.all_oneway = all_oneway
+    settings.bidirectional_network_types = bidirectional_network_types
     settings.cache_folder = cache_folder
     settings.data_folder = data_folder
+    settings.default_accept_language = default_accept_language
+    settings.default_access = default_access
+    settings.default_crs = default_crs
+    settings.default_referer = default_referer
+    settings.default_user_agent = default_user_agent
+    settings.elevation_provider = elevation_provider
     settings.imgs_folder = imgs_folder
-    settings.logs_folder = logs_folder
     settings.log_console = log_console
     settings.log_file = log_file
+    settings.log_filename = log_filename
     settings.log_level = log_level
     settings.log_name = log_name
-    settings.log_filename = log_filename
-    settings.useful_tags_node = useful_tags_node
-    settings.useful_tags_way = useful_tags_way
+    settings.logs_folder = logs_folder
+    settings.max_query_area_size = max_query_area_size
+    settings.memory = memory
+    settings.nominatim_endpoint = nominatim_endpoint
+    settings.nominatim_key = nominatim_key
     settings.osm_xml_node_attrs = osm_xml_node_attrs
     settings.osm_xml_node_tags = osm_xml_node_tags
     settings.osm_xml_way_attrs = osm_xml_way_attrs
     settings.osm_xml_way_tags = osm_xml_way_tags
+    settings.overpass_endpoint = overpass_endpoint
     settings.overpass_settings = overpass_settings
     settings.timeout = timeout
-    settings.memory = memory
-    settings.max_query_area_size = max_query_area_size
-    settings.default_access = default_access
-    settings.default_crs = default_crs
-    settings.default_user_agent = default_user_agent
-    settings.default_referer = default_referer
-    settings.default_accept_language = default_accept_language
-    settings.nominatim_endpoint = nominatim_endpoint
-    settings.nominatim_key = nominatim_key
-    settings.overpass_endpoint = overpass_endpoint
-    settings.all_oneway = all_oneway
-    settings.elevation_provider = elevation_provider
-    settings.bidirectional_network_types = bidirectional_network_types
+    settings.use_cache = use_cache
+    settings.useful_tags_node = useful_tags_node
+    settings.useful_tags_way = useful_tags_way
 
     log("Configured OSMnx")
 

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -112,8 +112,8 @@ def config(
     """
     Configure OSMnx by setting the default global settings' values.
 
-    Any parameters not passed by the caller are set to their original default
-    values.
+    Any parameters not passed by the caller are (re-)set to their original
+    default values.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR:
  - removes the internal `_is_simplified` function as its functionality is easily replicated in a single line of code in the two places it's used
  - sorts the parameters of the `utils.config` function
  - adds the OSMnx version and current status of HTTP response caching to the log message when `utils.config` is run