### PR TITLE
add setting for cache only mode and implement in downloader module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.0.0 (TBD)
 
   - set use_cache=True by default
+  - add optional setting for download/cache-only mode
+  - replace md5 with sha1 for cache filename hashing
   - replace streets_per_node graph attribute with equivalent street_count node attribute
   - remove redundant osmid node attribute
   - make graph_to_gdfs multi-index the edges GeoDataFrame by u, v, key
@@ -12,6 +14,7 @@
   - refactor get_undirected functionality for better speed and efficiency
   - extract all private/internal .osm XML functionality into new osm_xml module
   - deprecate io.save_graph_xml with warning (function moved to osm_xml module)
+  - remove internal _is_simplified function
   - remove deprecated pois module
   - remove deprecated footprints module
   - remove deprecated utils_graph.induce_subgraph function

--- a/osmnx/_errors.py
+++ b/osmnx/_errors.py
@@ -1,6 +1,14 @@
 """Custom errors."""
 
 
+class CacheOnlyModeInterrupt(InterruptedError):  # pragma: no cover
+    """Exception for cache_only_mode interruption."""
+
+    def __init__(self, *args, **kwargs):
+        """Create exception."""
+        Exception.__init__(self, *args, **kwargs)
+
+
 class EmptyOverpassResponse(ValueError):  # pragma: no cover
     """Exception for empty overpass response."""
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -17,6 +17,7 @@ from . import projection
 from . import settings
 from . import utils
 from . import utils_geo
+from ._errors import CacheOnlyModeInterrupt
 
 
 def _get_osm_filter(network_type):
@@ -462,7 +463,7 @@ def _osm_net_download(polygon, network_type, custom_filter):
     )
 
     if settings.cache_only_mode:
-        raise InterruptedError("settings.cache_only_mode=True")
+        raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")
 
     return response_jsons
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -461,6 +461,9 @@ def _osm_net_download(polygon, network_type, custom_filter):
         f"Got all network data within polygon from API in {len(polygon_coord_strs)} request(s)"
     )
 
+    if settings.cache_only_mode:
+        raise InterruptedError("settings.cache_only_mode=True")
+
     return response_jsons
 
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -11,6 +11,11 @@ cache_folder = "cache"
 # cache server responses
 use_cache = True
 
+# if True, download network data from Overpass then raise InterruptedError.
+# useful for sequentially caching lots of raw data then using that cache to
+# quickly build many graphs simultaneously with multiprocessing
+cache_only_mode = False
+
 # write log to file and/or to console
 log_file = False
 log_console = False

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -11,7 +11,7 @@ cache_folder = "cache"
 # cache server responses
 use_cache = True
 
-# if True, download network data from Overpass then raise InterruptedError.
+# if True, download net data from Overpass then raise CacheOnlyModeInterrupt.
 # useful for sequentially caching lots of raw data then using that cache to
 # quickly build many graphs simultaneously with multiprocessing
 cache_only_mode = False

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -81,6 +81,7 @@ def config(
     all_oneway=settings.all_oneway,
     bidirectional_network_types=settings.bidirectional_network_types,
     cache_folder=settings.cache_folder,
+    cache_only_mode=settings.cache_only_mode,
     data_folder=settings.data_folder,
     default_accept_language=settings.default_accept_language,
     default_access=settings.default_access,
@@ -126,6 +127,14 @@ def config(
         network types for which a fully bidirectional graph will be created
     cache_folder : string
         path to folder in which to save/load HTTP response cache
+    cache_only_mode : bool
+        If True, download network data from Overpass then raise a
+        CacheOnlyModeInterrupt error for the user to catch. This prevents any
+        graph building from taking place and instead just saves the OSM
+        response data to the cache. This is useful for sequentially caching
+        lots of raw data (as you can only query Overpass one request at a
+        time) then using the cache to quickly build many graphs simultaneously
+        with multiprocessing.
     data_folder : string
         path to folder in which to save/load graph files by default
     default_accept_language : string
@@ -200,6 +209,7 @@ def config(
     settings.all_oneway = all_oneway
     settings.bidirectional_network_types = bidirectional_network_types
     settings.cache_folder = cache_folder
+    settings.cache_only_mode = cache_only_mode
     settings.data_folder = data_folder
     settings.default_accept_language = default_accept_language
     settings.default_access = default_access

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -196,12 +196,13 @@ def count_streets_per_node(G, nodes=None):
     """
     Count how many physical street segments connect to each node in a graph.
 
-    This function uses an undirected representation of the graph to count
-    physical streets rather than directed edges. Note: this function is
-    automatically run by all the `graph.graph_from_x` functions prior to
-    truncating the graph to the requested boundaries, to add accurate
-    `street_count` attributes to each node even if some of its neighbors are
-    outside the requested graph boundaries.
+    This function uses an undirected representation of the graph and special
+    handling of self-loops to accurately count physical streets rather than
+    directed edges. Note: this function is automatically run by all the
+    `graph.graph_from_x` functions prior to truncating the graph to the
+    requested boundaries, to add accurate `street_count` attributes to each
+    node even if some of its neighbors are outside the requested graph
+    boundaries.
 
     Parameters
     ----------


### PR DESCRIPTION
Add `cache_only_mode` setting. Can be configured via `ox.config()`. If True, `downloader._osm_net_download` will download the network data from Overpass then raise a `CacheOnlyModeInterrupt` error for the user to catch. This prevents any graph building from taking place and instead just saves the OSM response data to the cache. This is useful for sequentially caching lots of raw data (as you can only query Overpass one request at a time) then using that cache to quickly build many graphs simultaneously with multiprocessing.