### PR TITLE
Add query by OSM ID functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (TBD)
 
   - set use_cache=True by default
+  - add ability to query a place by OSM ID in geocoder.geocode_to_gdf function
   - add optional setting for download/cache-only mode
   - replace md5 with sha1 for cache filename hashing
   - replace streets_per_node graph attribute with equivalent street_count node attribute

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -496,7 +496,7 @@ def _osm_geometries_download(polygon, tags):
     return response_jsons
 
 
-def _osm_place_download(query, osmid=False, limit=1, polygon_geojson=1):
+def _osm_place_download(query, by_osmid=False, limit=1, polygon_geojson=1):
     """
     Retrieve a place from the Nominatim API.
 
@@ -504,8 +504,8 @@ def _osm_place_download(query, osmid=False, limit=1, polygon_geojson=1):
     ----------
     query : string or dict
         query string or structured query dict
-    osmid : bool
-        if True, treat query like an OSM ID for lookup rather than text search
+    by_osmid : bool
+        if True, handle query as an OSM ID for lookup rather than text search
     limit : int
         max number of results to return
     polygon_geojson : int
@@ -521,7 +521,7 @@ def _osm_place_download(query, osmid=False, limit=1, polygon_geojson=1):
     params["format"] = "json"
     params["polygon_geojson"] = polygon_geojson
 
-    if osmid:
+    if by_osmid:
         # if querying by OSM ID, use the lookup endpoint
         request_type = "lookup"
         params["osm_ids"] = query

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -351,7 +351,7 @@ def _create_overpass_query(polygon_coord_str, tags):
     polygon_coord_str : list
         list of lat lng coordinates
     tags : dict
-        dict of tags used for finding geometry in the selected area
+        dict of tags used for finding elements in the selected area
 
     Returns
     -------
@@ -413,22 +413,23 @@ def _create_overpass_query(polygon_coord_str, tags):
     return query
 
 
-def _osm_net_download(polygon, network_type, custom_filter):
+def _osm_network_download(polygon, network_type, custom_filter):
     """
-    Download OSM ways and nodes within some polygon from the Overpass API.
+    Retrieve networked ways and nodes within boundary from the Overpass API.
 
     Parameters
     ----------
     polygon : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
-        geographic boundaries to fetch the street network within
+        boundary to fetch the network ways/nodes within
     network_type : string
-        what type of street network to get if custom_filter is not None
+        what type of network to get if custom_filter is not None
     custom_filter : string
         a custom network filter to be used instead of the network_type presets
 
     Returns
     -------
     response_jsons : list
+        list of JSON responses from the Overpass server
     """
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type, if provided, otherwise use custom_filter
@@ -461,19 +462,16 @@ def _osm_net_download(polygon, network_type, custom_filter):
     return response_jsons
 
 
-def _osm_geometry_download(polygon, tags):
+def _osm_geometries_download(polygon, tags):
     """
-    Download all OSM geometry within some polygon from the Overpass API.
-
-    Note that if a polygon is passed-in, the query will be limited to the
-    exterior ring only.
+    Retrieve non-networked elements within boundary from the Overpass API.
 
     Parameters
     ----------
     polygon : shapely.geometry.Polygon
-        geographic boundaries to fetch geometry within
+        boundaries to fetch elements within
     tags : dict
-        dict of tags used for finding geometry in the selected area
+        dict of tags used for finding elements in the selected area
 
     Returns
     -------
@@ -492,30 +490,31 @@ def _osm_geometry_download(polygon, tags):
         response_jsons.append(response_json)
 
     utils.log(
-        f"Got all geometry data within polygon from API in {len(polygon_coord_strs)} request(s)"
+        f"Got all geometries data within polygon from API in {len(polygon_coord_strs)} request(s)"
     )
 
     return response_jsons
 
 
-def _osm_polygon_download(query, osmid=False, limit=1, polygon_geojson=1):
+def _osm_place_download(query, osmid=False, limit=1, polygon_geojson=1):
     """
-    Download a place's boundary from the Nominatim API.
+    Retrieve a place from the Nominatim API.
 
     Parameters
     ----------
     query : string or dict
-        query string or structured query dict to search for
+        query string or structured query dict
     osmid : bool
         if True, treat query like an OSM ID for lookup rather than text search
     limit : int
         max number of results to return
     polygon_geojson : int
-        request the boundary geometry from the API, 0=no, 1=yes
+        retrieve the place's geometry from the API, 0=no, 1=yes
 
     Returns
     -------
     response_json : dict
+        JSON response from the Nominatim server
     """
     # define the parameters
     params = OrderedDict()

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -133,7 +133,8 @@ def _geocode_query_to_gdf(query, which_result, by_osmid):
         query string or structured dict to geocode
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        (Multi)Polygon or raise an error if OSM doesn't return one.
+        (Multi)Polygon or raise an error if OSM doesn't return one. to keep
+        the best match regardless of geometry type, set which_result=1
     by_osmid : bool
         if True, handle query as an OSM ID for lookup rather than text search
 

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -29,7 +29,7 @@ def geocode(query):
     params = OrderedDict()
     params["format"] = "json"
     params["limit"] = 1
-    params["dedupe"] = 0  # prevent OSM deduping results so we get precisely 'limit' # of results
+    params["dedupe"] = 0  # prevent deduping to get precise number of results
     params["q"] = query
     response_json = downloader.nominatim_request(params=params)
 
@@ -49,14 +49,17 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
     Geocode a query or queries to a GeoDataFrame with the Nominatim API.
 
     The resulting GeoDataFrame's geometry column contains place boundaries if
-    they exist in OpenStreetMap. The query can be a place name string or
-    structured dict, or a list of such strings/dicts to send to the geocoder.
+    they exist in OpenStreetMap. The query argument can be a place name string
+    or structured dict, or a list of such strings/dicts to send to geocoder.
     If query is a list, then which_result should be either a single value or a
     list with the same length as query.
 
-    You can query by OSM ID with `by_osmid=True`. The OSM ID query value(s)
-    must be prepended with their types: node (N), way (W), or relation (R).
-    For example, `query='["R2192363", "N240109189", "W427818536"]'`.
+    You can instead query by OSM ID by setting `by_osmid=True`. In this case,
+    geocode_to_gdf treats the query argument as an OSM ID (or list of OSM IDs)
+    for Nominatim lookup rather than text search. OSM IDs must be prepended
+    with their types: node (N), way (W), or relation (R), in accordance with
+    the Nominatim format. For example, `query='["R2192363", "N240109189",
+    "W427818536"]'`.
 
     Parameters
     ----------
@@ -64,7 +67,8 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
         query string(s) or structured dict(s) to geocode
     which_result : int
         which geocoding result to use. if None, auto-select the first
-        (Multi)Polygon or raise an error if OSM doesn't return one.
+        (Multi)Polygon or raise an error if OSM doesn't return one. to keep
+        the best match regardless of geometry type, set which_result=1
     by_osmid : bool
         if True, handle query as an OSM ID for lookup rather than text search
     buffer_dist : float

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -143,7 +143,7 @@ def _geocode_query_to_gdf(query, which_result, osmid):
     else:
         limit = which_result
 
-    results = downloader._osm_polygon_download(query, osmid=osmid, limit=limit)
+    results = downloader._osm_place_download(query, osmid=osmid, limit=limit)
 
     # choose the right result from the JSON response
     if not results:
@@ -201,7 +201,7 @@ def _get_first_polygon(results, query):
     Parameters
     ----------
     results : list
-        list of results from downloader._osm_polygon_download
+        list of results from downloader._osm_place_download
     query : str
         the query string or structured dict that was geocoded
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -260,7 +260,7 @@ def geometries_from_polygon(polygon, tags):
         )
 
     # download the geometry data from OSM
-    response_jsons = downloader._osm_geometry_download(polygon, tags)
+    response_jsons = downloader._osm_geometries_download(polygon, tags)
 
     # create GeoDataFrame from the downloaded data
     gdf = _create_gdf(response_jsons, polygon, tags)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -421,7 +421,7 @@ def graph_from_polygon(
         poly_buff, _ = projection.project_geometry(poly_proj_buff, crs=crs_utm, to_latlong=True)
 
         # download the network data from OSM within buffered polygon
-        response_jsons = downloader._osm_net_download(poly_buff, network_type, custom_filter)
+        response_jsons = downloader._osm_network_download(poly_buff, network_type, custom_filter)
 
         # create buffered graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types
@@ -453,7 +453,7 @@ def graph_from_polygon(
     # if clean_periphery=False, just use the polygon as provided
     else:
         # download the network data from OSM
-        response_jsons = downloader._osm_net_download(polygon, network_type, custom_filter)
+        response_jsons = downloader._osm_network_download(polygon, network_type, custom_filter)
 
         # create graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types


### PR DESCRIPTION
Resolves #620. Simple demonstration: 

```python
# query by place name, same as before
query = ["Copenhagen", "Berlin", "Central Park, New York"]
gdf = ox.geocode_to_gdf(query)

# new ability to query by OSM ID
query = ["R2192363", "N240109189", "W427818536"]
gdf = ox.geocode_to_gdf(query, by_osmid=True)
```

By passing `by_osmid=True`, the `geocode_to_gdf` function will treat the `query` argument as an OSM ID (or list of OSM IDs) for [Nominatim lookup](https://nominatim.org/release-docs/develop/api/Lookup/) rather than text search. Note that each integer OSM ID must be represented as a string with an N, W, or R prepended to identify its type (node, way, or relation) in accordance with the Nominatim format.