### PR TITLE
Remove Python2 numeric relics

### DIFF
--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -41,7 +41,7 @@ def get_bearing(origin_point, destination_point):
 
     # normalize initial bearing to 0-360 degrees to get compass bearing
     initial_bearing = math.degrees(initial_bearing)
-    bearing = (initial_bearing + 360) % 360
+    bearing = initial_bearing % 360
 
     return bearing
 

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -22,7 +22,7 @@ except ImportError:
     BallTree = None
 
 
-def great_circle_vec(lat1, lng1, lat2, lng2, earth_radius=6371009):
+def great_circle_vec(lat1, lng1, lat2, lng2, earth_radius=6_371_009):
     """
     Calculate great-circle distances between points.
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -595,7 +595,7 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1000.0
+        size_kb = len(response.content) / 1000
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
         utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
 
@@ -663,7 +663,7 @@ def overpass_request(data, pause=None, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1000.0
+        size_kb = len(response.content) / 1000
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
         utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -595,7 +595,7 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1000
+        size_kb = len(response.content) / 1024
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
         utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
 
@@ -663,7 +663,7 @@ def overpass_request(data, pause=None, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1000
+        size_kb = len(response.content) / 1024
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
         utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
 

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -595,9 +595,9 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1024
+        size_kb = len(response.content) / 1000
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
-        utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
+        utils.log(f"Downloaded {size_kb:,.1f}kB from {domain}")
 
         try:
             response_json = response.json()
@@ -663,9 +663,9 @@ def overpass_request(data, pause=None, error_pause=60):
         sc = response.status_code
 
         # log the response size and domain
-        size_kb = len(response.content) / 1024
+        size_kb = len(response.content) / 1000
         domain = re.findall(r"(?s)//(.*?)/", url)[0]
-        utils.log(f"Downloaded {size_kb:,.1f}KB from {domain}")
+        utils.log(f"Downloaded {size_kb:,.1f}kB from {domain}")
 
         try:
             response_json = response.json()

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -157,7 +157,7 @@ def add_edge_grades(G, add_absolute=True, precision=3):
 
         try:
             # divide by edge length then round
-            edge_grade = float(elevation_change) / float(data["length"])
+            edge_grade = elevation_change / data["length"]
             data["grade"] = round(edge_grade, precision)
         except ZeroDivisionError:
             data["grade"] = np.nan

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -785,8 +785,8 @@ def _config_ax(ax, crs, bbox, padding):
     # set aspect ratio
     if crs == settings.default_crs:
         # if data are not projected, conform aspect ratio to not stretch plot
-        coslat = np.cos((south + north) / 2.0 / 180.0 * np.pi)
-        ax.set_aspect(1.0 / coslat)
+        coslat = np.cos((south + north) / 2 / 180 * np.pi)
+        ax.set_aspect(1 / coslat)
     else:
         # if projected, make everything square
         ax.set_aspect("equal")

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -91,7 +91,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
         avg_lng = gdf["geometry"].unary_union.centroid.x
 
         # calculate UTM zone from avg longitude to define CRS to project to
-        utm_zone = int(math.floor((avg_lng + 180) / 6.0) + 1)
+        utm_zone = math.floor((avg_lng + 180) / 6) + 1
         utm_crs = f"+proj=utm +zone={utm_zone} +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
 
         # project the GeoDataFrame to the UTM CRS

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -82,7 +82,7 @@ def basic_stats(G, area=None, clean_intersects=False, tolerance=15, circuity_dis
           - clean_intersection_density_km = clean_intersection_count divided
                 by area in square kilometers
     """
-    sq_m_in_sq_km = 1e6  # there are 1 million sq meters in 1 sq km
+    sq_m_in_sq_km = 1_000_000  # there are 1 million sq meters in 1 sq km
     Gu = None
     node_ids = set(G.nodes)
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -40,7 +40,7 @@ def redistribute_vertices(geom, dist):
         MultiLineString if geom is a MultiLineString
     """
     if geom.geom_type == "LineString":
-        num_vert = int(round(geom.length / dist))
+        num_vert = round(geom.length / dist)
         if num_vert == 0:
             num_vert = 1
         return [geom.interpolate(float(n) / num_vert, normalized=True) for n in range(num_vert + 1)]

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -43,7 +43,7 @@ def redistribute_vertices(geom, dist):
         num_vert = round(geom.length / dist)
         if num_vert == 0:
             num_vert = 1
-        return [geom.interpolate(float(n) / num_vert, normalized=True) for n in range(num_vert + 1)]
+        return [geom.interpolate(n / num_vert, normalized=True) for n in range(num_vert + 1)]
     elif geom.geom_type == "MultiLineString":
         parts = [redistribute_vertices(part, dist) for part in geom]
         return type(geom)([p for p in parts if not p])

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -408,7 +408,7 @@ def bbox_from_point(point, dist=1000, project_utm=False, return_crs=False):
     tuple
         (north, south, east, west) or (north, south, east, west, crs_proj)
     """
-    earth_radius = 6371009  # meters
+    earth_radius = 6_371_009  # meters
     lat, lng = point
 
     delta_lat = (dist / earth_radius) * (180 / math.pi)


### PR DESCRIPTION
Remove code used in Python2 that is no more necessary in Python3, such as:

- `a / b` for two integers returns a float, so it is no more necessary to convert one or both to floats before the division
- `math.floor`, `math.ceil`, and `round` return integers

And a few numeric fixes or visual improvements.