### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
     name: Python ${{ matrix.python-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']

--- a/environments/docker/Dockerfile
+++ b/environments/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN conda config --set show_channel_urls true && \
     conda config --set channel_priority strict && \
     conda config --prepend channels conda-forge && \
     conda update --yes -n base conda && \
-    conda install --update-all --force-reinstall --yes --file /tmp/requirements.txt python-igraph && \
+    conda install --update-all --force-reinstall --yes --file /tmp/requirements.txt && \
     rm -f -r -v /opt/conda/share/jupyter/kernels/python3 && \
     python -m ipykernel install --sys-prefix --name ox --display-name "Python (ox)" && \
     conda clean --all --yes && \

--- a/environments/docker/requirements.txt
+++ b/environments/docker/requirements.txt
@@ -25,11 +25,11 @@ pyproj
 pysal
 pytest
 python == 3.9.*
+python-igraph
 rasterio
 seaborn
 scikit-learn
 scipy
 sphinx
 statsmodels
-twine
 urbanaccess

--- a/environments/linux/create-environment.sh
+++ b/environments/linux/create-environment.sh
@@ -7,7 +7,7 @@ conda clean --all --yes --quiet
 conda config --set show_channel_urls true
 conda config --set channel_priority strict
 conda config --prepend channels conda-forge
-mamba create -n ox --file "../docker/requirements.txt" python-igraph --yes
+mamba create -n ox --file "../docker/requirements.txt" --yes
 eval "$(conda shell.bash hook)"
 conda activate ox
 pip uninstall osmnx --yes

--- a/environments/windows/create-environment.bat
+++ b/environments/windows/create-environment.bat
@@ -8,7 +8,6 @@ CALL mamba create -n ox --file "../docker/requirements.txt" --yes
 CALL conda activate ox
 CALL pip uninstall osmnx --yes
 CALL pip install -e ../../.
-CALL pip install https://ocf.berkeley.edu/~gboeing/share/python_igraph-0.8.3-cp39-cp39-win_amd64.whl
 CALL python -m ipykernel install --sys-prefix --name ox --display-name "Python (ox)"
 CALL conda clean --all --yes --quiet
 CALL conda env export > environment.yml

--- a/tests/git-repack.sh
+++ b/tests/git-repack.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+git repack -a -d -f --depth=250 --window=250


### PR DESCRIPTION
  - disable fail fast, so all platforms get tested without canceling if one fails
  - add git repack script
  - for environment creation, move python-igraph to requirements file now that it's available from conda-forge on windows