### PR TITLE
Replace slow pandas operation with faster groupby

### DIFF
--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -295,8 +295,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
     gdf_edges.reset_index(inplace=True)
     if merge_edges:
 
-        for e in gdf_edges["id"].unique():
-            all_way_edges = gdf_edges[gdf_edges["id"] == e]
+        for _, all_way_edges in gdf_edges.groupby("id"):
             first = all_way_edges.iloc[0]
             edge = etree.SubElement(root, "way", attrib=first[edge_attrs].dropna().to_dict())
 


### PR DESCRIPTION
Resolves #645

**Description:** Speed up save_graph_xml by replacing O(edges^2) pandas operation with O(edges) groupby operation. Change is just an implementation change, there are no feature changes. 
[Edit, removed: Change to tests/test_osmnx.py was an formatting change made by black.]

**Minimum code example to exercise change:**
```
import osmnx as ox
ox.config(log_console=True, all_oneway=True)
osm_xml = ox.graph.graph_from_xml('input.osm', simplify=True)
ox.save_graph_xml(osm_xml, filepath='output.osm')
```
