### PR TITLE
Adds optional return_dist option to get_nearest_nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
   - improve save_graph_xml speed
+  - optionally return distances in nearest nodes search
 
 ## 1.0.1 (2021-01-13)
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -224,9 +224,13 @@ def test_find_nearest():
     # get nearest nodes: haversine, kdtree, balltree
     X = gdf_nodes["x"].head()
     Y = gdf_nodes["y"].head()
-    nn1 = ox.get_nearest_nodes(G, X, Y)
-    nn2 = ox.get_nearest_nodes(G, X, Y, method="kdtree")
-    nn3 = ox.get_nearest_nodes(G, X, Y, method="balltree")
+
+    nn1, dist1 = ox.get_nearest_nodes(G, X, Y, return_dist=True)
+    nn2, dist2 = ox.get_nearest_nodes(G, X, Y, method="kdtree", return_dist=True)
+    nn3, dist3 = ox.get_nearest_nodes(G, X, Y, method="balltree", return_dist=True)
+    nn4 = ox.get_nearest_nodes(G, X, Y)
+    nn5 = ox.get_nearest_nodes(G, X, Y, method="kdtree")
+    nn6 = ox.get_nearest_nodes(G, X, Y, method="balltree")
 
     # get nearest edge
     u, v, k, g, d = ox.get_nearest_edge(G, location_point, return_geom=True, return_dist=True)


### PR DESCRIPTION
This PR fixes #649 and adds an optional `return_dist` parameter to `osmnx.distance.get_neareast_nodes()`

Usage example:

```python
nn1, dist1 = ox.get_nearest_nodes(G, X, Y, return_dist=True)
```
