### PR TITLE
make node ids integers when consolidating intersections

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -533,6 +533,9 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
                     gdf.loc[wcc, "cluster"] = f"{cluster_label}-{suffix}"
                     suffix += 1
 
+    # reassign integer cluster labels since wccs with suffixes have string labels
+    gdf["cluster"] = gdf["cluster"].factorize()[0]
+
     # STEP 4
     # create new empty graph and copy over misc graph data
     H = nx.MultiDiGraph()


### PR DESCRIPTION
resolves #647 

When consolidating intersections, weakly connected components in the
same cluster are separated and given different cluster labels. The
cluster label is the original cluster label, plus a suffix for the
component, separated by a '-'. Since osm xml format requires integer
osmids, the clusters need to be renamed after components are separated.