### PR TITLE
specify bool conversion function manually

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,16 +14,16 @@ Boeing, G. 2017. `OSMnx: New Methods for Acquiring, Constructing, Analyzing, and
 Installation
 ------------
 
-You can install OSMnx with conda:
+You can install OSMnx with `conda`_:
 
 .. code-block:: shell
 
     conda config --prepend channels conda-forge
     conda create -n ox --strict-channel-priority osmnx
 
-If you want other packages, such as :code:`jupyterlab`, installed in this environment as well, just add their names after :code:`osmnx` above. See the `conda`_ documentation for further details. To upgrade OSMnx to a newer release, just remove the conda environment you created and then create a new one again, as above. Don't just run "conda update" or you could get package conflicts.
+If you want other packages, such as :code:`jupyterlab`, installed in this environment as well, just add their names after :code:`osmnx` above. See the conda documentation for further details. To upgrade OSMnx to a newer release, remove the conda environment you created and then create a new one again, as above. Don't just run "conda update" or you could get package conflicts.
 
-You can also run OSMnx + Jupyter directly from its official `Docker container`_, or you can install OSMnx via `pip`_ if you already have all of its dependencies installed and fully tested on your system. Note: installing the dependencies with pip is nontrivial. If you don't know *exactly* what you're doing, just use conda as described above.
+You can also run OSMnx + Jupyter directly from its official `Docker container`_, or you can install OSMnx via `pip`_ if you already have all of its dependencies installed and fully tested on your system. Note: installing the dependencies with pip is nontrivial. If you don't know exactly what you're doing, just use conda as described above.
 
 .. _conda: https://conda.io/
 .. _Docker container: https://hub.docker.com/r/gboeing/osmnx
@@ -34,7 +34,7 @@ You can also run OSMnx + Jupyter directly from its official `Docker container`_,
 Usage
 -----
 
-To get started with sample code and usage examples/demos, see the `examples`_ GitHub repo and read the `user reference`_.
+To **get started** with OSMnx, read its `user reference`_ and work through its `examples`_ repo for introductory usage demonstrations and sample code. Make sure you have read the `GeoPandas`_ and `NetworkX`_ user guides if you're not already familiar with these packages, as OSMnx uses their data structures and functionality.
 
 OSMnx is built on top of GeoPandas, NetworkX, and matplotlib and interacts with OpenStreetMap's APIs to:
 
@@ -61,8 +61,10 @@ OSMnx automatically processes network topology from the original raw OpenStreetM
 
 Usage examples and demonstrations of these features are in the `examples`_ GitHub repo. More feature development details are in the `change log`_. Read the `journal article`_ for further technical details. Package usage is detailed in the `user reference`_.
 
-.. _examples: https://github.com/gboeing/osmnx-examples
 .. _user reference: osmnx.html
+.. _examples: https://github.com/gboeing/osmnx-examples
+.. _GeoPandas: https://geopandas.org/
+.. _NetworkX: https://networkx.org/
 .. _journal article: https://geoffboeing.com/publications/osmnx-complex-street-networks/
 .. _change log: https://github.com/gboeing/osmnx/blob/master/CHANGELOG.md
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -177,7 +177,10 @@ def load_graphml(filepath, node_dtypes=None, edge_dtypes=None, graph_dtypes=None
     functions. For example, if you want to convert some attribute's values to
     `bool`, consider using the built-in `ox.io._convert_bool_string` function
     to properly handle "True"/"False" string literals as True/False booleans:
-    `ox.load_graphml(fp, node_dtypes={"my_attr": ox.io._convert_bool_string})`
+    `ox.load_graphml(fp, node_dtypes={my_attr: ox.io._convert_bool_string})`
+
+    If you manually configured the `all_oneway=True` setting, you may need to
+    manually specify here that edge `oneway` attributes should be type `str`.
 
     Parameters
     ----------

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -337,9 +337,9 @@ def test_graph_save_load():
     filepath = Path(ox.settings.data_folder) / "graph.graphml"
     G2 = ox.load_graphml(
         filepath,
-        graph_dtypes={attr_name: bool},
-        node_dtypes={attr_name: bool},
-        edge_dtypes={attr_name: bool},
+        graph_dtypes={attr_name: ox.io._convert_bool_string},
+        node_dtypes={attr_name: ox.io._convert_bool_string},
+        edge_dtypes={attr_name: ox.io._convert_bool_string},
     )
 
     # verify everything in G is equivalent in G2


### PR DESCRIPTION
This PR amends #670 and further resolves #665.

@guibar after giving it more thought, I came to believe that the previous method of silently replacing `bool` types with a custom converter function was too obfuscated and would result in difficult to understand behavior. I've amended the fix to now clarify that the user should specify a custom converter function if they want to convert "True"/"False" string literals to True/False booleans, and pointed them to how to use the built-in `io._convert_bool_string` as an example in the docstring:
```python
ox.load_graphml(fp, node_dtypes={"my_attr": ox.io._convert_bool_string})
```