### PR TITLE
refactor stats module

### DIFF
--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -8,7 +8,7 @@ import numpy as np
 # scipy is an optional dependency for entropy calculation
 try:
     import scipy
-except ImportError:
+except ImportError:  # pragma: no cover
     scipy = None
 
 
@@ -33,7 +33,9 @@ def get_bearing(origin_point, destination_point):
         the compass bearing in decimal degrees from the origin point to the
         destination point
     """
-    if not (isinstance(origin_point, tuple) and isinstance(destination_point, tuple)):
+    if not (
+        isinstance(origin_point, tuple) and isinstance(destination_point, tuple)
+    ):  # pragma: no cover
         raise TypeError("origin_point and destination_point must be (lat, lng) tuples")
 
     # get latitudes and the difference in longitude, as radians
@@ -119,7 +121,7 @@ def orientation_entropy(Gu, num_bins=36, min_length=0, weight=None):
         the graph's orientation entropy
     """
     # check if we were able to import scipy
-    if scipy is None:
+    if scipy is None:  # pragma: no cover
         raise ImportError("scipy must be installed to calculate entropy")
     bin_counts, _ = _bearings_distribution(Gu, num_bins, min_length, weight)
     return scipy.stats.entropy(bin_counts)
@@ -150,7 +152,7 @@ def _extract_edge_bearings(Gu, min_length=0, weight=None):
     bearings : numpy.array
         the graph's bidirectional edge bearings
     """
-    if nx.is_directed(Gu):
+    if nx.is_directed(Gu):  # pragma: no cover
         raise ValueError("`Gu` must be undirected")
     bearings = list()
     for _, _, data in add_edge_bearings(Gu).edges(data=True):

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -139,7 +139,6 @@ def plot_orientation(
     title_y=1.05,
     title_font=None,
     xtick_font=None,
-    ytick_font=None,
 ):
     """
     Plot a polar histogram of a spatial network's bidirectional edge bearings.
@@ -175,11 +174,9 @@ def plot_orientation(
     title_y : float
         y position to place title
     title_font : dict
-        the title's matplotlib fontdict
+        the title's fontdict to pass to matplotlib
     xtick_font : dict
-        the xtick labels' matplotlib fontdict
-    ytick_font : dict
-        the ytick labels' matplotlib fontdict
+        the xtick labels' fontdict to pass to matplotlib
 
     Returns
     -------
@@ -196,14 +193,6 @@ def plot_orientation(
             "alpha": 1.0,
             "zorder": 3,
         }
-    if ytick_font is None:
-        ytick_font = {
-            "family": "DejaVu Sans",
-            "size": 9,
-            "weight": "bold",
-            "alpha": 0.2,
-            "zorder": 3,
-        }
 
     # get the bearings' distribution's bin counts and edges
     bin_counts, bin_edges = bearing._bearings_distribution(Gu, num_bins, min_length, weight)
@@ -216,14 +205,13 @@ def plot_orientation(
     width = 2 * np.pi / num_bins
 
     # radius: how long to make each bar
-    radius_height = bin_counts / bin_counts.sum()
+    bin_frequency = bin_counts / bin_counts.sum()
     if area:
         # set bar length so area is proportional to frequency
-        radius_area = np.sqrt(radius_height)
-        radius = radius_area
+        radius = np.sqrt(bin_frequency)
     else:
         # set bar length so height is proportional to frequency
-        radius = radius_height
+        radius = bin_frequency
 
     # create ax (if necessary) then set N at top and go clockwise
     if ax is None:
@@ -238,12 +226,9 @@ def plot_orientation(
         # set the title
         ax.set_title(title, y=title_y, fontdict=title_font)
 
-    # configure the y-ticks and their labels; always use radius_height so
-    # labels mean relative frequency of edges in each bin
-    labels = np.linspace(0, radius_height.max(), 5)
-    yticklabels = [""] + [f"{y:.2f}" for y in labels[1:]]
+    # configure the y-ticks and remove their labels
     ax.set_yticks(np.linspace(0, radius.max(), 5))
-    ax.set_yticklabels(labels=yticklabels, fontdict=ytick_font)
+    ax.set_yticklabels(labels="")
 
     # configure the x-ticks and their labels
     xticklabels = ["N", "", "E", "", "S", "", "W", ""]

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -477,7 +477,7 @@ def plot_figure_ground(
     else:
         raise ValueError("You must pass an address or lat-lng point or graph.")
 
-    # we need an undirected graph to find every edge incident to a node
+    # we need an undirected graph to find every edge incident on a node
     Gu = utils_graph.get_undirected(G)
 
     # for each edge, get a linewidth according to street type

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -152,13 +152,9 @@ def plot_orientation(
         number of bins; for example, if `num_bins=36` is provided, then each
         bin will represent 10° around the compass
     min_length : float
-        ignore edges with `length` attributes less than `min_length`; useful
-        to ignore the noise of many very short edges
+        ignore edges with `length` attributes less than `min_length`
     weight : string
-        if not None, weight edges' bearings by this (non-null) edge attribute.
-        for example, if "length" is provided, this will return 1 bearing
-        observation per meter per street, which could result in a very large
-        `bearings` array.
+        if not None, weight edges' bearings by this (non-null) edge attribute
     ax : matplotlib.axes.PolarAxesSubplot
         if not None, plot on this preexisting axis; must have projection=polar
     figsize : tuple
@@ -223,7 +219,7 @@ def plot_orientation(
     radius_height = bin_counts / bin_counts.sum()
     if area:
         # set bar length so area is proportional to frequency
-        radius_area = np.sqrt(bin_counts / num_bins / np.pi)
+        radius_area = np.sqrt(radius_height)
         radius = radius_area
     else:
         # set bar length so height is proportional to frequency
@@ -242,7 +238,8 @@ def plot_orientation(
         # set the title
         ax.set_title(title, y=title_y, fontdict=title_font)
 
-    # configure the y-ticks and their labels
+    # configure the y-ticks and their labels; always use radius_height so
+    # labels mean relative frequency of edges in each bin
     labels = np.linspace(0, radius_height.max(), 5)
     yticklabels = [""] + [f"{y:.2f}" for y in labels[1:]]
     ax.set_yticks(np.linspace(0, radius.max(), 5))

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 
 from . import graph
+from . import projection
 from . import settings
 from . import simplification
 from . import utils
@@ -783,12 +784,12 @@ def _config_ax(ax, crs, bbox, padding):
     ax.get_yaxis().set_visible(False)
 
     # set aspect ratio
-    if crs == settings.default_crs:
-        # if data are not projected, conform aspect ratio to not stretch plot
-        coslat = np.cos((south + north) / 2 / 180 * np.pi)
-        ax.set_aspect(1 / coslat)
-    else:
-        # if projected, make everything square
+    if projection.is_projected(crs):
+        # if projected, make equal aspect ratio
         ax.set_aspect("equal")
+    else:
+        # if not projected, conform aspect ratio to not stretch plot
+        cos_lat = np.cos((south + north) / 2 / 180 * np.pi)
+        ax.set_aspect(1 / cos_lat)
 
     return ax

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -10,6 +10,25 @@ from . import utils
 from . import utils_graph
 
 
+def is_projected(crs):
+    """
+    Determine if a coordinate reference system is projected or not.
+
+    This is a convenience wrapper around the pyproj.CRS.is_projected function.
+
+    Parameters
+    ----------
+    crs : string or pyproj.CRS
+        the coordinate reference system
+
+    Returns
+    -------
+    projected : bool
+        True if crs is projected, otherwise False
+    """
+    return CRS.from_user_input(crs).is_projected
+
+
 def project_geometry(geometry, crs=None, to_crs=None, to_latlong=False):
     """
     Project a shapely geometry from its current CRS to another.
@@ -84,7 +103,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
 
     # otherwise, automatically project the gdf to UTM
     else:
-        if CRS.from_user_input(gdf.crs).is_projected:
+        if is_projected(gdf.crs):
             raise ValueError("Geometry must be unprojected to calculate UTM zone")
 
         # calculate longitude of centroid of union of all geometries in gdf

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -598,7 +598,7 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
             y = H.nodes[cluster_label]["y"]
             xy = [(x, y)]
 
-            # for each edge incident to this new merged node, update its
+            # for each edge incident on this new merged node, update its
             # geometry to extend to/from the new node's point coords
             in_edges = set(H.in_edges(cluster_label, keys=True))
             out_edges = set(H.out_edges(cluster_label, keys=True))

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -1,7 +1,15 @@
 """
 Calculate geometric and topological network measures.
 
-TO-DO: Describe correct intersection counts from buffering and counting.
+This module defines streets as the edges in an undirected representation of
+the graph. Using undirected graph edges prevents double-counting bidirectional
+edges of a two-way street, but may double-count a divided road's separate
+centerlines with different end point nodes. If `clean_periphery=True` when the
+graph was created (which is the default parameterization), then you will get
+accurate node degrees (and in turn streets-per-node counts) even at the
+periphery of the graph.
+
+You can use NetworkX directly for additional topological network measures.
 """
 
 import logging as lg
@@ -20,10 +28,6 @@ from . import utils_graph
 def streets_per_node(G):
     """
     Count streets (undirected edges) incident on each node.
-
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
 
     Parameters
     ----------
@@ -45,10 +49,6 @@ def streets_per_node_avg(G):
     """
     Calculate graph's average count of streets per node.
 
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
-
     Parameters
     ----------
     G : networkx.MultiDiGraph
@@ -66,10 +66,6 @@ def streets_per_node_avg(G):
 def streets_per_node_counts(G):
     """
     Calculate streets-per-node counts.
-
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
 
     Parameters
     ----------
@@ -89,10 +85,6 @@ def streets_per_node_counts(G):
 def streets_per_node_proportions(G):
     """
     Calculate streets-per-node proportions.
-
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
 
     Parameters
     ----------
@@ -115,9 +107,7 @@ def intersection_count(G=None, min_streets=2):
     Count the intersections in a graph.
 
     Intersections are defined as nodes with at least `min_streets` number of
-    streets incident on them. Prevents double-counting bidirectional edges of
-    a two-way street, but may double-count a divided road's separate
-    centerlines with different end point nodes.
+    streets incident on them.
 
     Parameters
     ----------
@@ -141,10 +131,6 @@ def street_segment_count(Gu):
     """
     Count the street segments in a graph.
 
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
-
     Parameters
     ----------
     Gu : networkx.MultiGraph
@@ -163,10 +149,6 @@ def street_segment_count(Gu):
 def street_length_total(Gu):
     """
     Calculate graph's total street segment length.
-
-    Prevents double-counting bidirectional edges of a two-way street, but may
-    double-count a divided road's separate centerlines with different end
-    point nodes.
 
     Parameters
     ----------
@@ -205,8 +187,6 @@ def self_loop_proportion(Gu):
     Calculate percent of edges that are self-loops in a graph.
 
     A self-loop is defined as an edge from node `u` to node `v` where `u==v`.
-    Using an undirected graph prevents double-counting bidirectional edges of
-    two-way streets.
 
     Parameters
     ----------
@@ -230,9 +210,6 @@ def circuity_avg(Gu):
     Circuity is the sum of edge lengths divided by the sum of straight-line
     distances between edge endpoints. Calculates straight-line distance as
     euclidean distance if projected or great-circle distance if unprojected.
-    Using undirected graph edges prevents double-counting bidirectional edges
-    of a two-way street, but may double-count a divided road's separate
-    centerlines with different end point nodes.
 
     Parameters
     ----------
@@ -313,27 +290,27 @@ def basic_stats(
     Returns
     -------
     stats : dict
-        dictionary with the following attributes: `n` (count of nodes in
-        graph), `m` (count of edges in graph), `k_avg` (graph's average node
-        degree), `edge_length_total` (see `edge_length_total` function
-        documentation), `edge_length_avg` (`edge_length_total / m`),
-        `streets_per_node_avg` (see `streets_per_node_avg` function
-        documentation), `streets_per_node_counts` (see
-        `streets_per_node_counts` function documentation),
-        `streets_per_node_proportions` (see `streets_per_node_proportions`
-        function documentation), `intersection_count` (see
-        `intersection_count` function documentation), `street_length_total`
-        (see `street_length_total` function documentation),
-        `street_segment_count` (see `street_segment_count` function
-        documentation), `street_length_avg` (`street_length_total /
-        street_segment_count`), `circuity_avg` (see `circuity_avg` function
-        documentation), `self_loop_proportion`, (see `self_loop_proportion`
-        function documentation), `clean_intersection_count` (see
-        `clean_intersection_count` function documentation), `node_density_km`
-        (`n` per sq km), `intersection_density_km` (`intersection_count`
-        per sq km), `edge_density_km` (`edge_length_total` per sq km),
-        `street_density_km` (`street_length_total` per sq km),
-        `clean_intersection_density_km` (`clean_intersection_count` per sq km)
+        dictionary containing the following attributes
+          - `circuity_avg` - see `circuity_avg` function documentation
+          - `clean_intersection_count` - see `clean_intersection_count` function documentation
+          - `clean_intersection_density_km` - `clean_intersection_count` per sq km
+          - `edge_density_km` - `edge_length_total` per sq km
+          - `edge_length_avg` - `edge_length_total / m`
+          - `edge_length_total` - see `edge_length_total` function documentation
+          - `intersection_count` - see `intersection_count` function documentation
+          - `intersection_density_km` - `intersection_count` per sq km
+          - `k_avg` - graph's average node degree (in-degree and out-degree)
+          - `m` - count of edges in graph
+          - `n` - count of nodes in graph
+          - `node_density_km` - `n` per sq km
+          - `self_loop_proportion` - see `self_loop_proportion` function documentation
+          - `street_density_km` - `street_length_total` per sq km
+          - `street_length_avg` - `street_length_total / street_segment_count`
+          - `street_length_total` - see `street_length_total` function documentation
+          - `street_segment_count` - see `street_segment_count` function documentation
+          - `streets_per_node_avg` - see `streets_per_node_avg` function documentation
+          - `streets_per_node_counts` - see `streets_per_node_counts` function documentation
+          - `streets_per_node_proportions` - see `streets_per_node_proportions` function documentation
     """
     if circuity_dist is not None:
         msg = (

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -252,17 +252,16 @@ def circuity_avg(Gu):
 def basic_stats(
     G,
     area=None,
+    clean_int_tol=None,
     clean_intersects=None,
     tolerance=None,
     circuity_dist=None,
-    clean_intersects_tol=None,
 ):
     """
     Calculate basic descriptive geometric and topological measures of a graph.
 
     Density measures are only calculated if `area` is provided and clean
-    intersection measures are only calculated if `clean_intersects_tol` is
-    provided.
+    intersection measures are only calculated if `clean_int_tol` is provided.
 
     Parameters
     ----------
@@ -271,7 +270,7 @@ def basic_stats(
     area : float
         if not None, calculate density measures and use this area value (in
         square meters) as the denominator
-    clean_intersects_tol : float
+    clean_int_tol : float
         if not None, calculate consolidated intersections count (and density,
         if `area` is also provided) and use this tolerance value; refer to the
         `simplification.consolidate_intersections` function documentation for
@@ -321,7 +320,7 @@ def basic_stats(
         msg = (
             "The `clean_intersects` and `tolerance` arguments have been "
             "deprecated and will be removed in a future release. Use the "
-            "`clean_intersects_tol` argument instead."
+            "`clean_int_tol` argument instead."
         )
         warnings.warn(msg)
 
@@ -331,7 +330,7 @@ def basic_stats(
         msg = (
             "The `clean_intersects` and `tolerance` arguments have been "
             "deprecated and will be removed in a future release. Use the "
-            "`clean_intersects_tol` argument instead."
+            "`clean_int_tol` argument instead."
         )
         warnings.warn(msg)
 
@@ -354,10 +353,10 @@ def basic_stats(
     stats["self_loop_proportion"] = self_loop_proportion(Gu)
 
     # calculate clean intersection counts if requested
-    if clean_intersects_tol:
+    if clean_int_tol:
         stats["clean_intersection_count"] = len(
             simplification.consolidate_intersections(
-                G, tolerance=clean_intersects_tol, rebuild_graph=False, dead_ends=False
+                G, tolerance=clean_int_tol, rebuild_graph=False, dead_ends=False
             )
         )
 
@@ -368,7 +367,7 @@ def basic_stats(
         stats["intersection_density_km"] = stats["intersection_count"] / area_km
         stats["edge_density_km"] = stats["edge_length_total"] / area_km
         stats["street_density_km"] = stats["street_length_total"] / area_km
-        if clean_intersects_tol:
+        if clean_int_tol:
             stats["clean_intersection_density_km"] = stats["clean_intersection_count"] / area_km
 
     return stats

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -32,91 +32,28 @@ except ImportError:
     scipy = None
 
 
-def _get_bearings(Gu, min_length=0, weight=None):
-    """
-    Calculate undirected graph's edge bearings in both directions.
-
-    For example, if an edge has a bearing of 90° then we will record bearings
-    of both 90° and 270° for this edge.
-
-    Parameters
-    ----------
-    Gu : networkx.MultiGraph
-        undirected input graph
-    min_length : float
-        ignore edges with `length` attributes less than `min_length`; useful
-        to ignore the noise of many very short edges
-    weight : string
-        if not None, weight edges' bearings by this (non-null) edge attribute
-
-    Returns
-    -------
-    bearings : numpy.array
-        the graph's bidirectional edge bearings
-    """
-    if nx.is_directed(Gu):
-        raise ValueError("`Gu` must be undirected")
-    bearings = list()
-    for _, _, data in bearing.add_edge_bearings(Gu).edges(data=True):
-        if data["length"] >= min_length:
-            if weight:
-                # weight edges' bearings by some edge attribute value
-                bearings.extend([data["bearing"]] * int(data[weight]))
-            else:
-                # don't weight bearings, just take one value per edge
-                bearings.append(data["bearing"])
-
-    # drop any nulls, calculate reverse bearings, concatenate and return
-    bearings = np.array(bearings)
-    bearings = bearings[~np.isnan(bearings)]
-    bearings_r = (bearings - 180) % 360
-    return np.concatenate([bearings, bearings_r])
-
-
-def _count_and_merge_bins(bearings, num_bins):
-    """
-    Compute distribution of bearings across evenly spaced bins.
-
-    Prevents bin-edge effects around common values like 0° and 90° by making
-    twice as many bins as desired, then merging them in pairs.
-
-    Parameters
-    ----------
-    bearings : numpy.array
-        the graph's bidirectional edge bearings
-    num_bins : int
-        how many bins to bin the bearings into
-
-    Returns
-    -------
-    bin_counts
-    """
-    n = num_bins * 2
-    bin_edges = np.arange(n + 1) * 360 / n
-    count, _ = np.histogram(bearings, bins=bin_edges)
-
-    # move last bin to front, so eg 0.01° and 359.99° will be binned together
-    count = np.roll(count, 1)
-    return count[::2] + count[1::2]
-
-
 def orientation_entropy(Gu, num_bins=36, min_length=0, weight=None):
     """
     Calculate undirected graph's orientation entropy.
 
-    Orientation entropy is the entropy of its edges' bidirectional bearings.
+    Orientation entropy is the entropy of its edges' bidirectional bearings
+    across evenly spaced bins.
 
     Parameters
     ----------
     Gu : networkx.MultiGraph
         undirected input graph
     num_bins : int
-        how many bins to calculate entropy across
+        number of bins; for example, if `num_bins=36` is provided, then each
+        bin will represent 10° around the compass
     min_length : float
         ignore edges with `length` attributes less than `min_length`; useful
         to ignore the noise of many very short edges
     weight : string
-        if not None, weight edges' bearings by this (non-null) edge attribute
+        if not None, weight edges' bearings by this (non-null) edge attribute.
+        for example, if "length" is provided, this will return 1 bearing
+        observation per meter per street, which could result in a very large
+        `bearings` array.
 
     Returns
     -------
@@ -126,8 +63,8 @@ def orientation_entropy(Gu, num_bins=36, min_length=0, weight=None):
     # check if we were able to import scipy
     if scipy is None:
         raise ImportError("scipy must be installed to calculate entropy")
-    bearings = _get_bearings(Gu, min_length=min_length, weight=weight)
-    bin_counts = _count_and_merge_bins(bearings, num_bins)
+    bearings = bearing._extract_edge_bearings(Gu, min_length, weight)
+    bin_counts = bearing._bearings_distribution(bearings, num_bins)
     return scipy.stats.entropy(bin_counts)
 
 
@@ -505,8 +442,8 @@ def extended_stats(G, connectivity=False, anc=False, ecc=False, bc=False, cc=Fal
     dict
     """
     msg = (
-        "The extended_stats function has been deprecated and will be removed "
-        "in a future release. Use NetworkX directly to calculate measures."
+        "The extended_stats function has been deprecated and will be removed in a "
+        "future release. Use NetworkX directly for extended topological measures."
     )
     warnings.warn(msg)
     stats = dict()

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -18,54 +18,11 @@ import warnings
 import networkx as nx
 import numpy as np
 
-from . import bearing
 from . import distance
 from . import projection
 from . import simplification
 from . import utils
 from . import utils_graph
-
-# scipy is an optional dependency for entropy stats
-try:
-    import scipy
-except ImportError:
-    scipy = None
-
-
-def orientation_entropy(Gu, num_bins=36, min_length=0, weight=None):
-    """
-    Calculate undirected graph's orientation entropy.
-
-    Orientation entropy is the entropy of its edges' bidirectional bearings
-    across evenly spaced bins.
-
-    Parameters
-    ----------
-    Gu : networkx.MultiGraph
-        undirected input graph
-    num_bins : int
-        number of bins; for example, if `num_bins=36` is provided, then each
-        bin will represent 10° around the compass
-    min_length : float
-        ignore edges with `length` attributes less than `min_length`; useful
-        to ignore the noise of many very short edges
-    weight : string
-        if not None, weight edges' bearings by this (non-null) edge attribute.
-        for example, if "length" is provided, this will return 1 bearing
-        observation per meter per street, which could result in a very large
-        `bearings` array.
-
-    Returns
-    -------
-    entropy : float
-        the graph's orientation entropy
-    """
-    # check if we were able to import scipy
-    if scipy is None:
-        raise ImportError("scipy must be installed to calculate entropy")
-    bearings = bearing._extract_edge_bearings(Gu, min_length, weight)
-    bin_counts = bearing._bearings_distribution(bearings, num_bins)
-    return scipy.stats.entropy(bin_counts)
 
 
 def streets_per_node(G):

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -19,7 +19,7 @@ from . import utils_graph
 
 def streets_per_node(G):
     """
-    Count streets (undirected edges) incident to each node.
+    Count streets (undirected edges) incident on each node.
 
     Prevents double-counting bidirectional edges of a two-way street, but may
     double-count a divided road's separate centerlines with different end
@@ -79,7 +79,7 @@ def streets_per_node_counts(G):
     Returns
     -------
     spnc : dict
-        dictionary keyed by count of streets incident to each node, and with
+        dictionary keyed by count of streets incident on each node, and with
         values of how many nodes in the graph have this count
     """
     spn_vals = list(streets_per_node(G).values())
@@ -102,7 +102,7 @@ def streets_per_node_proportions(G):
     Returns
     -------
     spnp : dict
-        dictionary keyed by count of streets incident to each node, and with
+        dictionary keyed by count of streets incident on each node, and with
         values of what proportion of nodes in the graph have this count
     """
     n = len(G.nodes)
@@ -115,7 +115,7 @@ def intersection_count(G=None, min_streets=2):
     Count the intersections in a graph.
 
     Intersections are defined as nodes with at least `min_streets` number of
-    streets incident to them. Prevents double-counting bidirectional edges of
+    streets incident on them. Prevents double-counting bidirectional edges of
     a two-way street, but may double-count a divided road's separate
     centerlines with different end point nodes.
 
@@ -124,7 +124,7 @@ def intersection_count(G=None, min_streets=2):
     G : networkx.MultiDiGraph
         input graph
     min_streets : int
-        a node must have at least `min_streets` incident to them to count as
+        a node must have at least `min_streets` incident on them to count as
         an intersection
 
     Returns

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -16,13 +16,119 @@ import logging as lg
 import warnings
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 
+from . import bearing
 from . import distance
 from . import projection
 from . import simplification
 from . import utils
 from . import utils_graph
+
+# scipy is an optional dependency for entropy stats
+try:
+    import scipy
+except ImportError:
+    scipy = None
+
+
+def _get_bearings(Gu, min_length=0, weight=None):
+    """
+    Calculate undirected graph's edge bearings in both directions.
+
+    For example, if an edge has a bearing of 90° then we will record bearings
+    of both 90° and 270° for this edge.
+
+    Parameters
+    ----------
+    Gu : networkx.MultiGraph
+        undirected input graph
+    min_length : float
+        ignore edges with `length` attributes less than `min_length`; useful
+        to ignore the noise of many very short edges
+    weight : string
+        if not None, weight edges' bearings by this (non-null) edge attribute
+
+    Returns
+    -------
+    bearings : numpy.array
+        the graph's bidirectional edge bearings
+    """
+    if nx.is_directed(Gu):
+        raise ValueError("`Gu` must be undirected")
+    bearings = list()
+    for _, _, data in bearing.add_edge_bearings(Gu).edges(data=True):
+        if data["length"] >= min_length:
+            if weight:
+                # weight edges' bearings by some edge attribute value
+                bearings.extend([data["bearing"]] * int(data[weight]))
+            else:
+                # don't weight bearings, just take one value per edge
+                bearings.append(data["bearing"])
+
+    # drop any nulls, calculate reverse bearings, concatenate and return
+    bearings = pd.Series(bearings).dropna()
+    bearings_r = (bearings + 180) % 360
+    return np.concatenate([bearings, bearings_r])
+
+
+def _count_and_merge_bins(bearings, num_bins):
+    """
+    Compute distribution of bearings across evenly spaced bins.
+
+    Prevents bin-edge effects around common values like 0° and 90° by making
+    twice as many bins as desired, then merging them in pairs.
+
+    Parameters
+    ----------
+    bearings : numpy.array
+        the graph's bidirectional edge bearings
+    num_bins : int
+        how many bins to bin the bearings into
+
+    Returns
+    -------
+    bin_counts
+    """
+    n = num_bins * 2
+    bin_edges = np.arange(n + 1) * 360 / n
+    count, _ = np.histogram(bearings, bins=bin_edges)
+
+    # move last bin to front, so eg 0.01° and 359.99° will be binned together
+    count = np.roll(count, 1)
+    return count[::2] + count[1::2]
+
+
+def orientation_entropy(Gu, num_bins=36, min_length=0, weight=None):
+    """
+    Calculate undirected graph's orientation entropy.
+
+    Orientation entropy is the entropy of its edges' bidirectional bearings.
+
+    Parameters
+    ----------
+    Gu : networkx.MultiGraph
+        undirected input graph
+    num_bins : int
+        how many bins to calculate entropy across
+    min_length : float
+        ignore edges with `length` attributes less than `min_length`; useful
+        to ignore the noise of many very short edges
+    weight : string
+        if not None, weight edges' bearings by this (non-null) edge attribute
+
+    Returns
+    -------
+    entropy : float
+        the graph's orientation entropy
+    """
+    # check if we were able to import scipy
+    if scipy is None:
+        raise ImportError("scipy must be installed to calculate entropy")
+    bearings = _get_bearings(Gu, min_length=min_length, weight=weight)
+    bin_counts = _count_and_merge_bins(bearings, num_bins)
+    return scipy.stats.entropy(bin_counts)
 
 
 def streets_per_node(G):

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -205,7 +205,7 @@ def self_loop_proportion(Gu):
 
 def circuity_avg(Gu):
     """
-    Calculate graph's average (undirected) edge circuity.
+    Calculate average street circuity using edges of undirected graph.
 
     Circuity is the sum of edge lengths divided by the sum of straight-line
     distances between edge endpoints. Calculates straight-line distance as
@@ -230,25 +230,21 @@ def circuity_avg(Gu):
         for u, v, k in Gu.edges
     )
     df_coords = pd.DataFrame(coords, columns=["u_y", "u_x", "v_y", "v_x"])
+    y1 = df_coords["u_y"]
+    x1 = df_coords["u_x"]
+    y2 = df_coords["v_y"]
+    x2 = df_coords["v_x"]
 
-    # calculate straight-line distances as either euclidean distances if
-    # projected, or great-circle distances if unprojected
+    # calculate straight-line distances as euclidean distances if projected or
+    # great-circle distances if unprojected
     if projection.is_projected(Gu.graph["crs"]):
-        y1 = df_coords["u_y"]
-        x1 = df_coords["u_x"]
-        y2 = df_coords["v_y"]
-        x2 = df_coords["v_x"]
-        straight_line_dists = distance.euclidean_dist_vec(y1=y1, x1=x1, y2=y2, x2=x2)
+        sl_dists = distance.euclidean_dist_vec(y1=y1, x1=x1, y2=y2, x2=x2)
     else:
-        lat1 = df_coords["u_y"]
-        lng1 = df_coords["u_x"]
-        lat2 = df_coords["v_y"]
-        lng2 = df_coords["v_x"]
-        straight_line_dists = distance.great_circle_vec(lat1=lat1, lng1=lng1, lat2=lat2, lng2=lng2)
+        sl_dists = distance.great_circle_vec(lat1=y1, lng1=x1, lat2=y2, lng2=x2)
 
-    # return the ratio, handling possible divide by zero
+    # return the ratio, handling possible division by zero
     try:
-        return edge_length_total(Gu) / straight_line_dists.fillna(value=0).sum()
+        return edge_length_total(Gu) / sl_dists.fillna(value=0).sum()
     except ZeroDivisionError:
         return None
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -240,7 +240,7 @@ def count_streets_per_node(G, nodes=None):
     counts = Counter(edges_flat)
     streets_per_node = {node: counts[node] for node in nodes}
 
-    utils.log("Counted undirected street segments incident to each node")
+    utils.log("Counted undirected street segments incident on each node")
     return streets_per_node
 
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -121,7 +121,7 @@ def test_stats():
 
     # calculate entropy
     Gu = ox.get_undirected(G)
-    entropy = ox.bearing.orientation_entropy(Gu)
+    entropy = ox.bearing.orientation_entropy(Gu, weight="length")
     fig, ax = ox.plot.plot_orientation(Gu, area=True, title="Title")
 
     # test cleaning and rebuilding graph

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -103,6 +103,26 @@ def test_geocode_to_gdf():
     city_projected = ox.project_gdf(city, to_crs="epsg:3395")
 
 
+def test_stats():
+    # create graph, add bearings, project it
+    G = ox.graph_from_point(location_point, dist=500, network_type="drive")
+    G = ox.add_edge_bearings(G)
+    G_proj = ox.project_graph(G)
+
+    # calculate stats
+    stats = ox.basic_stats(G)
+    stats = ox.basic_stats(G, area=1000)
+    stats = ox.basic_stats(
+        G_proj, area=1000, clean_intersects=True, tolerance=15, circuity_dist="euclidean"
+    )
+
+    # calculate extended stats
+    stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
+
+    # test cleaning and rebuilding graph
+    G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
+
+
 def test_osm_xml():
     # test loading a graph from a local .osm xml file
     node_id = 53098262
@@ -406,26 +426,6 @@ def test_graph_from_functions():
         dist_type="network",
         network_type="all_private",
     )
-
-
-def test_stats():
-    # create graph, add bearings, project it
-    G = ox.graph_from_point(location_point, dist=500, network_type="drive")
-    G = ox.add_edge_bearings(G)
-    G_proj = ox.project_graph(G)
-
-    # calculate stats
-    stats = ox.basic_stats(G)
-    stats = ox.basic_stats(G, area=1000)
-    stats = ox.basic_stats(
-        G_proj, area=1000, clean_intersects=True, tolerance=15, circuity_dist="euclidean"
-    )
-
-    # calculate extended stats
-    stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
-
-    # test cleaning and rebuilding graph
-    G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
 
 
 def test_geometries():

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -119,6 +119,9 @@ def test_stats():
     # calculate extended stats
     stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
 
+    # calculate entropy
+    entropy = ox.stats.orientation_entropy(ox.get_undirected(G))
+
     # test cleaning and rebuilding graph
     G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -120,7 +120,9 @@ def test_stats():
     stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
 
     # calculate entropy
-    entropy = ox.bearing.orientation_entropy(ox.get_undirected(G))
+    Gu = ox.get_undirected(G)
+    entropy = ox.bearing.orientation_entropy(Gu)
+    fig, ax = ox.plot.plot_orientation(Gu, area=True, title="Title")
 
     # test cleaning and rebuilding graph
     G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -120,7 +120,7 @@ def test_stats():
     stats = ox.extended_stats(G, connectivity=True, anc=False, ecc=True, bc=True, cc=True)
 
     # calculate entropy
-    entropy = ox.stats.orientation_entropy(ox.get_undirected(G))
+    entropy = ox.bearing.orientation_entropy(ox.get_undirected(G))
 
     # test cleaning and rebuilding graph
     G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)


### PR DESCRIPTION
This PR:
  - [x] refactors the `stats` module
  - [x] exposes individual street network stats calculating functions
  - [x] adds network entropy and orientation stats to the `bearing` module
  - [x] adds `plot_orientation` function to plot [polar histograms](https://geoffboeing.com/2019/09/urban-street-network-orientation/) of graph bearings
  - [x] deprecates the `extended_stats` function
  - [x] test to confirm all stats yield same results as in v1.0.x (and compare to [snm](https://github.com/gboeing/street-network-models) indicators calculation workflow)