### PR TITLE
streamline node consolidation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # OSMnx
 
-**OSMnx** is a Python package that lets you download spatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks. You can download and model walkable, drivable, or bikeable urban networks with a single line of Python code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, and speed/travel time.
+**OSMnx** is a Python package that lets you download geospatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks and any other geospatial geometries. You can download and model walkable, drivable, or bikeable urban networks with a single line of Python code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, and speed/travel time.
 
 If you use OSMnx in your work, please cite the journal article.
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,25 @@
 
 **OSMnx** is a Python package that lets you download spatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks. You can download and model walkable, drivable, or bikeable urban networks with a single line of Python code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, and speed/travel time.
 
+If you use OSMnx in your work, please cite the journal article.
+
 **Citation info**: Boeing, G. 2017. "[OSMnx: New Methods for Acquiring, Constructing, Analyzing, and Visualizing Complex Street Networks](https://geoffboeing.com/publications/osmnx-complex-street-networks/)." *Computers, Environment and Urban Systems* 65, 126-139. doi:10.1016/j.compenvurbsys.2017.05.004
 
 
+## Getting Started
+
+"How do I install OSMnx?" Read the [installation](https://osmnx.readthedocs.io/) instructions.
+
+"How do I use OSMnx?" See the usage examples and tutorials in the [examples](https://github.com/gboeing/osmnx-examples) repo.
+
+"How does this function work?" Read the [documentation](https://osmnx.readthedocs.io/).
+
+"What can I do with OSMnx?" Check out recent projects and blog posts that [used OSMnx](https://geoffboeing.com/2018/03/osmnx-features-roundup/).
+
+"I have a 'how-to' question." Please ask it on [StackOverflow](https://stackoverflow.com/search?q=osmnx).
+
 
 ## Features
-
-To get started with sample code and usage examples/demos, see the [examples](https://github.com/gboeing/osmnx-examples) GitHub repo and read the [documentation](https://osmnx.readthedocs.io/).
 
 OSMnx is built on top of GeoPandas, NetworkX, and matplotlib and interacts with OpenStreetMap's APIs to:
 
@@ -36,29 +48,4 @@ OSMnx is built on top of GeoPandas, NetworkX, and matplotlib and interacts with 
   * Visualize travel distance and travel time with isoline and isochrone maps
   * Plot figure-ground diagrams of street networks and building footprints
 
-Examples and demonstrations of these features are in the [examples repo](https://github.com/gboeing/osmnx-examples). More feature development details are in the change log. Read the [journal article](https://geoffboeing.com/publications/osmnx-complex-street-networks/) for further technical details. Package usage is detailed in the [documentation](https://osmnx.readthedocs.io/).
-
-
-
-## Installation
-
-Install OSMnx in a clean conda environment:
-
-```
-conda config --prepend channels conda-forge
-conda create -n ox --strict-channel-priority osmnx
-```
-
-If you have any trouble with the installation, read the [docs](https://osmnx.readthedocs.io/) for more info. Alternatively, you can run OSMnx + Jupyter directly from its official [Docker container](https://hub.docker.com/r/gboeing/osmnx).
-
-
-
-## Documentation and Usage
-
-Documentation is available on [readthedocs](https://osmnx.readthedocs.io/).
-
-"How do I use OSMnx?" Usage examples and tutorials are available in the [examples repo](https://github.com/gboeing/osmnx-examples).
-
-Examples of projects and blog posts [using OSMnx](https://geoffboeing.com/2018/03/osmnx-features-roundup/).
-
-If you use OSMnx in your work, please cite the [journal article](https://geoffboeing.com/publications/osmnx-complex-street-networks/).
+All of these features are demonstrated in the [examples](https://github.com/gboeing/osmnx-examples) repo and documented in the [documentation](https://osmnx.readthedocs.io/). Feature development details are in the change log. Read the [journal article](https://geoffboeing.com/publications/osmnx-complex-street-networks/) for further technical details.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 OSMnx |version|
 ===============
 
-OSMnx is a Python package that lets you download spatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks. You can download and model walkable, drivable, or bikeable urban networks with a single line of Python code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, and speed/travel time.
+OSMnx is a Python package that lets you download geospatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks and any other geospatial geometries. You can download and model walkable, drivable, or bikeable urban networks with a single line of Python code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, and speed/travel time.
 
 If you use OSMnx in your work, please cite the journal article:
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -1001,4 +1001,7 @@ def _filter_gdf_by_polygon_and_tags(gdf, polygon, tags):
         gdf.dropna(axis="columns", how="all", inplace=True)
 
     # multi-index gdf by element_type and osmid then return
-    return gdf.set_index(["element_type", "osmid"])
+    idx_cols = ["element_type", "osmid"]
+    if all(c in gdf.columns for c in idx_cols):
+        gdf = gdf.set_index(idx_cols)
+    return gdf

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -347,6 +347,9 @@ def _convert_bool_string(value):
     to the boolean value True, that is, `bool("False") == True`. This function
     raises a ValueError if a value other than "True" or "False" is passed.
 
+    If the value is already a boolean, this function just returns it, to
+    accommodate usage when the value was originally inside a stringified list.
+
     Parameters
     ----------
     value : string {"True", "False"}
@@ -358,6 +361,8 @@ def _convert_bool_string(value):
     """
     if value in {"True", "False"}:
         return value == "True"
+    elif isinstance(value, bool):
+        return value
     else:
         raise ValueError(f'invalid literal for boolean: "{value}"')
 

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -4,7 +4,6 @@ import logging as lg
 
 import geopandas as gpd
 import networkx as nx
-import pandas as pd
 from shapely.geometry import LineString
 from shapely.geometry import Point
 from shapely.geometry import Polygon

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -187,7 +187,7 @@ def config(
     overpass_settings : string
         Settings string for overpass queries. For example, to query historical
         OSM data as of a certain date:
-        `'[out:json][timeout:90][date:"2019-10-28T19:20:00Z"]'`.
+        ``'[out:json][timeout:90][date:"2019-10-28T19:20:00Z"]'``.
         Use with caution.
     timeout : int
         the timeout interval for the HTTP request and for API to use while


### PR DESCRIPTION
Improves on #679.

Also improves on #670 and #672 in 9235b1f.

Requires testing before merge:
  - [x] validation of function results
  - [x] test pygeos speed with chunking on/off (can `chunk` arg just be replaced with a `geopandas.options.use_pygeos` check?)

In testing, `_merge_nodes_geometric` is now consistently faster with `chunk=False`, so the chunking code has been removed.