### PR TITLE
Upgrade networkx version to fix incorrect import in Python 3.9

### DIFF
--- a/environments/linux/environment.yml
+++ b/environments/linux/environment.yml
@@ -163,7 +163,7 @@ dependencies:
   - nbformat=5.0.8=py_0
   - ncurses=6.2=h58526e2_4
   - nest-asyncio=1.4.3=pyhd8ed1ab_0
-  - networkx=2.5=py_0
+  - networkx=2.5.1=py_0
   - nodejs=15.2.1=h914e61d_0
   - notebook=6.1.6=py39hf3d152e_0
   - nspr=4.29=he1b5a44_1


### PR DESCRIPTION
This might be radical and not the right response to the issue, but networkx version 2.5 which is currently bundled with osmnx's conda installation throws an error on installation, which has a similar stacktrace to that shown in this recent [StackOverflow post](https://stackoverflow.com/questions/66174862/import-error-cant-import-name-gcd-from-fractions): `ImportError: cannot import name 'gcd' from 'fractions' (/usr/local/Cellar/python@3.9/3.9.1_6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/fractions.py)`

The issue seems to be triggered by Python 3.9, where the `gcd()` function was moved from the `fractions` to `math` module.
Networkx adapted the import in their `dag.py` file in [this commit](https://github.com/networkx/networkx/commit/b007158f3bfbcf77c52e4b39a81061914788ddf9#diff-21e03bb1d46583650bcad6e960f2ab8a5397395c986942b59314033e963dd3fc) which I believe was included in the 2.5.1 release of the package.

I have not tested this but I think that updating the networkx package would work for python versions greater than 3.9. In my case, I was able to resolve the issue by manually changing that import line in networkx's `dag.py` file.
