### PR TITLE
simplification.py: Keep all travel_time values

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -266,7 +266,8 @@ def simplify_graph(G, strict=True, remove_rings=True):
                 # if there's only 1 unique value in this attribute list,
                 # consolidate it to the single value (the zero-th)
                 edge_attributes[key] = edge_attributes[key][0]
-            elif key != "length":
+            # also keep all travel_time values, to be able to sum them later
+            elif key not in ["length", "travel_time"]:
                 # otherwise, if there are multiple values, keep one of each value
                 edge_attributes[key] = list(set(edge_attributes[key]))
 

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -267,7 +267,7 @@ def simplify_graph(G, strict=True, remove_rings=True):
                 # consolidate it to the single value (the zero-th)
                 edge_attributes[key] = edge_attributes[key][0]
             # also keep all travel_time values, to be able to sum them later
-            elif key not in ["length", "travel_time"]:
+            elif key not in {"length", "travel_time"}:
                 # otherwise, if there are multiple values, keep one of each value
                 edge_attributes[key] = list(set(edge_attributes[key]))
 


### PR DESCRIPTION
Currently when multiple edges are merged together, all identical attribute values except length are discarded. While this is logical for most attributes like street names and road types, it doesn't make much sense for the travel time.

This commit adds an exception for the travel_time attribute that makes sure identical values aren't discarded. By keeping all travel time values, the total travel time can be calculated later.

Part of #717.