### PR TITLE
ENH: Improve performance of computing UTM zone number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   - fix geocoding when no geojson is returned
   - fix graph simplification to properly handle travel_time edge attributes
   - allow user-defined aggregation function when imputing missing edge speeds
-  - use a computationally cheaper method for obtaining UTM zone for graph projection
+  - use a computationally cheaper method for obtaining UTM zone number for graph projection
 
 ## 1.1.1 (2021-05-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - fix geocoding when no geojson is returned
   - fix graph simplification to properly handle travel_time edge attributes
   - allow user-defined aggregation function when imputing missing edge speeds
+  - use a computationally cheaper method for obtaining UTM zone for graph projection
 
 ## 1.1.1 (2021-05-19)
 

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -106,7 +106,7 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
             raise ValueError("Geometry must be unprojected to calculate UTM zone")
 
         # calculate approximate longitude of centroid of union of all geometries in gdf
-        avg_lng = gdf["geometry"].to_crs("epsg:4326").representative_point().x.mean()
+        avg_lng = gdf["geometry"].representative_point().x.mean()
 
         # calculate UTM zone from avg longitude to define CRS to project to
         utm_zone = int(np.floor((avg_lng + 180) / 6) + 1)

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -105,8 +105,8 @@ def project_gdf(gdf, to_crs=None, to_latlong=False):
         if is_projected(gdf.crs):  # pragma: no cover
             raise ValueError("Geometry must be unprojected to calculate UTM zone")
 
-        # calculate longitude of centroid of union of all geometries in gdf
-        avg_lng = gdf["geometry"].unary_union.centroid.x
+        # calculate approximate longitude of centroid of union of all geometries in gdf
+        avg_lng = gdf["geometry"].to_crs("epsg:4326").representative_point().x.mean()
 
         # calculate UTM zone from avg longitude to define CRS to project to
         utm_zone = int(np.floor((avg_lng + 180) / 6) + 1)


### PR DESCRIPTION
Following the discussion in #741, this PR uses an approximate method for computing longitude of a GeoDataFrame to obtain UTM zone number.
