### PR TITLE
Expose parameters to requests methods

### DIFF
--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -319,7 +319,7 @@ def _get_pause(base_endpoint, recursive_delay=5, default_duration=60):
 
     try:
         url = base_endpoint.rstrip("/") + "/status"
-        response = requests.get(url, headers=_get_http_headers())
+        response = requests.get(url, headers=_get_http_headers(), **settings.requests_config)
         sc = response.status_code
         status = response.text.split("\n")[3]
         status_first_token = status.split(" ")[0]
@@ -649,7 +649,13 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
         # transmit the HTTP GET request
         utils.log(f"Get {prepared_url} with timeout={settings.timeout}")
         headers = _get_http_headers()
-        response = requests.get(url, params=params, timeout=settings.timeout, headers=headers)
+        response = requests.get(
+            url,
+            params=params,
+            timeout=settings.timeout,
+            headers=headers,
+            **settings.requests_config,
+        )
         sc = response.status_code
 
         # log the response size and domain
@@ -722,7 +728,9 @@ def overpass_request(data, pause=None, error_pause=60):
         # transmit the HTTP POST request
         utils.log(f"Post {prepared_url} with timeout={settings.timeout}")
         headers = _get_http_headers()
-        response = requests.post(url, data=data, timeout=settings.timeout, headers=headers)
+        response = requests.post(
+            url, data=data, timeout=settings.timeout, headers=headers, **settings.requests_config
+        )
         sc = response.status_code
 
         # log the response size and domain

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -319,7 +319,7 @@ def _get_pause(base_endpoint, recursive_delay=5, default_duration=60):
 
     try:
         url = base_endpoint.rstrip("/") + "/status"
-        response = requests.get(url, headers=_get_http_headers(), **settings.requests_config)
+        response = requests.get(url, headers=_get_http_headers(), **settings.requests_kwargs)
         sc = response.status_code
         status = response.text.split("\n")[3]
         status_first_token = status.split(" ")[0]
@@ -654,7 +654,7 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
             params=params,
             timeout=settings.timeout,
             headers=headers,
-            **settings.requests_config,
+            **settings.requests_kwargs,
         )
         sc = response.status_code
 
@@ -729,7 +729,7 @@ def overpass_request(data, pause=None, error_pause=60):
         utils.log(f"Post {prepared_url} with timeout={settings.timeout}")
         headers = _get_http_headers()
         response = requests.post(
-            url, data=data, timeout=settings.timeout, headers=headers, **settings.requests_config
+            url, data=data, timeout=settings.timeout, headers=headers, **settings.requests_kwargs
         )
         sc = response.status_code
 

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -111,4 +111,4 @@ overpass_rate_limit = True
 elevation_provider = "google"
 
 # dictionary of configuration to be used by requests for connection to external APIs
-requests_config = {}
+requests_kwargs = {}

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -109,3 +109,6 @@ overpass_rate_limit = True
 # for Google Maps Elevation API but also accepts "airmap"
 # this setting is deprecated and will be removed in a future release
 elevation_provider = "google"
+
+# dictionary of configuration to be used by requests for connection to external APIs
+requests_config = {}

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -110,6 +110,7 @@ def config(
     use_cache=settings.use_cache,
     useful_tags_node=settings.useful_tags_node,
     useful_tags_way=settings.useful_tags_way,
+    requests_config=settings.requests_config,
 ):
     """
     Configure OSMnx by setting the default global settings' values.
@@ -204,6 +205,11 @@ def config(
         OSM "node" tags to add as graph node attributes, when present
     useful_tags_way : list
         OSM "way" tags to add as graph edge attributes, when present
+    requests_config : dict
+        dictionary that supports overriding keyword arguments to be used
+        by the requests package. more information on options such as auth,
+        cert, verify, and proxies can be found in the documentation
+        https://docs.python-requests.org/en/master/user/advanced/
 
     Returns
     -------
@@ -243,6 +249,7 @@ def config(
     settings.use_cache = use_cache
     settings.useful_tags_node = useful_tags_node
     settings.useful_tags_way = useful_tags_way
+    settings.requests_config = requests_config
 
     log(f"Configured OSMnx {_version.__version__}")
     log(f"HTTP response caching is {'on' if settings.use_cache else 'off'}")

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -110,7 +110,7 @@ def config(
     use_cache=settings.use_cache,
     useful_tags_node=settings.useful_tags_node,
     useful_tags_way=settings.useful_tags_way,
-    requests_config=settings.requests_config,
+    requests_kwargs=settings.requests_kwargs,
 ):
     """
     Configure OSMnx by setting the default global settings' values.
@@ -205,7 +205,7 @@ def config(
         OSM "node" tags to add as graph node attributes, when present
     useful_tags_way : list
         OSM "way" tags to add as graph edge attributes, when present
-    requests_config : dict
+    requests_kwargs : dict
         dictionary that supports overriding keyword arguments to be used
         by the requests package. more information on options such as auth,
         cert, verify, and proxies can be found in the documentation
@@ -249,7 +249,7 @@ def config(
     settings.use_cache = use_cache
     settings.useful_tags_node = useful_tags_node
     settings.useful_tags_way = useful_tags_way
-    settings.requests_config = requests_config
+    settings.requests_kwargs = requests_kwargs
 
     log(f"Configured OSMnx {_version.__version__}")
     log(f"HTTP response caching is {'on' if settings.use_cache else 'off'}")


### PR DESCRIPTION
This proposed change would resolve any issues similar to issue #17 .

Description: Include a dictionary of configuration for parameters to requests methods. This allows configuring HTTP requests for environments where the nominatum or overpass api requires 2-way SSL or basic authentication. More details on what keyword arguments are available and how they're configured is available in the [requests documentation for advanced usage](https://docs.python-requests.org/en/master/user/advanced/). 

Example Usage:

import osmnx as ox

requests_config = {}
requests_config ['auth'] = ('username', 'password')
requests_config ['cert'] = '/path/to/cert'
requests_config ['verify'] = '/path/to/CA/'

osmnx.config(requests_config=requests_config )