### PR TITLE
CI: Add Python 3.10 to job matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     defaults:
       run:


### PR DESCRIPTION
CI: Add Python 3.10 to job matrix.

In draft status, currently unable to resolve dependencies.