### PR TITLE
ENH: Address Shapely and GeoPandas deprecations

### DIFF
--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -813,7 +813,7 @@ def _assemble_multipolygon_component_polygons(element, geometries):
     if merged_inner_linestrings.geom_type == "LineString":
         inner_polygons += polygonize(merged_inner_linestrings)
     elif merged_inner_linestrings.geom_type == "MultiLineString":
-        for merged_inner_linestring in list(merged_inner_linestrings):
+        for merged_inner_linestring in merged_inner_linestrings.geoms:
             inner_polygons += polygonize(merged_inner_linestring)
 
     if not outer_polygons:

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -7,7 +7,6 @@ import geopandas as gpd
 import networkx as nx
 from shapely.geometry import LineString
 from shapely.geometry import Point
-from shapely.geometry import Polygon
 
 from . import stats
 from . import utils

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -477,7 +477,14 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
     # graph's node points then spatial join to give each node the label of
     # cluster it's within
     node_points = utils_graph.graph_to_gdfs(G, edges=False)[["geometry"]]
-    gdf = gpd.sjoin(node_points, node_clusters, how="left", predicate="within")
+
+    # since geopandas 0.10.0, sjoin uses predicate instead of op.
+    v_maj, v_min, _ = gpd.__version__.split(".")
+    if int(v_maj) == 0 and int(v_min) < 10:
+        op_kwd = {"op": "within"}
+    else:
+        op_kwd = {"predicate": "within"}
+    gdf = gpd.sjoin(node_points, node_clusters, how="left", **op_kwd)
     gdf = gdf.drop(columns="geometry").rename(columns={"index_right": "cluster"})
 
     # STEP 3


### PR DESCRIPTION
Shapely and GeoPandas have deprecated some options that will be removed in their future version. This PR fixes those warnings. The deprecation functionalities are:

* Shapely has deprecated iterating over multi-part geometries which is documented [here](https://shapely.readthedocs.io/en/stable/migration.html).
* GeoPandas has deprecated op argument in favor of predicate in sjoin (geopandas/geopandas#1626).