### PR TITLE
geopandas 0.11 compatibility fix

### DIFF
--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -153,13 +153,14 @@ def project_graph(G, to_crs=None):
     gdf_nodes_proj = project_gdf(gdf_nodes, to_crs=to_crs)
     gdf_nodes_proj["x"] = gdf_nodes_proj["geometry"].x
     gdf_nodes_proj["y"] = gdf_nodes_proj["geometry"].y
+    to_crs = gdf_nodes_proj.crs
     gdf_nodes_proj = gdf_nodes_proj.drop(columns=["geometry"])
 
     # STEP 2: PROJECT THE EDGES
     if "simplified" in G.graph and G.graph["simplified"]:
         # if graph has previously been simplified, project the edge geometries
         gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=True)
-        gdf_edges_proj = project_gdf(gdf_edges, to_crs=gdf_nodes_proj.crs)
+        gdf_edges_proj = project_gdf(gdf_edges, to_crs=to_crs)
     else:
         # if not, you don't have to project these edges because the nodes
         # contain all the spatial data in the graph (unsimplified edges have
@@ -171,7 +172,7 @@ def project_graph(G, to_crs=None):
     # STEP 3: REBUILD GRAPH
     # turn projected node/edge gdfs into a graph and update its CRS attribute
     G_proj = utils_graph.graph_from_gdfs(gdf_nodes_proj, gdf_edges_proj, G.graph)
-    G_proj.graph["crs"] = gdf_nodes_proj.crs
+    G_proj.graph["crs"] = to_crs
 
     utils.log(f"Projected graph with {len(G)} nodes and {len(G.edges)} edges")
     return G_proj


### PR DESCRIPTION
GeoPandas merged a a fix of an old bug and when you drop a geometry column from a GeoDataFrame, it now correctly returns a pandas.DataFrame instead of an invalid GeoDataFrame (https://github.com/geopandas/geopandas/pull/2060).

I've noticed that OSMnx now depends on this behaviour and tests fail when run against GeoPandas main. This PR issues a patch.