### PR TITLE
CI: Add Python 3.10 to job matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [ubuntu-latest]
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
Add Python 3.10 to the CI job matrix.

Fiona now supports Python 3.10, since it's [1.8.21](https://github.com/Toblerity/Fiona/releases/tag/1.8.21) release. That should unblock GeoPandas, as https://github.com/geopandas/geopandas/issues/2212.