### PR TITLE
CI: Run weekly to detect changes in dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
 
 jobs:
 


### PR DESCRIPTION
Run the CI weekly (every Monday at 06:00) to detect changes in dependencies, such as linters.
