### PR TITLE
plot undirected graph route correctly

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -258,7 +258,7 @@ def plot_graph_route(
 
     Parameters
     ----------
-    G : networkx.MultiDiGraph
+    G : networkx.MultiDiGraph or networkx.MultiGraph
         input graph
     route : list
         route as a list of node IDs
@@ -304,6 +304,9 @@ def plot_graph_route(
         if "geometry" in data:
             # if geometry attribute exists, add all its coords to list
             xs, ys = data["geometry"].xy
+            # When graph is nx.MultiGraph check if geometry of edge is in correct order
+            if not G.is_directed() and G.nodes[u]["x"] != data["geometry"].coords[0][0]:
+                xs, ys = xs[::-1], ys[::-1]
             x.extend(xs)
             y.extend(ys)
         else:


### PR DESCRIPTION
Plotting the route in an undirected graph fails because the geometry of the edge is always in a certain direction.

For example:

```python
import numpy as np
import osmnx as ox
from matplotlib import pyplot as plt

place = "Piedmont, California, USA"
G = ox.graph_from_place(place, network_type="drive")
G_undirected = ox.get_undirected(G)

# print route
orig = list(G_undirected)[0]
dest = list(G_undirected[120]
route = ox.shortest_path(G_undirected, orig, dest, weight="length")
fig, ax = ox.plot_graph_route(G_undirected, route, route_color="y", route_linewidth=6, node_size=0)
```

This results in the following image:

![funky_route](https://user-images.githubusercontent.com/78442543/149326894-6b46e234-e8e9-4c89-bf4e-2a0e7e91e276.png)

However, with the proposed changes the route is plotted like this:

![output](https://user-images.githubusercontent.com/78442543/149327179-7e8eff25-b645-41c8-b077-a2236b505515.png)

I was thinking of creating a different `for` loop for `nx.MultiGraph` objects but the proposed `if` statement ([here](https://github.com/amorfinv/osmnx/blob/ab85b50e0ae37acf7d130f88bcb53fa8c8bf498c/osmnx/plot.py#L308)) seems a bit cleaner to me. It would only check the second condition if the the graph is an `nx.MultiGraph`.

``` python
if not G.is_directed() and G.nodes[u]["x"] != data["geometry"].coords[0][0]:
```
Let me know if you think this would be useful or if you have any suggestions.

-Andres