### PR TITLE
edge params in plot_footprints

### DIFF
--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -560,8 +560,8 @@ def plot_footprints(
     ax=None,
     figsize=(8, 8),
     color="orange",
-    edgecolor="none",
-    edgewidth=0,
+    edge_color="none",
+    edge_linewidth=0,
     alpha=None,
     bgcolor="#111111",
     bbox=None,
@@ -584,9 +584,9 @@ def plot_footprints(
         if ax is None, create new figure with size (width, height)
     color : string
         color of the footprints
-    edgecolor : string
+    edge_color : string
         color of the edge of the footprints
-    edgewidth : float
+    edge_linewidth : float
         width of the edge of the footprints
     alpha : float
         opacity of the footprints
@@ -620,7 +620,7 @@ def plot_footprints(
 
     # retain only Polygons and MultiPolygons, then plot
     gdf = gdf[gdf["geometry"].type.isin({"Polygon", "MultiPolygon"})]
-    ax = gdf.plot(ax=ax, facecolor=color, edgecolor=edgecolor, linewidth=edgewidth, alpha=alpha)
+    ax = gdf.plot(ax=ax, facecolor=color, edgecolor=edge_color, linewidth=edge_linewidth, alpha=alpha)
 
     # determine figure extents
     if bbox is None:

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -560,6 +560,8 @@ def plot_footprints(
     ax=None,
     figsize=(8, 8),
     color="orange",
+    edgecolor="none",
+    edgewidth=0,
     alpha=None,
     bgcolor="#111111",
     bbox=None,
@@ -582,6 +584,10 @@ def plot_footprints(
         if ax is None, create new figure with size (width, height)
     color : string
         color of the footprints
+    edgecolor : string
+        color of the edge of the footprints
+    edgewidth : float
+        width of the edge of the footprints
     alpha : float
         opacity of the footprints
     bgcolor : string
@@ -614,7 +620,7 @@ def plot_footprints(
 
     # retain only Polygons and MultiPolygons, then plot
     gdf = gdf[gdf["geometry"].type.isin({"Polygon", "MultiPolygon"})]
-    ax = gdf.plot(ax=ax, facecolor=color, edgecolor="none", linewidth=0, alpha=alpha)
+    ax = gdf.plot(ax=ax, facecolor=color, edgecolor=edgecolor, linewidth=edgewidth, alpha=alpha)
 
     # determine figure extents
     if bbox is None:


### PR DESCRIPTION
Fix #795

`plot_footprints()` does not have the functionality to customize edge color and edge width. The function uses `gdf.plot()` which has optional `edgecolor` and `linewidth` parameters. These parameters are by default set to `"none"` and `0` respectively within `plot_footprints()` function, but they are not accessible to change.

Fix this by adding `edgecolor` and `edgewidth` parameters to `plot_footprints()`. Their default values are `"none"` and `0`, which will leave the default behavior of `plot_footprints()` the exact same as before this update. Within the function, pass `edgecolor` to `gdf.plot()`'s `edgecolor`, and `edgewidth` to `gdf.plot()`'s `linewidth`.