### PR TITLE
addressing #810 - breaking ties from rtree

### DIFF
--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -285,7 +285,7 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
         # then minimize euclidean distance from point to the possible matches
         ne_dist = list()
         for xy in zip(X, Y):
-            dists = geoms.iloc[list(rtree.nearest(xy))].distance(Point(xy))
+            dists = geoms.iloc[list(rtree.nearest(xy, num_results=10))].distance(Point(xy))
             ne_dist.append((dists.idxmin(), dists.min()))
         ne, dist = zip(*ne_dist)
 


### PR DESCRIPTION
This PR addresses #810, which shows that within `rtree` a nearest edge can be selected arbitrarily when bounding boxes overlap. Adding the `num_results=10` to `rtree.nearest()` [here](https://github.com/gboeing/osmnx/blob/605fa2f75c0d3e886b087964dc137d7491af4113/osmnx/distance.py#L288) resolves this infrequent situation by selecting the network edge that is actually nearest.
