### PR TITLE
deprecate utils.config function

### DIFF
--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -1,30 +1,161 @@
-"""Global settings that can be configured by user with utils.config()."""
+"""
+Global settings that can be configured by the user.
+
+all_oneway : bool
+    If True, forces all ways to be loaded as oneway ways, preserving the
+    original order of nodes stored in the OSM way XML. This also retains
+    original OSM string values for oneway attribute values, rather than
+    converting them to a True/False bool. Only use if specifically saving to
+    .osm XML file with the `save_graph_xml` function. Default is `False`.
+bidirectional_network_types : list
+    Network types for which a fully bidirectional graph will be created.
+    Default is `["walk"]`.
+cache_folder : string or pathlib.Path
+    Path to folder in which to save/load HTTP response cache. Default is
+    `"./cache"`.
+cache_only_mode : bool
+    If True, download network data from Overpass then raise a
+    `CacheOnlyModeInterrupt` error for user to catch. This prevents graph
+    building from taking place and instead just saves OSM response data to
+    cache. Useful for sequentially caching lots of raw data (as you can
+    only query Overpass one request at a time) then using the local cache to
+    quickly build many graphs simultaneously with multiprocessing. Default is
+    `False`.
+data_folder : string or pathlib.Path
+    Path to folder in which to save/load graph files by default. Default is
+    `"./data"`.
+default_accept_language : string
+    HTTP header accept-language. Default is `"en"`.
+default_access : string
+    Default filter for OSM "access" key. Default is `'["access"!~"private"]'`.
+    Note that also filtering out "access=no" ways prevents including
+    transit-only bridges (e.g., Tilikum Crossing) from appearing in drivable
+    road network (e.g., `'["access"!~"private|no"]'`). However, some drivable
+    tollroads have "access=no" plus a "access:conditional" key to clarify when
+    it is accessible, so we can't filter out all "access=no" ways by default.
+    Best to be permissive here then remove complicated combinations of tags
+    programatically after the full graph is downloaded and constructed.
+default_crs : string
+    Default coordinate reference system to set when creating graphs. Default
+    is `"epsg:4326"`.
+default_referer : string
+    HTTP header referer. Default is
+    `"OSMnx Python package (https://github.com/gboeing/osmnx)"`.
+default_user_agent : string
+    HTTP header user-agent. Default is
+    `"OSMnx Python package (https://github.com/gboeing/osmnx)"`.
+imgs_folder : string or pathlib.Path
+    Path to folder in which to save plotted images by default. Default is
+    "./images".
+log_file : bool
+    If True, save log output to a file in logs_folder. Default is `False`.
+log_filename : string
+    Name of the log file, without file extension. Default is `"osmnx"`.
+log_console : bool
+    If True, print log output to the console (terminal window). Default is
+    `False`.
+log_level : int
+    One of Python's logger.level constants. Default is `logging.INFO`.
+log_name : string
+    Name of the logger. Default is `"OSMnx"`.
+logs_folder : string or pathlib.Path
+    Path to folder in which to save log files. Default is `"./logs"`.
+max_query_area_size : int
+    Maximum area for any part of the geometry in meters: any polygon bigger
+    than this will get divided up for multiple queries to the API. Default is
+    `2500000000`.
+memory : int
+    Overpass server memory allocation size for the query, in bytes. If
+    None, server will use its default allocation size. Use with caution.
+    Default is `None`.
+nominatim_endpoint : string
+    Base API endpoint to use for Nominatim queries. Default is
+    `"https://nominatim.openstreetmap.org/"`.
+nominatim_key : string
+    Your Nominatim API key, if you are using an endpoint that requires one.
+    Default is `None`.
+osm_xml_node_attrs : list
+    Node attributes for saving .osm XML files with `save_graph_xml` function.
+    Default is `["id", "timestamp", "uid", "user", "version", "changeset",
+    "lat", "lon"]`.
+osm_xml_node_tags : list
+    Node tags for saving .osm XML files with `save_graph_xml` function.
+    Default is `["highway"]`.
+osm_xml_way_attrs : list
+    Edge attributes for saving .osm XML files with `save_graph_xml` function.
+    Default is `["id", "timestamp", "uid", "user", "version", "changeset"]`.
+osm_xml_way_tags : list
+    Edge tags for for saving .osm XML files with `save_graph_xml` function.
+    Default is `["highway", "lanes", "maxspeed", "name", "oneway"]`.
+overpass_endpoint : string
+    Base API endpoint to use for overpass queries. Default is
+    `"https://overpass-api.de/api"`.
+overpass_rate_limit : bool
+    If True, check the Overpass server status endpoint for how long to
+    pause before making request. Necessary if server uses slot management,
+    but can be set to False if you are running your own overpass instance
+    without rate limiting. Default is `True`.
+overpass_settings : string
+    Settings string for Overpass queries. Default is
+    `"[out:json][timeout:{timeout}]{maxsize}"`. By default, the {timeout} and
+    {maxsize} values are set dynamically by OSMnx when used.
+    To query, for example, historical OSM data as of a certain date:
+    `'[out:json][timeout:90][date:"2019-10-28T19:20:00Z"]'`. Use with caution.
+requests_kwargs : dict
+    Optional keyword args to pass to the requests package when connecting
+    to APIs, for example to configure authentication or provide a path to
+    a local certificate file. More info on options such as auth, cert,
+    verify, and proxies can be found in the requests package advanced docs.
+    Default is `{}`.
+timeout : int
+    The timeout interval in seconds for the HTTP request and for API to use
+    while running the query. Default is `180`.
+use_cache : bool
+    If True, cache HTTP responses locally instead of calling API repeatedly
+    for the same request. Default is `True`.
+useful_tags_node : list
+    OSM "node" tags to add as graph node attributes, when present in the data
+    retrieved from OSM. Default is `["ref", "highway"]`.
+useful_tags_way : list
+    OSM "way" tags to add as graph edge attributes, when present in the data
+    retrieved from OSM. Default is `["bridge", "tunnel", "oneway", "lanes",
+    "ref", "name", "highway", "maxspeed", "service", "access", "area",
+    "landuse", "width", "est_width", "junction"]`.
+"""
 
 import logging as lg
 
-# default locations to save data, logs, images, and cache
-data_folder = "./data"
-logs_folder = "./logs"
-imgs_folder = "./images"
+all_oneway = False
+bidirectional_network_types = ["walk"]
 cache_folder = "./cache"
-
-# cache server responses
-use_cache = True
-
-# if True, download net data from Overpass then raise CacheOnlyModeInterrupt.
-# useful for sequentially caching lots of raw data then using that cache to
-# quickly build many graphs simultaneously with multiprocessing
 cache_only_mode = False
-
-# write log to file and/or to console
-log_file = False
+data_folder = "./data"
+default_accept_language = "en"
+default_access = '["access"!~"private"]'
+default_crs = "epsg:4326"
+default_referer = "OSMnx Python package (https://github.com/gboeing/osmnx)"
+default_user_agent = "OSMnx Python package (https://github.com/gboeing/osmnx)"
+imgs_folder = "./images"
 log_console = False
+log_file = False
+log_filename = "osmnx"
 log_level = lg.INFO
 log_name = "OSMnx"
-log_filename = "osmnx"
-
-# OSM node/way tags to add as graph node/edge attributes when these tags are
-# present in the data retrieved from OSM
+logs_folder = "./logs"
+max_query_area_size = 50 * 1000 * 50 * 1000
+memory = None
+nominatim_endpoint = "https://nominatim.openstreetmap.org/"
+nominatim_key = None
+osm_xml_node_attrs = ["id", "timestamp", "uid", "user", "version", "changeset", "lat", "lon"]
+osm_xml_node_tags = ["highway"]
+osm_xml_way_attrs = ["id", "timestamp", "uid", "user", "version", "changeset"]
+osm_xml_way_tags = ["highway", "lanes", "maxspeed", "name", "oneway"]
+overpass_endpoint = "https://overpass-api.de/api"
+overpass_rate_limit = True
+overpass_settings = "[out:json][timeout:{timeout}]{maxsize}"
+requests_kwargs = dict()
+timeout = 180
+use_cache = True
 useful_tags_node = ["ref", "highway"]
 useful_tags_way = [
     "bridge",
@@ -43,68 +174,3 @@ useful_tags_way = [
     "est_width",
     "junction",
 ]
-
-# tags and attributes for generating an OSM XML file
-osm_xml_node_attrs = ["id", "timestamp", "uid", "user", "version", "changeset", "lat", "lon"]
-osm_xml_node_tags = ["highway"]
-osm_xml_way_attrs = ["id", "timestamp", "uid", "user", "version", "changeset"]
-osm_xml_way_tags = ["highway", "lanes", "maxspeed", "name", "oneway"]
-
-# default settings string for overpass queries: timeout and maxsize need to
-# be dynamically set where used
-overpass_settings = "[out:json][timeout:{timeout}]{maxsize}"
-
-# the timeout interval for the HTTP request and for API to use while running
-# the query
-timeout = 180
-
-# overpass server memory allocation size for the query, in bytes. If None,
-# server will use its default allocation size
-memory = None
-
-# maximum area for any part of the geometry in meters: any polygon bigger than
-# this will get divided up for multiple queries to API (default 50km x 50km)
-max_query_area_size = 50 * 1000 * 50 * 1000
-
-# default filter for OSM "access" key. filtering out "access=no" ways prevents
-# including transit-only bridges like tilikum crossing from appearing in drivable
-# road network (e.g., '["access"!~"private|no"]'). however, some drivable
-# tollroads have "access=no" plus a "access:conditional" key to clarify when
-# it is accessible, so we can't filter out all "access=no" ways by default.
-# best to be permissive here then remove complicated combinations of tags
-# programatically after the full graph is downloaded and constructed.
-default_access = '["access"!~"private"]'
-
-# The network types for which a bidirectional graph will be created
-bidirectional_network_types = ["walk"]
-
-# all one-way mode to maintain original OSM node order when creating graphs
-# specifically to save to .osm xml file with save_graph_xml function.
-# this also retains original OSM string values for oneway attribute rather
-# than converting it to a True/False bool
-all_oneway = False
-
-# default CRS to set when creating graphs
-default_crs = "epsg:4326"
-
-# default HTTP request headers
-default_user_agent = "OSMnx Python package (https://github.com/gboeing/osmnx)"
-default_referer = "OSMnx Python package (https://github.com/gboeing/osmnx)"
-default_accept_language = "en"
-
-# dict of optional keyword arguments to pass to the requests package when
-# connecting to APIs
-requests_kwargs = {}
-
-# base API endpoint to use for nominatim queries
-# and your nominatim API key, if you are using a host that requires one
-nominatim_endpoint = "https://nominatim.openstreetmap.org/"
-nominatim_key = None
-
-# base API endpoint to use for overpass queries
-overpass_endpoint = "https://overpass-api.de/api"
-
-# whether to check the overpass server status endpoint for how long to pause
-# between requests: necessary if server uses slot management, but can be set
-# to False if you are running your own overpass instance without rate limiting
-overpass_rate_limit = True

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -5,6 +5,7 @@ import logging as lg
 import os
 import sys
 import unicodedata
+import warnings
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -114,107 +115,87 @@ def config(
     useful_tags_way=settings.useful_tags_way,
 ):
     """
-    Configure OSMnx by setting the default global settings' values.
-
-    Any parameters not passed by the caller are (re-)set to their original
-    default values.
+    Do not use: deprecated.
 
     Parameters
     ----------
     all_oneway : bool
-        Only use if specifically saving to .osm XML file with save_graph_xml
-        function. if True, forces all ways to be loaded as oneway ways,
-        preserving the original order of nodes stored in the OSM way XML.
-        This also retains original OSM string values for oneway attribute
-        values, rather than converting them to a True/False bool.
+        deprecated
     bidirectional_network_types : list
-        network types for which a fully bidirectional graph will be created
+        deprecated
     cache_folder : string or pathlib.Path
-        path to folder in which to save/load HTTP response cache
+        deprecated
     data_folder : string or pathlib.Path
-        path to folder in which to save/load graph files by default
+        deprecated
     cache_only_mode : bool
-        If True, download network data from Overpass then raise a
-        CacheOnlyModeInterrupt error for user to catch. This prevents graph
-        building from taking place and instead just saves OSM response data to
-        cache. Useful for sequentially caching lots of raw data (as you can
-        only query Overpass one request at a time) then using the cache to
-        quickly build many graphs simultaneously with multiprocessing.
+        deprecated
     default_accept_language : string
-        HTTP header accept-language
+        deprecated
     default_access : string
-        default filter for OSM "access" key
+        deprecated
     default_crs : string
-        default coordinate reference system to set when creating graphs
+        deprecated
     default_referer : string
-        HTTP header referer
+        deprecated
     default_user_agent : string
-        HTTP header user-agent
+        deprecated
     imgs_folder : string or pathlib.Path
-        path to folder in which to save plot images by default
+        deprecated
     log_file : bool
-        if True, save log output to a file in logs_folder
+        deprecated
     log_filename : string
-        name of the log file, without file extension
+        deprecated
     log_console : bool
-        if True, print log output to the console (terminal window)
+        deprecated
     log_level : int
-        one of Python's logger.level constants
+        deprecated
     log_name : string
-        name of the logger
+        deprecated
     logs_folder : string or pathlib.Path
-        path to folder in which to save log files
+        deprecated
     max_query_area_size : int
-        maximum area for any part of the geometry in meters: any polygon
-        bigger than this will get divided up for multiple queries to API
-        (default 50km x 50km)
+        deprecated
     memory : int
-        Overpass server memory allocation size for the query, in bytes. If
-        None, server will use its default allocation size. Use with caution.
+        deprecated
     nominatim_endpoint : string
-        base API endpoint to use for nominatim queries
+        deprecated
     nominatim_key : string
-        your API key, if you are using an endpoint that requires one
+        deprecated
     osm_xml_node_attrs : list
-        node attributes for saving .osm XML files with save_graph_xml function
+        deprecated
     osm_xml_node_tags : list
-        node tags for saving .osm XML files with save_graph_xml function
+        deprecated
     osm_xml_way_attrs : list
-        edge attributes for saving .osm XML files with save_graph_xml function
+        deprecated
     osm_xml_way_tags : list
-        edge tags for for saving .osm XML files with save_graph_xml function
+        deprecated
     overpass_endpoint : string
-        base API endpoint to use for overpass queries
+        deprecated
     overpass_rate_limit : bool
-        if True, check the overpass server status endpoint for how long to
-        pause before making request. Necessary if server uses slot management,
-        but can be set to False if you are running your own overpass instance.
+        deprecated
     overpass_settings : string
-        Settings string for overpass queries. For example, to query historical
-        OSM data as of a certain date:
-        ``'[out:json][timeout:90][date:"2019-10-28T19:20:00Z"]'``. Use with
-        caution.
+        deprecated
     requests_kwargs : dict
-        optional keyword args to pass to the requests package when connecting
-        to APIs, for example to configure authentication or provide a path to
-        a local certificate file. More info on options such as auth, cert,
-        verify, and proxies can be found in the requests package advanced docs
-        at https://docs.python-requests.org/
+        deprecated
     timeout : int
-        the timeout interval for the HTTP request and for API to use while
-        running the query
+        deprecated
     use_cache : bool
-        if True, cache HTTP responses locally instead of calling API
-        repeatedly for the same request
+        deprecated
     useful_tags_node : list
-        OSM "node" tags to add as graph node attributes, when present
+        deprecated
     useful_tags_way : list
-        OSM "way" tags to add as graph edge attributes, when present
+        deprecated
 
     Returns
     -------
     None
     """
+    warnings.warn(
+        "The `utils.config` function is deprecated and will be removed in a "
+        "future release. Instead, use the `settings` module directly. For "
+        "example, `ox.settings.log_console=True`."
+    )
+
     # set each global setting to the argument value
     settings.all_oneway = all_oneway
     settings.bidirectional_network_types = bidirectional_network_types

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -9,7 +9,6 @@ import warnings
 from contextlib import redirect_stdout
 from pathlib import Path
 
-from . import _version
 from . import settings
 
 
@@ -115,7 +114,7 @@ def config(
     useful_tags_way=settings.useful_tags_way,
 ):
     """
-    Do not use: deprecated.
+    Do not use: deprecated. Use the settings module directly.
 
     Parameters
     ----------
@@ -192,8 +191,9 @@ def config(
     """
     warnings.warn(
         "The `utils.config` function is deprecated and will be removed in a "
-        "future release. Instead, use the `settings` module directly. For "
-        "example, `ox.settings.log_console=True`."
+        "future release. Instead, use the `settings` module directly to "
+        "configure a global setting's value. For example, "
+        "`ox.settings.log_console=True`."
     )
 
     # set each global setting to the argument value
@@ -230,9 +230,6 @@ def config(
     settings.useful_tags_node = useful_tags_node
     settings.useful_tags_way = useful_tags_way
     settings.requests_kwargs = requests_kwargs
-
-    log(f"Configured OSMnx {_version.__version__}")
-    log(f"HTTP response caching is {'on' if settings.use_cache else 'off'}")
 
 
 def log(message, level=None, name=None, filename=None):


### PR DESCRIPTION
Deprecate the `utils.config` function and clean up the `settings` module for users to use directly instead.