### PR TITLE
Proposed fix for CI failure

### DIFF
--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -42,7 +42,8 @@ def _query_raster(nodes, filepath, band):
     """
     # must open raster file here: cannot pickle it to pass in multiprocessing
     with rasterio.open(filepath) as raster:
-        values = np.array(tuple(raster.sample(nodes.values, band)), dtype=float).squeeze()
+        nodes_generator = (tuple(x) for x in nodes.values)
+        values = np.array(tuple(raster.sample(nodes_generator, band)), dtype=float).squeeze()
         values[values == raster.nodata] = np.nan
         return zip(nodes.index, values)
 

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -92,7 +92,7 @@ def plot_route_folium(
     """
     # create gdf of the route edges in order
     node_pairs = zip(route[:-1], route[1:])
-    uvk = ((u, v, min(G[u][v], key=lambda k: G[u][v][k]["length"])) for u, v in node_pairs)
+    uvk = ((u, v, min(G[u][v].items(), key=lambda k: k[1]["length"])[0]) for u, v in node_pairs)
     gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
     return _plot_folium(gdf_edges, route_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)
 


### PR DESCRIPTION
flake8-bugbear complains of "B023 Function definition does not bind loop variable 'u'." ([link to action log](https://github.com/gboeing/osmnx/runs/7175001370?check_suite_focus=true#step:5:14).) See [the upstream issue](https://github.com/PyCQA/flake8-bugbear/issues/263) for why the warning was added and what it's checking for. 

This is not really a bug, because the lambda only lasts as long as a single iteration of the iterator. This PR fixes the warning by passing the edge as a parameter to the key lambda, which avoids binding the loop var.

Also, I refactored by moving _get_shortest_edges to own function. Too hard to wrap my head around the code otherwise.

Tested changes by using the 11-plot-routes-folium-web-map.ipynb example.

You may also want to just ignore the bugbear error as a false positive. If that's your preference, feel free to close this PR.