### PR TITLE
Multi platform GitHub action

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -14,8 +14,8 @@ on:
         description: Image platform to build for [arm64/amd64]
         required: true
         type: string
-      base_tag:
-        description: Tag of the notebook base image [latest/aarch64-latest]
+      jupyter_tag:
+        description: Tag of the notebook image to build from [latest/aarch64-latest]
         required: true
         type: string
 
@@ -40,4 +40,4 @@ jobs:
           push: false
           platforms: ${{ inputs.platform }}
           tags: ${{ env.OWNER }}/osmnx:${{ inputs.resulting_tag }}
-          build-args: ARCH=${{ inputs.base_tag }}
+          build-args: JUPYTER_TAG=${{ inputs.jupyter_tag }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,40 @@
+name: Build new image, and upload to GitHub artifacts
+
+env:
+  OWNER: ${{ github.repository_owner }}
+
+on:
+  workflow_call:
+    inputs:
+      resulting_tag:
+        description: Resulting tag name [latest/aarch64-latest]
+        required: true
+        type: string
+      platform:
+        description: Image platform to build for [arm64/amd64]
+        required: true
+        type: string
+      base_tag:
+        description: Tag of the notebook base image [latest/aarch64-latest]
+        required: true
+        type: string
+
+jobs:
+  build-upload:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: "./environments/docker"
+          push: false
+          platforms: ${{ inputs.platform }}
+          tags: ${{ env.OWNER }}/osmnx:${{ inputs.resulting_tag }}
+          build-args: ARCH=${{ inputs.base_tag }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -27,6 +27,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,37 +6,14 @@ env:
 on: [push]
 jobs:
   amd64-base:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: "./environments/docker"
-          push: false
-          platforms: amd64
-          tags: ${{ env.OWNER }}/osmnx:latest
-  aarch64-base:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: "./environments/docker"
-          push: false
-          platforms: arm64
-          tags: ${{ env.OWNER }}/osmnx:aarch64-latest
-          build-args: ARCH=aarch64-latest
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      platform: amd64
+      resulting_tag: 'latest'
+      base_tag: 'latest'
+  # aarch64-base:
+  #   uses: ./.github/workflows/docker-build-push.yml
+  #   with:
+  #     platform: arm64
+  #     resulting_tag: 'aarch64-latest'
+  #     base_tag: 'aarch64-latest'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,10 @@ jobs:
     with:
       platform: amd64
       resulting_tag: 'latest'
-      base_tag: 'latest'
+      jupyter_tag: 'latest'
   aarch64-base:
     uses: ./.github/workflows/docker-build-push.yml
     with:
       platform: arm64
       resulting_tag: 'aarch64-latest'
-      base_tag: 'aarch64-latest'
+      jupyter_tag: 'aarch64-latest'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: ./environments/docker
+          context: "{{defaultContext}}/environments/docker"
           push: false
           platforms: amd64
           tags: ${{ env.OWNER }}/osmnx:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,9 +11,9 @@ jobs:
       platform: amd64
       resulting_tag: 'latest'
       base_tag: 'latest'
-  # aarch64-base:
-  #   uses: ./.github/workflows/docker-build-push.yml
-  #   with:
-  #     platform: arm64
-  #     resulting_tag: 'aarch64-latest'
-  #     base_tag: 'aarch64-latest'
+  aarch64-base:
+    uses: ./.github/workflows/docker-build-push.yml
+    with:
+      platform: arm64
+      resulting_tag: 'aarch64-latest'
+      base_tag: 'aarch64-latest'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
           platforms: amd64
           tags: ${{ env.OWNER }}/osmnx:latest
   aarch64-base:
-    runs-on: [self-hosted, linux, ARM64]
+    runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
@@ -39,3 +39,4 @@ jobs:
           push: false
           platforms: arm64
           tags: ${{ env.OWNER }}/osmnx:aarch64-latest
+          build-args: ARCH=aarch64-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,14 @@
+name: Build and push docker images
+
+env:
+  OWNER: ${{ github.repository_owner }}
+
+on:
+  workflow_dispatch:
+jobs:
+  amd64-base:
+    uses: docker/build-push-action@v3
+    with:
+      context: ./environments/docker
+      push: false
+      tags: ${{ env.OWNER }}/osmnx:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,13 @@ on:
   workflow_dispatch:
 jobs:
   amd64-base:
-    uses: docker/build-push-action@v3
-    with:
-      context: ./environments/docker
-      push: false
-      tags: ${{ env.OWNER }}/osmnx:latest
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./environments/docker
+          push: false
+          platforms: amd64
+          tags: ${{ env.OWNER }}/osmnx:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,7 @@ name: Build and push docker images
 env:
   OWNER: ${{ github.repository_owner }}
 
-on:
-  workflow_dispatch:
+on: [push]
 jobs:
   amd64-base:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,10 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: "{{defaultContext}}/environments/docker"
+          context: "./environments/docker"
           push: false
           platforms: amd64
           tags: ${{ env.OWNER }}/osmnx:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,3 +22,20 @@ jobs:
           push: false
           platforms: amd64
           tags: ${{ env.OWNER }}/osmnx:latest
+  aarch64-base:
+    runs-on: [self-hosted, linux, ARM64]
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: "./environments/docker"
+          push: false
+          platforms: arm64
+          tags: ${{ env.OWNER }}/osmnx:aarch64-latest

--- a/environments/docker/Dockerfile
+++ b/environments/docker/Dockerfile
@@ -4,7 +4,10 @@
 # Web: https://github.com/gboeing/osmnx
 ########################################################################
 
-FROM jupyter/base-notebook
+# use --build-arg ARCH=aarch64-latest to build for ARM
+ARG ARCH='latest'
+
+FROM jupyter/base-notebook:$ARCH
 LABEL maintainer="Geoff Boeing <boeing@usc.edu>"
 LABEL url="https://github.com/gboeing/osmnx"
 LABEL description="OSMnx is a Python package to retrieve, model, analyze, and visualize OpenStreetMap networks and other spatial data."

--- a/environments/docker/Dockerfile
+++ b/environments/docker/Dockerfile
@@ -4,10 +4,10 @@
 # Web: https://github.com/gboeing/osmnx
 ########################################################################
 
-# use --build-arg ARCH=aarch64-latest to build for ARM
-ARG ARCH='latest'
+# use --build-arg JUPYTER_TAG=aarch64-latest to build for ARM
+ARG JUPYTER_TAG='latest'
 
-FROM jupyter/base-notebook:$ARCH
+FROM jupyter/base-notebook:$JUPYTER_TAG
 LABEL maintainer="Geoff Boeing <boeing@usc.edu>"
 LABEL url="https://github.com/gboeing/osmnx"
 LABEL description="OSMnx is a Python package to retrieve, model, analyze, and visualize OpenStreetMap networks and other spatial data."


### PR DESCRIPTION
Following up with a proof of concept on https://github.com/gboeing/osmnx/issues/855

Uses GitHub Actions to build the docker images on a remote machine. This remote machine is configured to allow builds of an ARM based image (using QEMU)

Some more "upstream reality" scuppered the original plan for a single cross-platform image. [The Jupyter project creates separate images](https://github.com/jupyter/docker-stacks/issues/1737) for arm and x86 and since we need to use the relevant one of these as the base image, we also need to create separate images.

So, this workflow will build `osmnx:latest` and `osmnx:aarch64-latest` which is in line with the naming convention used on the Jupyter project.

### Work remaining

Before I go further, I wanted to post a draft PR and see what you think. You should be able to see the build logs of the images in https://github.com/tomharvey/osmnx/actions but I think if you approve the new workflow it'll run on your account so you can see it build in there. Note that the aarch64 build takes considerably longer as it's run under QEMU emulation

- [ ] We're currently only building `latest` tags, add the ability to build for tag version (such as `v1.2`)
- [ ] Build on manual trigger instead of code push
- [ ] Actually push to dockerhub. Suggest that I initially push to `tomharvey/osmnx:{aarch64-}latest` so we can QA from there.
- [ ] What to do with the conda env? `conda env export -n base > /home/jovyan/work/environment.yml`

The current build.sh dumps the conda env to your workstation. What's that used for? This could upload that file to the build artefacts on GitHub if you needed to keep that.

### Potential future improvements

None of the below are strictly necessary, but let me know if you think otherwise.

##### 1. Add some testing.
Just as in the build step you've got `ipython -c "import osmnx; print('OSMnx version', osmnx.__version__)"` we could add a test step to ask the built image to run this before pushing to dockerhub.

##### 2. Build more images for more feature packed containers.
As we have a mechanism to choose the base image tag, we can expand on this to change the base image, and build an osmnx image from the [base/minimal/datascience/pyspark notebook images as well](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html).