### PR TITLE
Revert "Convert numpy array to tuples before passing to raster.sample()"

### DIFF
--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -42,8 +42,7 @@ def _query_raster(nodes, filepath, band):
     """
     # must open raster file here: cannot pickle it to pass in multiprocessing
     with rasterio.open(filepath) as raster:
-        nodes_generator = (tuple(x) for x in nodes.values)
-        values = np.array(tuple(raster.sample(nodes_generator, band)), dtype=float).squeeze()
+        values = np.array(tuple(raster.sample(nodes.values, band)), dtype=float).squeeze()
         values[values == raster.nodata] = np.nan
         return zip(nodes.index, values)
 


### PR DESCRIPTION
Fixes #863.

This commit was originally added to fix a rasterio bug which has now been resolved upstream. See rasterio/rasterio#2547 for the fix, and PR #842 for how it applies to OSMnx.

This reverts commit 4ba2b1dbb3e15ab12f7eb5a807e481844948542f.