### PR TITLE
union statement for custom_filter

### DIFF
--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -518,8 +518,9 @@ def _osm_network_download(polygon, network_type, custom_filter):
         boundary to fetch the network ways/nodes within
     network_type : string
         what type of street network to get if custom_filter is None
-    custom_filter : string
-        a custom ways filter to be used instead of the network_type presets
+    custom_filter : string | list of strings
+        a custom ways filter to be used instead of the network_type presets. 
+        If a list of strings is provided, those a combined with the union criteria.
 
     Returns
     -------
@@ -544,7 +545,11 @@ def _osm_network_download(polygon, network_type, custom_filter):
     # pass each polygon exterior coordinates in the list to the API, one at a
     # time. The '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
-        query_str = f"{overpass_settings};(way{osm_filter}(poly:'{polygon_coord_str}');>;);out;"
+        if type(osm_filter) == list:
+            waystring = ';'.join(["way"+part+f"(poly:'{polygon_coord_str}')" for part in osm_filter])
+            query_str = f"{overpass_settings};({waystring};>;);out;"
+        else:
+            query_str = f"{overpass_settings};(way{osm_filter}(poly:'{polygon_coord_str}');>;);out;"
         response_json = overpass_request(data={"data": query_str})
         response_jsons.append(response_json)
     utils.log(

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -546,8 +546,8 @@ def _osm_network_download(polygon, network_type, custom_filter):
     # time. The '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
         if type(osm_filter) == list:
-            waystring = ';'.join(["way"+part+f"(poly:'{polygon_coord_str}')" for part in osm_filter])
-            query_str = f"{overpass_settings};({waystring};>;);out;"
+            waystring = ''.join(["way"+part+f"(poly:'{polygon_coord_str}');>;" for part in osm_filter])
+            query_str = f"{overpass_settings};({waystring});out;"
         else:
             query_str = f"{overpass_settings};(way{osm_filter}(poly:'{polygon_coord_str}');>;);out;"
         response_json = overpass_request(data={"data": query_str})

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -61,11 +61,12 @@ def graph_from_bbox(
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
+    custom_filter : string | list of strings
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
         in a network_type that is in settings.bidirectional_network_types if
         you want graph to be fully bi-directional.
+        If a list of strings is provided, those are combined with the union criteria.
 
     Returns
     -------
@@ -135,11 +136,12 @@ def graph_from_point(
     clean_periphery : bool,
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
+    custom_filter : string | list of strings
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
         in a network_type that is in settings.bidirectional_network_types if
         you want graph to be fully bi-directional.
+        If a list of strings is provided, those are combined with the union criteria.
 
     Returns
     -------
@@ -225,11 +227,12 @@ def graph_from_address(
     clean_periphery : bool,
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
+    custom_filter : string | list of strings
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
         in a network_type that is in settings.bidirectional_network_types if
         you want graph to be fully bi-directional.
+        If a list of strings is provided, those are combined with the union criteria.
 
     Returns
     -------
@@ -313,11 +316,12 @@ def graph_from_place(
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
+    custom_filter : string | list of strings
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
         in a network_type that is in settings.bidirectional_network_types if
         you want graph to be fully bi-directional.
+        If a list of strings is provided, those are combined with the union criteria.
 
     Returns
     -------
@@ -392,11 +396,12 @@ def graph_from_polygon(
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
-    custom_filter : string
+    custom_filter : string | list of strings
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
         in a network_type that is in settings.bidirectional_network_types if
         you want graph to be fully bi-directional.
+        If a list of strings is provided, those are combined with the union criteria.
 
     Returns
     -------


### PR DESCRIPTION
I had the problem that I have to analyse the bicycle quality of a city. For that I needed all small roads and big roads with cyclelanes. For that I needed a union statement in the filter and therefore I needed a fix.

This for overpass-turbo:

```overpassQL
[out:json][timeout:240];(way["highway"]["area"!~"yes"]["access"!~"private"]["highway"!~"abandoned|construction|planned|platform|proposed|raceway|motorway|trunk|primary|secondary|tertiary"]["service"!~"private"]({{bbox}});>;
                         way["highway"]["area"!~"yes"]["access"!~"private"]["cycleway"]["cycleway"!~"no"]["service"!~"private"]({{bbox}});>;);out;
```

Don't know if this quick fix will pass tests... lets see.