### PR TITLE
deprecate save_graph_shapefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
   - fix bug that added unsimplified edge geometry attributes when projecting
+  - deprecate save_graph_shapefile function
 
 ## 1.2.2 (2022-08-05)
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -1,6 +1,7 @@
 """Serialize graphs to/from files on disk."""
 
 import ast
+import warnings
 from pathlib import Path
 
 import networkx as nx
@@ -59,11 +60,11 @@ def save_graph_geopackage(G, filepath=None, encoding="utf-8", directed=False):
 
 def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
     """
-    Save graph nodes and edges to disk as ESRI shapefiles.
+    Do not use: deprecated. Use the save_graph_geopackage function instead.
 
-    The shapefile format is proprietary and outdated. Whenever possible, you
-    should use the superior GeoPackage file format instead via the
-    save_graph_geopackage function.
+    The Shapefile format is proprietary and outdated. Instead, use the
+    superior GeoPackage file format via the save_graph_geopackage function.
+    See http://switchfromshapefile.org/ for more information.
 
     Parameters
     ----------
@@ -83,6 +84,12 @@ def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
     -------
     None
     """
+    warnings.warn(
+        "The `save_graph_shapefile` function is deprecated and will be removed "
+        "in a future release. Instead, use the `save_graph_geopackage` function "
+        "to save graphs as modern GeoPackage files for subsequent GIS analysis."
+    )
+
     # default filepath if none was provided
     if filepath is None:
         filepath = Path(settings.data_folder) / "graph_shapefile"

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -87,7 +87,7 @@ def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
     warnings.warn(
         "The `save_graph_shapefile` function is deprecated and will be removed "
         "in a future release. Instead, use the `save_graph_geopackage` function "
-        "to save graphs as modern GeoPackage files for subsequent GIS analysis."
+        "to save graphs as GeoPackage files for subsequent GIS analysis."
     )
 
     # default filepath if none was provided

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -104,9 +104,12 @@ def save_graph_xml(
 
     This function exists only to allow serialization to the .osm file format
     for applications that require it, and has constraints to conform to that.
-    To save/load full-featured OSMnx graphs to/from disk for later use, use
-    the `io.save_graphml` and `io.load_graphml` functions instead. To load a
-    graph from a .osm file, use the `graph.graph_from_xml` function.
+    As such, this function has a limited use case which does not include
+    saving/loading graphs for subsequent OSMnx analysis. To save/load graphs
+    to/from disk for later use in OSMnx, use the `io.save_graphml` and
+    `io.load_graphml` functions instead. To load a graph from a .osm file that
+    you have downloaded or generated elsewhere, use the `graph.graph_from_xml`
+    function.
 
     Note: for large networks this function can take a long time to run. Before
     using this function, make sure you configured OSMnx as described in the

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import pandas as pd
+from matplotlib import colormaps
 
 from . import graph
 from . import projection
@@ -42,7 +43,7 @@ def get_colors(n, cmap="viridis", start=0.0, stop=1.0, alpha=1.0, return_hex=Fal
     -------
     color_list : list
     """
-    color_list = [cm.get_cmap(cmap)(x) for x in np.linspace(start, stop, n)]
+    color_list = [colormaps[cmap](x) for x in np.linspace(start, stop, n)]
     if return_hex:
         color_list = [colors.to_hex(c) for c in color_list]
     else:
@@ -677,7 +678,7 @@ def _get_colors_by_value(vals, num_bins, cmap, start, stop, na_color, equal_size
 
         # linearly map a color to each attribute value
         normalizer = colors.Normalize(full_min, full_max)
-        scalar_mapper = cm.ScalarMappable(normalizer, cm.get_cmap(cmap))
+        scalar_mapper = cm.ScalarMappable(normalizer, colormaps[cmap])
         color_series = vals.map(scalar_mapper.to_rgba)
         color_series.loc[pd.isnull(vals)] = na_color
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -43,7 +43,7 @@ ox.settings.cache_folder = ".temp/cache"
 location_point = (37.791427, -122.410018)
 address = "600 Montgomery St, San Francisco, California, USA"
 place1 = {"city": "Piedmont", "state": "California", "country": "USA"}
-place2 = "Bunker Hill, Los Angeles, California"
+place2 = "Civic Center, Los Angeles, California"
 p = (
     "POLYGON ((-122.262 37.869, -122.255 37.869, -122.255 37.874,"
     "-122.262 37.874, -122.262 37.869))"


### PR DESCRIPTION
Shapefiles are a proprietary, outdated, and increasingly obsolete file format for serializing geospatial data. Given the Shapefile format's limitations, and OSMnx's existing support for GeoPackage saving, we will begin shifting away from supporting Shapefiles with this `save_graph_shapefile` deprecation. Users can utilize the `save_graph_geopackage` function instead, and GeoPackages can be converted to Shapefiles by pretty much any GIS software, if the user needs a Shapefile in the end.

More info:
  - https://en.wikipedia.org/wiki/Shapefile#Limitations
  - http://switchfromshapefile.org/