### PR TITLE
Fix ImportError with Shapely 2.0.

### DIFF
--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -14,11 +14,11 @@ import warnings
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from shapely.errors import TopologicalError
 from shapely.geometry import LineString
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Point
 from shapely.geometry import Polygon
-from shapely.errors import TopologicalError
 from shapely.ops import linemerge
 from shapely.ops import polygonize
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -18,7 +18,7 @@ from shapely.geometry import LineString
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Point
 from shapely.geometry import Polygon
-from shapely.geos import TopologicalError
+from shapely.errors import TopologicalError
 from shapely.ops import linemerge
 from shapely.ops import polygonize
 


### PR DESCRIPTION
shapely.errors provides TopologicalError since [1.6a2](https://github.com/shapely/shapely/commit/b16ea053b4b33d7bbd3fa3ba644901bfbd9de387#diff-f85c004203caea01bd763e4f07be4d363924d37ba71fc7f6ed212b1db5508a0b).