### PR TITLE
Compatibility with shapely 2 and matplotlib 3.4

### DIFF
--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -15,6 +15,10 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from shapely.errors import TopologicalError
+try:
+    from shapely.errors import GEOSException
+except ImportError:
+    GEOSException = ValueError
 from shapely.geometry import LineString
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Point
@@ -570,7 +574,7 @@ def _parse_way_to_linestring_or_polygon(element, coords, polygon_features=_polyg
             # if it is a Polygon
             try:
                 geometry = Polygon([(coords[node]["lon"], coords[node]["lat"]) for node in nodes])
-            except ValueError as e:
+            except (GEOSException, ValueError) as e:
                 # XMLs may include geometries that are incomplete, in which
                 # case return an empty geometry
                 utils.log(
@@ -584,7 +588,7 @@ def _parse_way_to_linestring_or_polygon(element, coords, polygon_features=_polyg
                 geometry = LineString(
                     [(coords[node]["lon"], coords[node]["lat"]) for node in nodes]
                 )
-            except ValueError as e:
+            except (GEOSException, ValueError) as e:
                 # XMLs may include geometries that are incomplete, in which
                 # case return an empty geometry
                 utils.log(

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -15,6 +15,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 from shapely.errors import TopologicalError
+
 try:
     from shapely.errors import GEOSException
 except ImportError:

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -8,10 +8,12 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import pandas as pd
+
 try:
     from matplotlib import colormaps
 except ImportError:
     from matplotlib.pyplot import colormaps as mpl_cmaps
+
     colormaps = {c: cm.get_cmap(c) for c in mpl_cmaps()}
 
 from . import graph

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -8,7 +8,10 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
 import pandas as pd
-from matplotlib import colormaps
+try:
+    from matplotlib import colormaps
+except ImportError:
+    from matplotlib.pyplot import colormaps
 
 from . import graph
 from . import projection

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -11,7 +11,8 @@ import pandas as pd
 try:
     from matplotlib import colormaps
 except ImportError:
-    from matplotlib.pyplot import colormaps
+    from matplotlib.pyplot import colormaps as mpl_cmaps
+    colormaps = {c: cm.get_cmap(c) for c in mpl_cmaps()}
 
 from . import graph
 from . import projection

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pandas>=1.4
 pyproj>=3.3
 requests>=2.28
 Rtree>=1.0
-Shapely>=1.8,<2.0
+Shapely>=1.8


### PR DESCRIPTION
This PR fixes an issue with `shapely` 2 in the `osm_xml` module and another compatibility issue with `matplotlib` 3.4.

I also have another suggestion regarding `shapely` 2. Since `geopandas` throws a warning when both `pygeos` and `shapely` 2.0 are installed, we can add these lines to `__init__.py` to take care of the warning:

```python
from importlib.metadata import version

if int(version("shapely").split(".")[0]) > 1:
    import os

    os.environ["USE_PYGEOS"] = "0"
```

Note that `importlib` is a built-in Python 3.8+ module.