### PR TITLE
add add_node_elevations_opentopodata function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - hard code Google DNS IP address
   - resolve matplotlib deprecation warning
   - deprecate save_graph_shapefile function
+  - add add_node_elevations_opentopodata function
 
 ## 1.2.2 (2022-08-05)
 

--- a/osmnx/_api.py
+++ b/osmnx/_api.py
@@ -9,6 +9,7 @@ from .distance import nearest_nodes
 from .distance import shortest_path
 from .elevation import add_edge_grades
 from .elevation import add_node_elevations_google
+from .elevation import add_node_elevations_opentopodata
 from .elevation import add_node_elevations_raster
 from .folium import plot_graph_folium
 from .folium import plot_route_folium


### PR DESCRIPTION
hence there are APIs between google and opentopodata are quite similar, they share the same underlying function.

for opentopodata it is possible to customize the endpoint because it can be hosted locally. by default it uses the public API. the dataset is customizeable as well because the user might want use a different one. the default is aster30m, which works worldwide to 30m

Solving issue:
https://github.com/gboeing/osmnx/issues/893

Example: 
`G = ox.add_node_elevations_opentopodata(G)`