### PR TITLE
Shapely 2.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .pytest_cache
 tests/run_tests.bat
 *.vrt
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,6 @@ autodoc_mock_imports = [
     "pyproj",
     "rasterio",
     "requests",
-    "rtree",
     "scipy",
     "scipy.spatial",
     "shapely",

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -14,6 +14,7 @@ import warnings
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from shapely.errors import GEOSException
 from shapely.errors import TopologicalError
 from shapely.geometry import LineString
 from shapely.geometry import MultiPolygon
@@ -570,7 +571,7 @@ def _parse_way_to_linestring_or_polygon(element, coords, polygon_features=_polyg
             # if it is a Polygon
             try:
                 geometry = Polygon([(coords[node]["lon"], coords[node]["lat"]) for node in nodes])
-            except ValueError as e:
+            except (GEOSException, ValueError) as e:
                 # XMLs may include geometries that are incomplete, in which
                 # case return an empty geometry
                 utils.log(
@@ -584,7 +585,7 @@ def _parse_way_to_linestring_or_polygon(element, coords, polygon_features=_polyg
                 geometry = LineString(
                     [(coords[node]["lon"], coords[node]["lat"]) for node in nodes]
                 )
-            except ValueError as e:
+            except (GEOSException, ValueError) as e:
                 # XMLs may include geometries that are incomplete, in which
                 # case return an empty geometry
                 utils.log(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pandas>=1.4
 pyproj>=3.3
 requests>=2.28
 Rtree>=1.0
-Shapely>=1.8,<2.0
+Shapely>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dateutil>=2.8
 geopandas>=0.11
 matplotlib>=3.5
 networkx>=2.8
@@ -5,5 +6,4 @@ numpy>=1.22
 pandas>=1.4
 pyproj>=3.3
 requests>=2.28
-Rtree>=1.0
 Shapely>=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-dateutil>=2.8
 geopandas>=0.12
 matplotlib>=3.6
 networkx>=2.8
 numpy>=1.23
 pandas>=1.5
 pyproj>=3.4
+python-dateutil>=2.8
 requests>=2.28
 Shapely>=2.0

--- a/tests/environment-dev.yml
+++ b/tests/environment-dev.yml
@@ -12,7 +12,6 @@ dependencies:
     - pandas
     - pyproj
     - requests
-    - Rtree
     - Shapely
 
     # extras

--- a/tests/environment-dev.yml
+++ b/tests/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
     - pyproj
     - requests
     - Rtree
-    - Shapely=1.8.*
+    - Shapely
 
     # extras
     - folium


### PR DESCRIPTION
fixes to finalize compatibility with [Shapely 2.0](https://shapely.readthedocs.io/en/stable/migration.html)

  - [x] replace RTree with shapley.STRTree for nearest edges search (much faster)
  - [x] remove RTree package dependency
  - [x] handle GEOSException