### PR TITLE
Improvements to save_as_xml function

### DIFF
--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -166,9 +166,11 @@ def save_graph_xml(
         component edges. Otherwise, the length attribute will simply
         reflect the length of the first edge associated with the way.
     osm_version : int
-        OpenStreetMap data version to write in the XML file header. Default 0.6.
+        OpenStreetMap data version to write in the XML file header.
+        Default 0.6.
     coordinate_precision : int
-        Number of decimal places to keep when writing latitude and longitude values. Default 7.
+        Number of decimal places to keep when writing latitude and longitude values.
+        Default 7.
 
     Returns
     -------

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -164,7 +164,9 @@ def save_graph_xml(
         this method to aggregate the lengths of the individual
         component edges. Otherwise, the length attribute will simply
         reflect the length of the first edge associated with the way.
-    osm_version : OpenStreetMap data version to write in the XML file header. Default 0.6.
+    osm_version : int
+        OpenStreetMap data version to write in the XML file header. Default 0.6.
+    
     Returns
     -------
     None

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -203,8 +203,8 @@ def save_graph_xml(
 
     # rename columns per osm specification
     gdf_nodes.rename(columns={"x": "lon", "y": "lat"}, inplace=True)
-    gdf_nodes.lon = gdf_nodes.lon.round(coordinate_precision)
-    gdf_nodes.lat = gdf_nodes.lat.round(coordinate_precision)
+    gdf_nodes['lon'] = gdf_nodes['lon'].round(coordinate_precision)
+    gdf_nodes['lat'] = gdf_nodes['lat'].round(coordinate_precision)
     gdf_nodes = gdf_nodes.reset_index().rename(columns={"osmid": "id"})
     if "id" in gdf_edges.columns:
         gdf_edges = gdf_edges[[col for col in gdf_edges if col != "id"]]

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -239,7 +239,7 @@ def save_graph_xml(
 
     # write to disk
     etree.ElementTree(root).write(filepath, encoding="utf-8", xml_declaration=True)
-    utils.log(f'Saved graph as .osm file at "{filepath}"')
+    utils.log(f"Saved graph as .osm file at {filepath!r}")
 
 
 def _append_nodes_xml_tree(root, gdf_nodes, node_attrs, node_tags):

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -203,8 +203,8 @@ def save_graph_xml(
 
     # rename columns per osm specification
     gdf_nodes.rename(columns={"x": "lon", "y": "lat"}, inplace=True)
-    gdf_nodes['lon'] = gdf_nodes['lon'].round(coordinate_precision)
-    gdf_nodes['lat'] = gdf_nodes['lat'].round(coordinate_precision)
+    gdf_nodes["lon"] = gdf_nodes["lon"].round(coordinate_precision)
+    gdf_nodes["lat"] = gdf_nodes["lat"].round(coordinate_precision)
     gdf_nodes = gdf_nodes.reset_index().rename(columns={"osmid": "id"})
     if "id" in gdf_edges.columns:
         gdf_edges = gdf_edges[[col for col in gdf_edges if col != "id"]]

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -98,6 +98,7 @@ def save_graph_xml(
     oneway=False,
     merge_edges=True,
     edge_tag_aggs=None,
+    osm_version=0.6
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.
@@ -163,7 +164,7 @@ def save_graph_xml(
         this method to aggregate the lengths of the individual
         component edges. Otherwise, the length attribute will simply
         reflect the length of the first edge associated with the way.
-
+    osm_version : OpenStreetMap data version to write in the XML file header. Default 0.6.
     Returns
     -------
     None
@@ -221,7 +222,7 @@ def save_graph_xml(
         )
 
     # initialize XML tree with an OSM root element then append nodes/edges
-    root = etree.Element("osm", attrib={"version": "0.6", "generator": "OSMnx"})
+    root = etree.Element("osm", attrib={"version": str(osm_version), "generator": "OSMnx"})
     root = _append_nodes_xml_tree(root, gdf_nodes, node_attrs, node_tags)
     root = _append_edges_xml_tree(
         root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs, merge_edges

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -211,10 +211,6 @@ def save_graph_xml(
         table["changeset"] = "1"
         table["timestamp"] = "2017-01-01T00:00:00Z"
 
-    # convert all datatypes to str
-    gdf_nodes = gdf_nodes.applymap(str)
-    gdf_edges = gdf_edges.applymap(str)
-
     # misc. string replacements to meet OSM XML spec
     if "oneway" in gdf_edges.columns:
         # fill blank oneway tags with default (False)
@@ -257,9 +253,11 @@ def _append_nodes_xml_tree(root, gdf_nodes, node_attrs, node_tags):
         xml tree with nodes appended
     """
     for _, row in gdf_nodes.iterrows():
-        node = etree.SubElement(root, "node", attrib=row[node_attrs].dropna().to_dict())
+        row = row.dropna().astype(str)        
+        node = etree.SubElement(root, "node", attrib=row[node_attrs].to_dict())
+
         for tag in node_tags:
-            if tag in gdf_nodes.columns:
+            if tag in row:
                 etree.SubElement(node, "tag", attrib={"k": tag, "v": row[tag]})
     return root
 
@@ -302,7 +300,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
     if merge_edges:
 
         for _, all_way_edges in gdf_edges.groupby("id"):
-            first = all_way_edges.iloc[0]
+            first = all_way_edges.iloc[0].dropna().astype(str)
             edge = etree.SubElement(root, "way", attrib=first[edge_attrs].dropna().to_dict())
 
             if len(all_way_edges) == 1:
@@ -312,15 +310,15 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
                 # topological sort
                 ordered_nodes = _get_unique_nodes_ordered_from_way(all_way_edges)
                 for node in ordered_nodes:
-                    etree.SubElement(edge, "nd", attrib={"ref": node})
+                    etree.SubElement(edge, "nd", attrib={"ref": str(node)})
 
             if edge_tag_aggs is None:
                 for tag in edge_tags:
-                    if tag in all_way_edges.columns:
+                    if tag in first:
                         etree.SubElement(edge, "tag", attrib={"k": tag, "v": first[tag]})
             else:
                 for tag in edge_tags:
-                    if (tag in all_way_edges.columns) and (
+                    if (tag in first) and (
                         tag not in (t for t, agg in edge_tag_aggs)
                     ):
                         etree.SubElement(edge, "tag", attrib={"k": tag, "v": first[tag]})
@@ -328,7 +326,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
                 for tag, agg in edge_tag_aggs:
                     if tag in all_way_edges.columns:
                         etree.SubElement(
-                            edge, "tag", attrib={"k": tag, "v": all_way_edges[tag].aggregate(agg)}
+                            edge, "tag", attrib={"k": tag, "v": str(all_way_edges[tag].aggregate(agg))}
                         )
     else:
         # NOTE: this will generate separate OSM ways for each network edge,
@@ -338,11 +336,12 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
         # OSM XML schema standard, however, the data will still comprise a
         # valid network and will be readable by *most* OSM tools.
         for _, row in gdf_edges.iterrows():
-            edge = etree.SubElement(root, "way", attrib=row[edge_attrs].dropna().to_dict())
+            row = row.dropna().astype(str)               
+            edge = etree.SubElement(root, "way", attrib=row[edge_attrs].to_dict())
             etree.SubElement(edge, "nd", attrib={"ref": row["u"]})
             etree.SubElement(edge, "nd", attrib={"ref": row["v"]})
             for tag in edge_tags:
-                if tag in gdf_edges.columns:
+                if tag in row:
                     etree.SubElement(edge, "tag", attrib={"k": tag, "v": row[tag]})
 
     return root

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -99,7 +99,7 @@ def save_graph_xml(
     merge_edges=True,
     edge_tag_aggs=None,
     osm_version=0.6,
-    coordinate_precision=6
+    coordinate_precision=7
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -229,7 +229,7 @@ def save_graph_xml(
     )
 
     # write to disk
-    etree.ElementTree(root).write(filepath)
+    etree.ElementTree(root).write(filepath, encoding='utf-8', xml_declaration=True)
     utils.log(f'Saved graph as .osm file at "{filepath}"')
 
 

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -169,6 +169,7 @@ def save_graph_xml(
         OpenStreetMap data version to write in the XML file header. Default 0.6.
     coordinate_precision : int
         Number of decimal places to keep when writing latitude and longitude values. Default 7.
+
     Returns
     -------
     None

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -98,7 +98,8 @@ def save_graph_xml(
     oneway=False,
     merge_edges=True,
     edge_tag_aggs=None,
-    osm_version=0.6
+    osm_version=0.6,
+    coordinate_precision=6
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.
@@ -166,7 +167,8 @@ def save_graph_xml(
         reflect the length of the first edge associated with the way.
     osm_version : int
         OpenStreetMap data version to write in the XML file header. Default 0.6.
-    
+    coordinate_precision : int
+        Number of decimal places to keep when writing latitude and longitude values. Default 7.
     Returns
     -------
     None
@@ -198,6 +200,8 @@ def save_graph_xml(
 
     # rename columns per osm specification
     gdf_nodes.rename(columns={"x": "lon", "y": "lat"}, inplace=True)
+    gdf_nodes.lon = gdf_nodes.lon.round(coordinate_precision)
+    gdf_nodes.lat = gdf_nodes.lat.round(coordinate_precision)
     gdf_nodes = gdf_nodes.reset_index().rename(columns={"osmid": "id"})
     if "id" in gdf_edges.columns:
         gdf_edges = gdf_edges[[col for col in gdf_edges if col != "id"]]

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -99,7 +99,7 @@ def save_graph_xml(
     merge_edges=True,
     edge_tag_aggs=None,
     osm_version=0.6,
-    coordinate_precision=7
+    coordinate_precision=7,
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.
@@ -235,7 +235,7 @@ def save_graph_xml(
     )
 
     # write to disk
-    etree.ElementTree(root).write(filepath, encoding='utf-8', xml_declaration=True)
+    etree.ElementTree(root).write(filepath, encoding="utf-8", xml_declaration=True)
     utils.log(f'Saved graph as .osm file at "{filepath}"')
 
 
@@ -260,7 +260,7 @@ def _append_nodes_xml_tree(root, gdf_nodes, node_attrs, node_tags):
         xml tree with nodes appended
     """
     for _, row in gdf_nodes.iterrows():
-        row = row.dropna().astype(str)        
+        row = row.dropna().astype(str)
         node = etree.SubElement(root, "node", attrib=row[node_attrs].to_dict())
 
         for tag in node_tags:
@@ -325,15 +325,15 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
                         etree.SubElement(edge, "tag", attrib={"k": tag, "v": first[tag]})
             else:
                 for tag in edge_tags:
-                    if (tag in first) and (
-                        tag not in (t for t, agg in edge_tag_aggs)
-                    ):
+                    if (tag in first) and (tag not in (t for t, agg in edge_tag_aggs)):
                         etree.SubElement(edge, "tag", attrib={"k": tag, "v": first[tag]})
 
                 for tag, agg in edge_tag_aggs:
                     if tag in all_way_edges.columns:
                         etree.SubElement(
-                            edge, "tag", attrib={"k": tag, "v": str(all_way_edges[tag].aggregate(agg))}
+                            edge,
+                            "tag",
+                            attrib={"k": tag, "v": str(all_way_edges[tag].aggregate(agg))},
                         )
     else:
         # NOTE: this will generate separate OSM ways for each network edge,
@@ -343,7 +343,7 @@ def _append_edges_xml_tree(root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs
         # OSM XML schema standard, however, the data will still comprise a
         # valid network and will be readable by *most* OSM tools.
         for _, row in gdf_edges.iterrows():
-            row = row.dropna().astype(str)               
+            row = row.dropna().astype(str)
             edge = etree.SubElement(root, "way", attrib=row[edge_attrs].to_dict())
             etree.SubElement(edge, "nd", attrib={"ref": row["u"]})
             etree.SubElement(edge, "nd", attrib={"ref": row["v"]})


### PR DESCRIPTION
Somewhat related to issue #915.

Commits are quite self-explanatory, but this fixes a few things:
1. A bug where non-existent tags would get written to the XML file when they shouldn't.
2. Adds a way to specify the OSM version to write in the header
3. Adds a way to specify how many decimals to keep when writing lat-long coordinates
4. Sets the encoding to UTF-8. This is useful for areas that have non-ascii characters in the name (for example, in Québec)

Thanks