### PR TITLE
Fix possible KeyError in ox.simplify_graph

### DIFF
--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -289,7 +289,10 @@ def simplify_graph(G, strict=True, remove_rings=True, track_merged=False):
 
             # get edge between these nodes: if multiple edges exist between
             # them (see above), we retain only one in the simplified graph
-            edge_data = G.edges[u, v, 0]
+            # We can't assume that there exists an edge from u to v
+            # with key=0, so we get a list of all edges from u to v
+            # and just take the first one.
+            edge_data = list(G.get_edge_data(u, v).values())[0]
             for attr in edge_data:
                 if attr in path_attributes:
                     # if this key already exists in the dict, append it to the


### PR DESCRIPTION
Fix KeyError that occurs when blinding assuming there exists an edge between u and v with k=0

This is a fairly small fix.
When using `ox.get_undirected()`, we prune parallel edges by selecting the one with the smallest length.
The smallest edge might have `key = 1`, which raises a KeyError in `ox.simplify_graph`. This code fixes that.