### PR TITLE
Fix downloader._get_host_by_name when the request fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change log
 
+## TBD
+
+  - drop dateutil package dependency
+
 ## 1.3.0 (2023-01-01)
+
   - fully support Shapely 2.0 and drop support for Shapely 1.x
   - drop RTree package dependency
   - much faster nearest edges search using STRTree index

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -267,8 +267,14 @@ def _get_host_by_name(host):
         resolved IP address
     """
     dns_url = f"https://8.8.8.8/resolve?name={host}"
-    response = requests.get(dns_url)
-    data = response.json()
+    try:
+        response = requests.get(dns_url)
+        data = response.json()
+    except requests.exceptions.RequestException as e:
+        # if anything goes wrong trying to reach the Google DNS servers, (e.g.,
+        # a proxy is restricting access), return the host itself
+        utils.log(f"Got an error when trying to resolve {host!r} from Google DNS: {str(e)}")
+        return host
 
     # status = 0 means NOERROR: standard DNS response code
     if response.ok and data["Status"] == 0:

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -266,6 +266,9 @@ def _get_host_by_name(host):
     ip_address : string
         resolved IP address
     """
+    if settings.dns_http_url is None:
+        return host
+
     dns_url = settings.dns_http_url % f'name={host}'
     try:
         response = requests.get(dns_url)

--- a/osmnx/downloader.py
+++ b/osmnx/downloader.py
@@ -266,7 +266,7 @@ def _get_host_by_name(host):
     ip_address : string
         resolved IP address
     """
-    dns_url = f"https://8.8.8.8/resolve?name={host}"
+    dns_url = settings.dns_http_url % f'name={host}'
     try:
         response = requests.get(dns_url)
         data = response.json()

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -46,7 +46,8 @@ default_user_agent : string
     `"OSMnx Python package (https://github.com/gboeing/osmnx)"`.
 dns_http_url: string
     Endpoint to query DNS via DoH, if query via DNS protocol fails.
-    Enter a `%s` where the dns-query is to be placed. Default is:
+    Enter a `%s` where the dns-query is to be placed.
+    Set to None in order to disable DoH. Default is:
     `"https://8.8.8.8/resolve?%s"`
 imgs_folder : string or pathlib.Path
     Path to folder in which to save plotted images by default. Default is

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -44,6 +44,10 @@ default_referer : string
 default_user_agent : string
     HTTP header user-agent. Default is
     `"OSMnx Python package (https://github.com/gboeing/osmnx)"`.
+dns_http_url: string
+    Endpoint to query DNS via DoH, if query via DNS protocol fails.
+    Enter a `%s` where the dns-query is to be placed. Default is:
+    `"https://8.8.8.8/resolve?%s"`
 imgs_folder : string or pathlib.Path
     Path to folder in which to save plotted images by default. Default is
     "./images".
@@ -135,6 +139,7 @@ default_access = '["access"!~"private"]'
 default_crs = "epsg:4326"
 default_referer = "OSMnx Python package (https://github.com/gboeing/osmnx)"
 default_user_agent = "OSMnx Python package (https://github.com/gboeing/osmnx)"
+dns_http_url = "https://8.8.8.8/resolve?%s"
 imgs_folder = "./images"
 log_console = False
 log_file = False

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -308,6 +308,11 @@ def test_api_endpoints():
     ip = ox.downloader._get_host_by_name("overpass-api.de")
     ip = ox.downloader._get_host_by_name("AAAAAAAAAAA")
 
+    _dns_http_url_default = ox.settings.dns_http_url
+    ox.settings.dns_http_url = "http://aaaaaa.hostdoesntexist.org/nothinguseful?%s"
+    ip = ox.downloader._get_host_by_name("overpass-api.de")
+    ox.settings.dns_http_url = _dns_http_url_default
+
     params = OrderedDict()
     params["format"] = "json"
     params["address_details"] = 0

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -311,6 +311,8 @@ def test_api_endpoints():
     _dns_http_url_default = ox.settings.dns_http_url
     ox.settings.dns_http_url = "http://aaaaaa.hostdoesntexist.org/nothinguseful?%s"
     ip = ox.downloader._get_host_by_name("overpass-api.de")
+    ox.settings.dns_http_url = None
+    ip = ox.downloader._get_host_by_name("overpass-api.de")
     ox.settings.dns_http_url = _dns_http_url_default
 
     params = OrderedDict()


### PR DESCRIPTION
I am running osmnx in a private network with a very restrictive proxy server which won't allow the HTTP/HTTPS request to Google DNS servers, so the proxy server would return a 403 error directly. This resulted in an uncaught `ProxyError` thrown when trying to resolve the hostname this way, making osmnx unusable in this environment.

I added a try-except clause around the requests methods to make sure that any requests-related exception thrown during the request is caught, and used the same error handling as used in the function's status code check.

I have tested this fix in said environment, and it's working flawlessly.