### PR TITLE
split at vertical bar

### DIFF
--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -183,16 +183,23 @@ def _clean_maxspeed(value, convert_mph=True):
     value_clean : string
     """
     MPH_TO_KPH = 1.60934
-    pattern = re.compile(r"[^\d\.,;]")
-
+    # regex from https://wiki.openstreetmap.org/wiki/Key:maxspeed#Developers, plus comma.
+    # re.compile isn't necessary here.
+    pattern = "^([0-9][\\.,0-9]+?)(?:[ ]?(?:km/h|kmh|kph|mph|knots))?$"
+    values = re.split(r"\|", value)  # this creates a list even if it's a single value
     try:
-        # strip out everything but numbers, periods, commas, semicolons
-        value_clean = float(re.sub(pattern, "", value).replace(",", "."))
-        if convert_mph and "mph" in value.lower():
-            value_clean = value_clean * MPH_TO_KPH
-        return value_clean
+        lst = []
+        for v in values:
+            match = re.match(pattern, v)
+            value_clean = float(match.group(1).replace(",", "."))
+            if convert_mph and "mph" in v.lower():
+                value_clean = value_clean * MPH_TO_KPH
+            lst.append(value_clean)
+        lst_avg = sum(lst) / len(lst)
+        return lst_avg
 
-    except ValueError:
+    except (ValueError, AttributeError):
+        # if the match has no group, it raises an AttributeError
         return None
 
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -4,6 +4,8 @@
 # do this first before pyplot is imported by anything
 import matplotlib as mpl
 
+from osmnx.speed import _clean_maxspeed
+
 mpl.use("Agg")
 
 import bz2
@@ -495,3 +497,27 @@ def test_geometries():
         gdf = ox.geometries_from_xml(filename)
         assert "Willow Street" in gdf["name"].values
     os.remove(temp_filename)
+
+
+def test_cleaning():
+    # Commas and points should be returned as decimals
+    value = "100,2"
+    assert _clean_maxspeed(value) == 100.2
+    value = "100.2"
+    assert _clean_maxspeed(value) == 100.2
+
+    # units should be stripped away
+    value = "100 km/h"
+    assert _clean_maxspeed(value) == 100.0
+    # mph should be converted to kmh
+    value = "100 mph"
+    assert _clean_maxspeed(value) == pytest.approx(160.934)
+
+    # numbers with vertical bars should be split and averaged
+    value = "60|100"
+    assert _clean_maxspeed(value) == 80
+
+    value = "signal"
+    assert _clean_maxspeed(value) is None
+    value = "100;70"
+    assert _clean_maxspeed(value) is None


### PR DESCRIPTION
Resolves #934.
Now, it splits the string at vertical bars and uses the regex for each element of the list. 
I used the regular expression from the OSM docs. If the group value can't find a match, it throws an `AttributeError`. I also added some tests.

Personally, I would prefer that an actual averaging is logged or that the user can choose via a parameter whether min/max/average is done for several values. But so far I am happy with the behaviour. What do you think about that?
