### PR TITLE
ensure node coordinates are non-null

### DIFF
--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -147,8 +147,10 @@ def add_edge_lengths(G, precision=3, edges=None):
     try:
         # two-dimensional array of coordinates: y0, x0, y1, x1
         c = np.array([(y[u], x[u], y[v], x[v]) for u, v, k in uvk])
-    except KeyError:  # pragma: no cover
-        raise KeyError("some edges missing nodes, possibly due to input data clipping issue")
+        # ensure all coordinates can be converted to float and are non-null
+        assert not np.isnan(c.astype(float)).any()
+    except (AssertionError, KeyError):  # pragma: no cover
+        raise ValueError("some edges missing nodes, possibly due to input data clipping issue")
 
     # calculate great circle distances, round, and fill nulls with zeros
     dists = great_circle_vec(c[:, 0], c[:, 1], c[:, 2], c[:, 3]).round(precision)


### PR DESCRIPTION
Resolves #946.
See also #947 #948 #437 #436 #323.

If a user clips their .osm XML file before loading with the `graph_from_xml` function, it can result in ways in the XML file referencing nodes that are not present. This causes exceptions in the `add_edge_lengths` function. See #948 for an example: way ID 399296135 references node ID 4020273366, but there is no such node present in the XML file.

#437 previously added a descriptive error message when missing nodes could not be found. This PR adds another check to see if all the nodes' coordinates are non-null and convertible to float, and throws an error message if not. @Georgepop see proposed resolution here.