### PR TITLE
move plot_orientation function from bearing module to plot module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   - ensure node coordinates are non-null and covertible to float in the add_edge_lengths function
   - ignore ways tagged highway=no or highway=razed in built-in filters
   - do not assume an edge with key=0 exists between each node pair when simplifying graph
-  - deprecate bearing.plot_orientation and move plot_orientation function to plot module
+  - move plot_orientation function from bearing module to plot module
   - drop dateutil package dependency
 
 ## 1.3.0 (2023-01-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Change log
 
-## 1.3.1 (TBD)
+## 1.4.0 (TBD)
+
+  - move plot_orientation function from bearing module to plot module
+
+## 1.3.1 (2023-05-24)
 
   - improve DNS resolution when using proxies or on networks blocking DNS-over-HTTPS
   - improve processing of per-lane values when adding edge speeds
+  - improve file writing in save_graph_xml function
   - ensure node coordinates are non-null and covertible to float in the add_edge_lengths function
   - ignore ways tagged highway=no or highway=razed in built-in filters
   - do not assume an edge with key=0 exists between each node pair when simplifying graph
-  - move plot_orientation function from bearing module to plot module
   - drop dateutil package dependency
 
 ## 1.3.0 (2023-01-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - ensure node coordinates are non-null and covertible to float in the add_edge_lengths function
   - ignore ways tagged highway=no or highway=razed in built-in filters
   - do not assume an edge with key=0 exists between each node pair when simplifying graph
+  - deprecate bearing.plot_orientation and move plot_orientation function to plot module
   - drop dateutil package dependency
 
 ## 1.3.0 (2023-01-01)

--- a/osmnx/_api.py
+++ b/osmnx/_api.py
@@ -2,7 +2,6 @@
 
 from .bearing import add_edge_bearings
 from .bearing import orientation_entropy
-from .bearing import plot_orientation
 from .distance import k_shortest_paths
 from .distance import nearest_edges
 from .distance import nearest_nodes
@@ -36,6 +35,7 @@ from .plot import plot_footprints
 from .plot import plot_graph
 from .plot import plot_graph_route
 from .plot import plot_graph_routes
+from .plot import plot_orientation
 from .projection import project_gdf
 from .projection import project_graph
 from .simplification import consolidate_intersections

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -282,7 +282,7 @@ def plot_orientation(
     """
     warn(
         "The `plot_orientation` function moved to the `plot` module. Calling it "
-        "via the bearing module will raise an error in a future release."
+        "via the bearing module will cause an exception in a future release."
     )
     return plot.plot_orientation(
         Gu,

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -282,7 +282,7 @@ def plot_orientation(
     """
     warn(
         "The `plot_orientation` function moved to the `plot` module. Calling it "
-        "via the bearing module will cause an exception in a future release."
+        "via the `bearing` module will cause an exception in a future release."
     )
     return plot.plot_orientation(
         Gu,

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -1,9 +1,11 @@
 """Calculate graph edge bearings."""
 
-import matplotlib.pyplot as plt
+from warnings import warn
+
 import networkx as nx
 import numpy as np
 
+from . import plot
 from . import projection
 
 # scipy is an optional dependency for entropy calculation
@@ -235,118 +237,67 @@ def plot_orientation(
     xtick_font=None,
 ):
     """
-    Plot a polar histogram of a spatial network's bidirectional edge bearings.
+    Do not use: deprecated.
 
-    Ignores self-loop edges as their bearings are undefined.
-
-    For more info see: Boeing, G. 2019. "Urban Spatial Order: Street Network
-    Orientation, Configuration, and Entropy." Applied Network Science, 4 (1),
-    67. https://doi.org/10.1007/s41109-019-0189-1
+    The plot_orientation function moved to the plot module. Calling it via the
+    bearing module will raise an error in a future release.
 
     Parameters
     ----------
     Gu : networkx.MultiGraph
-        undirected, unprojected graph with `bearing` attributes on each edge
+        deprecated, do not use
     num_bins : int
-        number of bins; for example, if `num_bins=36` is provided, then each
-        bin will represent 10° around the compass
+        deprecated, do not use
     min_length : float
-        ignore edges with `length` attributes less than `min_length`
+        deprecated, do not use
     weight : string
-        if not None, weight edges' bearings by this (non-null) edge attribute
+        deprecated, do not use
     ax : matplotlib.axes.PolarAxesSubplot
-        if not None, plot on this preexisting axis; must have projection=polar
+        deprecated, do not use
     figsize : tuple
-        if ax is None, create new figure with size (width, height)
+        deprecated, do not use
     area : bool
-        if True, set bar length so area is proportional to frequency,
-        otherwise set bar length so height is proportional to frequency
+        deprecated, do not use
     color : string
-        color of histogram bars
+        deprecated, do not use
     edgecolor : string
-        color of histogram bar edges
+        deprecated, do not use
     linewidth : float
-        width of histogram bar edges
+        deprecated, do not use
     alpha : float
-        opacity of histogram bars
+        deprecated, do not use
     title : string
-        title for plot
+        deprecated, do not use
     title_y : float
-        y position to place title
+        deprecated, do not use
     title_font : dict
-        the title's fontdict to pass to matplotlib
+        deprecated, do not use
     xtick_font : dict
-        the xtick labels' fontdict to pass to matplotlib
+        deprecated, do not use
 
     Returns
     -------
     fig, ax : tuple
         matplotlib figure, axis
     """
-    if title_font is None:
-        title_font = {"family": "DejaVu Sans", "size": 24, "weight": "bold"}
-    if xtick_font is None:
-        xtick_font = {
-            "family": "DejaVu Sans",
-            "size": 10,
-            "weight": "bold",
-            "alpha": 1.0,
-            "zorder": 3,
-        }
-
-    # get the bearings' distribution's bin counts and edges
-    bin_counts, bin_edges = _bearings_distribution(Gu, num_bins, min_length, weight)
-
-    # positions: where to center each bar. ignore the last bin edge, because
-    # it's the same as the first (i.e., 0° = 360°)
-    positions = np.radians(bin_edges[:-1])
-
-    # width: make bars fill the circumference without gaps or overlaps
-    width = 2 * np.pi / num_bins
-
-    # radius: how long to make each bar
-    bin_frequency = bin_counts / bin_counts.sum()
-    if area:
-        # set bar length so area is proportional to frequency
-        radius = np.sqrt(bin_frequency)
-    else:
-        # set bar length so height is proportional to frequency
-        radius = bin_frequency
-
-    # create ax (if necessary) then set N at top and go clockwise
-    if ax is None:
-        fig, ax = plt.subplots(figsize=figsize, subplot_kw={"projection": "polar"})
-    else:
-        fig = ax.figure
-    ax.set_theta_zero_location("N")
-    ax.set_theta_direction("clockwise")
-    ax.set_ylim(top=radius.max())
-
-    # configure the y-ticks and remove their labels
-    ax.set_yticks(np.linspace(0, radius.max(), 5))
-    ax.set_yticklabels(labels="")
-
-    # configure the x-ticks and their labels
-    xticklabels = ["N", "", "E", "", "S", "", "W", ""]
-    ax.set_xticks(ax.get_xticks())
-    ax.set_xticklabels(labels=xticklabels, fontdict=xtick_font)
-    ax.tick_params(axis="x", which="major", pad=-2)
-
-    # draw the bars
-    ax.bar(
-        positions,
-        height=radius,
-        width=width,
-        align="center",
-        bottom=0,
-        zorder=2,
+    warn(
+        "The `plot_orientation` function moved to the `plot` module. Calling it "
+        "via the bearing module will raise an error in a future release."
+    )
+    return plot.plot_orientation(
+        Gu,
+        num_bins=num_bins,
+        min_length=min_length,
+        weight=weight,
+        ax=ax,
+        figsize=figsize,
+        area=area,
         color=color,
         edgecolor=edgecolor,
         linewidth=linewidth,
         alpha=alpha,
+        title=title,
+        title_y=title_y,
+        title_font=title_font,
+        xtick_font=xtick_font,
     )
-
-    if title:
-        ax.set_title(title, y=title_y, fontdict=title_font)
-    fig.tight_layout()
-    return fig, ax

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -17,10 +17,10 @@ def calculate_bearing(lat1, lng1, lat2, lng2):
     """
     Calculate the compass bearing(s) between pairs of lat-lng points.
 
-    Vectorized function to calculate (initial) bearings between two points'
+    Vectorized function to calculate initial bearings between two points'
     coordinates or between arrays of points' coordinates. Expects coordinates
-    in decimal degrees. Bearing represents angle in degrees (clockwise)
-    between north and the geodesic line from point 1 to point 2.
+    in decimal degrees. Bearing represents the clockwise angle in degrees
+    between north and the geodesic line from (lat1, lng1) to (lat2, lng2).
 
     Parameters
     ----------

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from matplotlib import colormaps
 
+from . import bearing
 from . import graph
 from . import projection
 from . import settings
@@ -810,3 +811,138 @@ def _config_ax(ax, crs, bbox, padding):
         ax.set_aspect(1 / cos_lat)
 
     return ax
+
+
+def plot_orientation(
+    Gu,
+    num_bins=36,
+    min_length=0,
+    weight=None,
+    ax=None,
+    figsize=(5, 5),
+    area=True,
+    color="#003366",
+    edgecolor="k",
+    linewidth=0.5,
+    alpha=0.7,
+    title=None,
+    title_y=1.05,
+    title_font=None,
+    xtick_font=None,
+):
+    """
+    Plot a polar histogram of a spatial network's bidirectional edge bearings.
+
+    Ignores self-loop edges as their bearings are undefined.
+
+    For more info see: Boeing, G. 2019. "Urban Spatial Order: Street Network
+    Orientation, Configuration, and Entropy." Applied Network Science, 4 (1),
+    67. https://doi.org/10.1007/s41109-019-0189-1
+
+    Parameters
+    ----------
+    Gu : networkx.MultiGraph
+        undirected, unprojected graph with `bearing` attributes on each edge
+    num_bins : int
+        number of bins; for example, if `num_bins=36` is provided, then each
+        bin will represent 10° around the compass
+    min_length : float
+        ignore edges with `length` attributes less than `min_length`
+    weight : string
+        if not None, weight edges' bearings by this (non-null) edge attribute
+    ax : matplotlib.axes.PolarAxesSubplot
+        if not None, plot on this preexisting axis; must have projection=polar
+    figsize : tuple
+        if ax is None, create new figure with size (width, height)
+    area : bool
+        if True, set bar length so area is proportional to frequency,
+        otherwise set bar length so height is proportional to frequency
+    color : string
+        color of histogram bars
+    edgecolor : string
+        color of histogram bar edges
+    linewidth : float
+        width of histogram bar edges
+    alpha : float
+        opacity of histogram bars
+    title : string
+        title for plot
+    title_y : float
+        y position to place title
+    title_font : dict
+        the title's fontdict to pass to matplotlib
+    xtick_font : dict
+        the xtick labels' fontdict to pass to matplotlib
+
+    Returns
+    -------
+    fig, ax : tuple
+        matplotlib figure, axis
+    """
+    if title_font is None:
+        title_font = {"family": "DejaVu Sans", "size": 24, "weight": "bold"}
+    if xtick_font is None:
+        xtick_font = {
+            "family": "DejaVu Sans",
+            "size": 10,
+            "weight": "bold",
+            "alpha": 1.0,
+            "zorder": 3,
+        }
+
+    # get the bearings' distribution's bin counts and edges
+    bin_counts, bin_edges = bearing._bearings_distribution(Gu, num_bins, min_length, weight)
+
+    # positions: where to center each bar. ignore the last bin edge, because
+    # it's the same as the first (i.e., 0° = 360°)
+    positions = np.radians(bin_edges[:-1])
+
+    # width: make bars fill the circumference without gaps or overlaps
+    width = 2 * np.pi / num_bins
+
+    # radius: how long to make each bar
+    bin_frequency = bin_counts / bin_counts.sum()
+    if area:
+        # set bar length so area is proportional to frequency
+        radius = np.sqrt(bin_frequency)
+    else:
+        # set bar length so height is proportional to frequency
+        radius = bin_frequency
+
+    # create ax (if necessary) then set N at top and go clockwise
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize, subplot_kw={"projection": "polar"})
+    else:
+        fig = ax.figure
+    ax.set_theta_zero_location("N")
+    ax.set_theta_direction("clockwise")
+    ax.set_ylim(top=radius.max())
+
+    # configure the y-ticks and remove their labels
+    ax.set_yticks(np.linspace(0, radius.max(), 5))
+    ax.set_yticklabels(labels="")
+
+    # configure the x-ticks and their labels
+    xticklabels = ["N", "", "E", "", "S", "", "W", ""]
+    ax.set_xticks(ax.get_xticks())
+    ax.set_xticklabels(labels=xticklabels, fontdict=xtick_font)
+    ax.tick_params(axis="x", which="major", pad=-2)
+
+    # draw the bars
+    ax.bar(
+        positions,
+        height=radius,
+        width=width,
+        align="center",
+        bottom=0,
+        zorder=2,
+        color=color,
+        edgecolor=edgecolor,
+        linewidth=linewidth,
+        alpha=alpha,
+    )
+
+    if title:
+        ax.set_title(title, y=title_y, fontdict=title_font)
+    fig.tight_layout()
+    return fig, ax

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -2,17 +2,17 @@
 Global settings that can be configured by the user.
 
 all_oneway : bool
-    If True, forces all ways to be loaded as oneway ways, preserving the
-    original order of nodes stored in the OSM way XML. This also retains
+    Only use if specifically saving to .osm XML file with the `save_graph_xml`
+    function. If True, forces all ways to be loaded as oneway ways, preserving
+    the original order of nodes stored in the OSM way XML. This also retains
     original OSM string values for oneway attribute values, rather than
-    converting them to a True/False bool. Only use if specifically saving to
-    .osm XML file with the `save_graph_xml` function. Default is `False`.
+    converting them to a True/False bool. Default is `False`.
 bidirectional_network_types : list
     Network types for which a fully bidirectional graph will be created.
     Default is `["walk"]`.
 cache_folder : string or pathlib.Path
-    Path to folder in which to save/load HTTP response cache. Default is
-    `"./cache"`.
+    Path to folder in which to save/load HTTP response cache, if the
+    `use_cache` setting equals `True`. Default is `"./cache"`.
 cache_only_mode : bool
     If True, download network data from Overpass then raise a
     `CacheOnlyModeInterrupt` error for user to catch. This prevents graph

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -127,7 +127,8 @@ def test_stats():
     Gu = ox.get_undirected(G)
     entropy = ox.bearing.orientation_entropy(Gu, weight="length")
     fig, ax = ox.bearing.plot_orientation(Gu, area=True, title="Title")
-    fig, ax = ox.bearing.plot_orientation(Gu, ax=ax, area=False, title="Title")
+    fig, ax = ox.plot_orientation(Gu, area=True, title="Title")
+    fig, ax = ox.plot_orientation(Gu, ax=ax, area=False, title="Title")
 
     # test cleaning and rebuilding graph
     G_clean = ox.consolidate_intersections(G_proj, tolerance=10, rebuild_graph=True, dead_ends=True)


### PR DESCRIPTION
As mentioned in #935. This PR moves the plot_orientation function from the bearing module to the plot module, for a more consistent organization. No change to the top-level API (ie, the function remains accessible as always via `ox.plot_orientation`).