### PR TITLE
Deprecate folium module in favor of GeoPandas explore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.3.1 (TBD)
 
+  - deprecate folium module in favor of using GeoPandas.GeoDataFrame.explore directly
+  - add route_to_gdf function to utils_graph module
   - improve DNS resolution when using proxies or on networks blocking DNS-over-HTTPS
   - improve processing of per-lane values when adding edge speeds
   - ensure node coordinates are non-null and covertible to float in the add_edge_lengths function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Change log
 
-## 1.3.1 (TBD)
+## 1.4.0 (TBD)
 
-  - deprecate folium module in favor of using GeoPandas.GeoDataFrame.explore directly
   - add route_to_gdf function to utils_graph module
+  - deprecate folium module in favor of using GeoPandas.GeoDataFrame.explore directly
+  - move plot_orientation function from bearing module to plot module
+
+## 1.3.1 (2023-05-24)
+
   - improve DNS resolution when using proxies or on networks blocking DNS-over-HTTPS
   - improve processing of per-lane values when adding edge speeds
+  - improve file writing in save_graph_xml function
   - ensure node coordinates are non-null and covertible to float in the add_edge_lengths function
   - ignore ways tagged highway=no or highway=razed in built-in filters
   - do not assume an edge with key=0 exists between each node pair when simplifying graph

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## 1.4.0 (TBD)
 
   - add route_to_gdf function to utils_graph module
+  - deprecate the get_route_edge_attributes function in favor of the new route_to_gdf function
   - deprecate folium module in favor of using GeoPandas.GeoDataFrame.explore directly
   - move plot_orientation function from bearing module to plot module
-  - provide consistent error if no data elements are returned from server
+  - provide consistent error when no data elements are returned from server
 
 ## 1.3.1 (2023-05-24)
 

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -1,6 +1,14 @@
-"""Create interactive Leaflet web maps of graphs and routes via folium."""
+"""Create interactive Leaflet web maps of graphs and routes via folium.
+
+This module is deprecated. Do not use. It will be removed in a future release.
+You can generate and explore interactive web maps of graph nodes, edges,
+and/or routes automatically using GeoPandas.GeoDataFrame.explore instead, for
+example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the OSMnx
+usage example repo for complete details and demonstrations.
+"""
 
 import json
+from warnings import warn
 
 from . import utils_graph
 
@@ -21,33 +29,41 @@ def plot_graph_folium(
     **kwargs,
 ):
     """
-    Plot a graph as an interactive Leaflet web map.
+    Do not use: deprecated.
 
-    Note that anything larger than a small city can produce a large web map
-    file that is slow to render in your browser.
+    You can generate and explore interactive web maps of graph nodes, edges,
+    and/or routes automatically using GeoPandas.GeoDataFrame.explore instead,
+    for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the
+    OSMnx usage example repo for complete details and demonstrations.
 
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        input graph
+        deprecated
     graph_map : folium.folium.Map
-        if not None, plot the graph on this preexisting folium map object
+        deprecated
     popup_attribute : string
-        edge attribute to display in a pop-up when an edge is clicked
+        deprecated
     tiles : string
-        name of a folium tileset
+        deprecated
     zoom : int
-        initial zoom level for the map
+        deprecated
     fit_bounds : bool
-        if True, fit the map to the boundaries of the graph's edges
+        deprecated
     kwargs
-        keyword arguments to pass to folium.PolyLine(), see folium docs for
-        options (for example `color="#333333", weight=5, opacity=0.7`)
+        deprecated
 
     Returns
     -------
     folium.folium.Map
     """
+    warn(
+        "The `folium` module has been deprecated and will be removed in a future release. "
+        "You can generate and explore interactive web maps of graph nodes, edges, "
+        "and/or routes automatically using GeoPandas.GeoDataFrame.explore instead, "
+        "for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the "
+        "OSMnx usage example repo for complete details and demonstrations."
+    )
     # create gdf of all graph edges
     gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False)
     return _plot_folium(gdf_edges, graph_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)
@@ -64,32 +80,43 @@ def plot_route_folium(
     **kwargs,
 ):
     """
-    Plot a route as an interactive Leaflet web map.
+    Do not use: deprecated.
+
+    You can generate and explore interactive web maps of graph nodes, edges,
+    and/or routes automatically using GeoPandas.GeoDataFrame.explore instead,
+    for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the
+    OSMnx usage example repo for complete details and demonstrations.
 
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        input graph
+        deprecated
     route : list
-        the route as a list of nodes
+        deprecated
     route_map : folium.folium.Map
-        if not None, plot the route on this preexisting folium map object
+        deprecated
     popup_attribute : string
-        edge attribute to display in a pop-up when an edge is clicked
+        deprecated
     tiles : string
-        name of a folium tileset
+        deprecated
     zoom : int
-        initial zoom level for the map
+        deprecated
     fit_bounds : bool
-        if True, fit the map to the boundaries of the route's edges
+        deprecated
     kwargs
-        keyword arguments to pass to folium.PolyLine(), see folium docs for
-        options (for example `color="#cc0000", weight=5, opacity=0.7`)
+        deprecated
 
     Returns
     -------
     folium.folium.Map
     """
+    warn(
+        "The `folium` module has been deprecated and will be removed in a future release. "
+        "You can generate and explore interactive web maps of graph nodes, edges, "
+        "and/or routes automatically using GeoPandas.GeoDataFrame.explore instead, "
+        "for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the "
+        "OSMnx usage example repo for complete details and demonstrations."
+    )
     # create gdf of the route edges in order
     node_pairs = zip(route[:-1], route[1:])
     uvk = ((u, v, min(G[u][v].items(), key=lambda k: k[1]["length"])[0]) for u, v in node_pairs)

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -172,9 +172,9 @@ def _clean_maxspeed(maxspeed, agg=np.mean, convert_mph=True):
     Clean a maxspeed string and convert mph to kph if necessary.
 
     If present, splits maxspeed on "|" (which denotes that the value contains
-    different speeds per lane) then aggregates the resulting values. See
-    https://wiki.openstreetmap.org/wiki/Key:maxspeed for details on values and
-    formats.
+    different speeds per lane) then aggregates the resulting values. Invalid
+    inputs return None. See https://wiki.openstreetmap.org/wiki/Key:maxspeed
+    for details on values and formats.
 
     Parameters
     ----------
@@ -205,7 +205,7 @@ def _clean_maxspeed(maxspeed, agg=np.mean, convert_mph=True):
         return agg(clean_values)
 
     except (ValueError, AttributeError):
-        # if the match has no group, it raises an AttributeError
+        # if invalid input, return None
         return None
 
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -179,6 +179,29 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
     return G
 
 
+def route_to_gdf(G, route, weight="length"):
+    """
+    Return a GeoDataFrame of the edges in a path, in order.
+
+    Parameters
+    ----------
+    G : networkx.MultiDiGraph
+        input graph
+    route : list
+        list of nodes IDs constituting the path
+    weight : string
+        if there are parallel edges between two nodes, choose lowest weight
+
+    Returns
+    -------
+    gdf_edges : geopandas.GeoDataFrame
+        GeoDataFrame of the edges
+    """
+    node_pairs = zip(route[:-1], route[1:])
+    uvk = ((u, v, min(G[u][v].items(), key=lambda i: i[1][weight])[0]) for u, v in node_pairs)
+    return graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
+
+
 def get_route_edge_attributes(
     G, route, attribute=None, minimize_key="length", retrieve_default=None
 ):

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -188,7 +188,7 @@ def route_to_gdf(G, route, weight="length"):
     G : networkx.MultiDiGraph
         input graph
     route : list
-        list of nodes IDs constituting the path
+        list of node IDs constituting the path
     weight : string
         if there are parallel edges between two nodes, choose lowest weight
 
@@ -213,7 +213,7 @@ def get_route_edge_attributes(
     G : networkx.MultiDiGraph
         input graph
     route : list
-        list of nodes IDs constituting the path
+        list of node IDs constituting the path
     attribute : string
         the name of the attribute to get the value of for each edge. If None,
         the complete data dict is returned for each edge.

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -1,7 +1,7 @@
 """Graph utility functions."""
 
 import itertools
-import warnings
+from warnings import warn
 
 import geopandas as gpd
 import networkx as nx
@@ -148,10 +148,9 @@ def graph_from_gdfs(gdf_nodes, gdf_edges, graph_attrs=None):
         except (AssertionError, ValueError):  # pragma: no cover
             # AssertionError if x/y coords don't match geometry column
             # ValueError if geometry column contains non-point geometry types
-            warnings.warn(
+            warn(
                 "discarding the gdf_nodes geometry column, though its "
-                "values differ from the coordinates in the x and y columns",
-                stacklevel=1,
+                "values differ from the coordinates in the x and y columns"
             )
         gdf_nodes = gdf_nodes.drop(columns=gdf_nodes.geometry.name)
 
@@ -197,8 +196,8 @@ def route_to_gdf(G, route, weight="length"):
     gdf_edges : geopandas.GeoDataFrame
         GeoDataFrame of the edges
     """
-    node_pairs = zip(route[:-1], route[1:])
-    uvk = ((u, v, min(G[u][v].items(), key=lambda i: i[1][weight])[0]) for u, v in node_pairs)
+    pairs = zip(route[:-1], route[1:])
+    uvk = ((u, v, min(G[u][v].items(), key=lambda i: i[1][weight])[0]) for u, v in pairs)
     return graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
 
 
@@ -206,30 +205,33 @@ def get_route_edge_attributes(
     G, route, attribute=None, minimize_key="length", retrieve_default=None
 ):
     """
-    Get a list of attribute values for each edge in a path.
+    Do not use: deprecated.
+
+    Use the `route_to_gdf` function instead.
 
     Parameters
     ----------
     G : networkx.MultiDiGraph
-        input graph
+        deprecated
     route : list
-        list of node IDs constituting the path
+        deprecated
     attribute : string
-        the name of the attribute to get the value of for each edge. If None,
-        the complete data dict is returned for each edge.
+        deprecated
     minimize_key : string
-        if there are parallel edges between two nodes, select the one with the
-        lowest value of minimize_key
+        deprecated
     retrieve_default : Callable[Tuple[Any, Any], Any]
-        function called with the edge nodes as parameters to retrieve a
-        default value, if the edge does not contain the given attribute
-        (otherwise a `KeyError` is raised)
+        deprecated
 
     Returns
     -------
     attribute_values : list
-        list of edge attribute values
+        deprecated
     """
+    msg = (
+        "The `get_route_edge_attributes` function has been deprecated and will "
+        "be removed in a future release. Use the `route_to_gdf` function instead."
+    )
+    warn(msg)
     attribute_values = []
     for u, v in zip(route[:-1], route[1:]):
         # if there are parallel edges between two nodes, select the one with the

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -226,6 +226,7 @@ def test_routing():
     dest_node = ox.distance.nearest_nodes(G, dest_x, dest_y)[0]
 
     route = ox.shortest_path(G, orig_node, dest_node, weight="travel_time")
+    route_edges = ox.utils_graph.route_to_gdf(G, route, "travel_time")
     attributes = ox.utils_graph.get_route_edge_attributes(G, route)
     attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")
 


### PR DESCRIPTION
Resolves #802 and #935.

- [x] Deprecates the `folium` module in favor of using the more powerful and flexible `GeoPandas.GeoDataFrame.explore` directly. [GeoPandas docs](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.explore.html). [See also](https://github.com/geopandas/geopandas/pull/1953).
- [x] Adds a new `route_to_gdf` helper function to the `utils_graph` module to make it easy to explore a route
- [x] Deprecates the `get_route_edge_attributes` function as it becomes redundant with the superior `route_to_gdf`

See https://github.com/gboeing/osmnx-examples/pull/64 for demonstration code in the examples repo. You can:
- interactively explore nodes, edges, or both together, optionally colored by attribute values
- interactively explore a route
- interactively explore building footprints, transit, amenities, etc