### PR TITLE
consistent error message if no data elements are retrieved

### DIFF
--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -551,7 +551,8 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
 
     # make sure we got data back from the server request(s)
     if not any(rj["elements"] for rj in response_jsons):  # pragma: no cover
-        raise EmptyOverpassResponse("There are no data elements in the response JSON")
+        msg = "There are no data elements in the server response. Check log and query location/filters."
+        raise EmptyOverpassResponse(msg)
 
     # create the graph as a MultiDiGraph and set its meta-attributes
     metadata = {

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -480,8 +480,11 @@ def test_graph_from_functions():
 
 
 def test_geometries():
-    # geometries_from_bbox - bounding box query to return empty GeoDataFrame
-    gdf = ox.geometries_from_bbox(0.009, -0.009, 0.009, -0.009, tags={"building": True})
+    # geometries_from_bbox - bounding box query to return no data
+    try:
+        gdf = ox.geometries_from_bbox(0.009, -0.009, 0.009, -0.009, tags={"building": True})
+    except ox._errors.EmptyOverpassResponse:
+        pass
 
     # geometries_from_bbox - successful
     north, south, east, west = ox.utils_geo.bbox_from_point(location_point, dist=500)


### PR DESCRIPTION
If we retrieve no data elements from Overpass when creating a graph, an `EmptyOverpassResponse` error is raised, accompanied by an explanatory message. However, if we retrieve no data elements from Overpass when creating a GeoDataFrame of geometries, we simply return an empty GeoDataFrame and raise no error (just a warning message, if the user has logging turned on). This is inconsistent. This PR makes the `graph` and `geometries` modules consistently raise `EmptyOverpassResponse` errors with explanatory messages in these circumstances:

```python
import osmnx as ox
ox.settings.log_console = True

# no data returned because of server memory exhaustion
place = {"city": "Los Angeles", "state": "California", "country": "USA"}
gdf = ox.geometries_from_place(place, {"building": True})

# no data returned because there's nothing there
gdf = ox.geometries_from_point((0, 0), {"building": True})

# no data returned because there's nothing there
G = ox.graph_from_point((0, 0))
```