### PR TITLE
Deprecate attribute precision/rounding functionality outside of serialization functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - add route_to_gdf function to utils_graph module to return a GeoDataFrame of the edges in a path
   - deprecate the get_route_edge_attributes function in favor of the new route_to_gdf function
   - deprecate folium module in favor of using geopandas.GeoDataFrame.explore directly
+  - deprecate precision parameter in bearing, distance, elevation, and speed modules' functions
+  - deprecate utils_geo.round_geometry_coords function
   - move plot_orientation function from bearing module to plot module
   - make matplotlib an optional dependency required only for the plot module
   - drop pyproj package dependency

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -54,7 +54,7 @@ def calculate_bearing(lat1, lng1, lat2, lng2):
     return initial_bearing % 360
 
 
-def add_edge_bearings(G, precision=1):
+def add_edge_bearings(G, precision=None):
     """
     Add compass `bearing` attributes to all graph edges.
 
@@ -70,13 +70,18 @@ def add_edge_bearings(G, precision=1):
     G : networkx.MultiDiGraph
         unprojected graph
     precision : int
-        decimal precision to round bearing
+        deprecated, do not use
 
     Returns
     -------
     G : networkx.MultiDiGraph
         graph with edge bearing attributes
     """
+    if precision is None:
+        precision = 1
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     if projection.is_projected(G.graph["crs"]):  # pragma: no cover
         raise ValueError("graph must be unprojected to add edge bearings")
 

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -80,7 +80,10 @@ def add_edge_bearings(G, precision=None):
     if precision is None:
         precision = 1
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     if projection.is_projected(G.graph["crs"]):  # pragma: no cover
         raise ValueError("graph must be unprojected to add edge bearings")

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -140,7 +140,10 @@ def add_edge_lengths(G, precision=None, edges=None):
     if precision is None:
         precision = 3
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     if edges is None:
         uvk = tuple(G.edges)

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -102,7 +102,7 @@ def euclidean_dist_vec(y1, x1, y2, x2):
     return ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
 
 
-def add_edge_lengths(G, precision=3, edges=None):
+def add_edge_lengths(G, precision=None, edges=None):
     """
     Add `length` attribute (in meters) to each edge.
 
@@ -127,7 +127,7 @@ def add_edge_lengths(G, precision=3, edges=None):
     G : networkx.MultiDiGraph
         unprojected, unsimplified input graph
     precision : int
-        decimal precision to round lengths
+        deprecated, do not use
     edges : tuple
         tuple of (u, v, k) tuples representing subset of edges to add length
         attributes to. if None, add lengths to all edges.
@@ -137,6 +137,11 @@ def add_edge_lengths(G, precision=3, edges=None):
     G : networkx.MultiDiGraph
         graph with edge length attributes
     """
+    if precision is None:
+        precision = 3
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     if edges is None:
         uvk = tuple(G.edges)
     else:

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -156,7 +156,10 @@ def add_node_elevations_google(
     if precision is None:
         precision = 3
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     # make a pandas series of all the nodes' coordinates as 'lat,lng'
     # round coordinates to 5 decimal places (approx 1 meter) to be able to fit
@@ -241,7 +244,10 @@ def add_edge_grades(G, add_absolute=True, precision=None):
     if precision is None:
         precision = 3
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     elev_lookup = G.nodes(data="elevation")
     u, v, k, lengths = zip(*G.edges(keys=True, data="length"))

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -4,6 +4,7 @@ import multiprocessing as mp
 import time
 from hashlib import sha1
 from pathlib import Path
+from warnings import warn
 
 import networkx as nx
 import numpy as np
@@ -113,7 +114,7 @@ def add_node_elevations_google(
     api_key,
     max_locations_per_batch=350,
     pause_duration=0,
-    precision=3,
+    precision=None,
     url_template="https://maps.googleapis.com/maps/api/elevation/json?locations={}&key={}",
 ):  # pragma: no cover
     """
@@ -141,7 +142,7 @@ def add_node_elevations_google(
         time to pause between API calls, which can be increased if you get
         rate limited
     precision : int
-        decimal precision to round elevation values
+        deprecated, do not use
     url_template : string
         a URL string template for the API endpoint, containing exactly two
         parameters: `locations` and `key`; for example, for Open Topo Data:
@@ -152,6 +153,11 @@ def add_node_elevations_google(
     G : networkx.MultiDiGraph
         graph with node elevation attributes
     """
+    if precision is None:
+        precision = 3
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     # make a pandas series of all the nodes' coordinates as 'lat,lng'
     # round coordinates to 5 decimal places (approx 1 meter) to be able to fit
     # in more locations per API call
@@ -207,7 +213,7 @@ def add_node_elevations_google(
     return G
 
 
-def add_edge_grades(G, add_absolute=True, precision=3):
+def add_edge_grades(G, add_absolute=True, precision=None):
     """
     Add `grade` attribute to each graph edge.
 
@@ -225,13 +231,18 @@ def add_edge_grades(G, add_absolute=True, precision=3):
     add_absolute : bool
         if True, also add absolute value of grade as `grade_abs` attribute
     precision : int
-        decimal precision to round grade values
+        deprecated, do not use
 
     Returns
     -------
     G : networkx.MultiDiGraph
         graph with edge `grade` (and optionally `grade_abs`) attributes
     """
+    if precision is None:
+        precision = 3
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     elev_lookup = G.nodes(data="elevation")
     u, v, k, lengths = zip(*G.edges(keys=True, data="length"))
     uvk = tuple(zip(u, v, k))

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -61,7 +61,10 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=None, agg=np.me
     if precision is None:
         precision = 1
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     if fallback is None:
         fallback = np.nan
@@ -151,7 +154,10 @@ def add_edge_travel_times(G, precision=None):
     if precision is None:
         precision = 1
     else:
-        warn("the `precision` parameter is deprecated and will be removed in a future release")
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
 
     edges = utils_graph.graph_to_gdfs(G, nodes=False)
 

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -1,6 +1,7 @@
 """Calculate graph edge speeds and travel times."""
 
 import re
+from warnings import warn
 
 import networkx as nx
 import numpy as np
@@ -9,7 +10,7 @@ import pandas as pd
 from . import utils_graph
 
 
-def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=1, agg=np.mean):
+def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=None, agg=np.mean):
     """
     Add edge speeds (km per hour) to graph as new `speed_kph` edge attributes.
 
@@ -46,7 +47,7 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=1, agg=np.mean)
         type did not appear in `hwy_speeds` and had no preexisting speed
         values on any edge
     precision : int
-        decimal precision to round speed_kph
+        deprecated, do not use
     agg : function
         aggregation function to impute missing values from observed values.
         the default is numpy.mean, but you might also consider for example
@@ -57,6 +58,11 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=1, agg=np.mean)
     G : networkx.MultiDiGraph
         graph with speed_kph attributes on all edges
     """
+    if precision is None:
+        precision = 1
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     if fallback is None:
         fallback = np.nan
 
@@ -121,7 +127,7 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=1, agg=np.mean)
     return G
 
 
-def add_edge_travel_times(G, precision=1):
+def add_edge_travel_times(G, precision=None):
     """
     Add edge travel time (seconds) to graph as new `travel_time` edge attributes.
 
@@ -135,13 +141,18 @@ def add_edge_travel_times(G, precision=1):
     G : networkx.MultiDiGraph
         input graph
     precision : int
-        decimal precision to round travel_time
+        deprecated, do not use
 
     Returns
     -------
     G : networkx.MultiDiGraph
         graph with travel_time attributes on all edges
     """
+    if precision is None:
+        precision = 1
+    else:
+        warn("the `precision` parameter is deprecated and will be removed in a future release")
+
     edges = utils_graph.graph_to_gdfs(G, nodes=False)
 
     # verify edge length and speed_kph attributes exist and contain no nulls

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -197,19 +197,23 @@ def _round_multilinestring_coords(mls, precision):
 
 def round_geometry_coords(geom, precision):
     """
-    Round the coordinates of a shapely geometry to some decimal precision.
+    Do not use: deprecated.
 
     Parameters
     ----------
     geom : shapely.geometry.geometry {Point, MultiPoint, LineString, MultiLineString, Polygon, MultiPolygon}
-        the geometry to round the coordinates of
+        deprecated, do not use
     precision : int
-        decimal precision to round coordinates to
+        deprecated, do not use
 
     Returns
     -------
     shapely.geometry.geometry
     """
+    warn(
+        "the `round_geometry_coords` function is deprecated and will be removed in a future release"
+    )
+
     if isinstance(geom, Point):
         return _round_point_coords(geom, precision)
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -211,7 +211,8 @@ def round_geometry_coords(geom, precision):
     shapely.geometry.geometry
     """
     warn(
-        "the `round_geometry_coords` function is deprecated and will be removed in a future release"
+        "the `round_geometry_coords` function is deprecated and will be removed in a future release",
+        stacklevel=2,
     )
 
     if isinstance(geom, Point):

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -193,7 +193,7 @@ def test_elevation():
     rasters = list(Path("tests/input_data").glob("elevation*.tif"))
 
     # add node elevations from a single raster file (some nodes will be null)
-    G = ox.elevation.add_node_elevations_raster(G, rasters[0], precision=2, cpus=1)
+    G = ox.elevation.add_node_elevations_raster(G, rasters[0], cpus=1)
 
     # add node elevations from multiple raster files
     G = ox.elevation.add_node_elevations_raster(G, rasters)
@@ -201,6 +201,7 @@ def test_elevation():
 
     # add edge grades and their absolute values
     G = ox.add_edge_grades(G, add_absolute=True)
+    G = ox.add_edge_grades(G, add_absolute=True, precision=2)
 
 
 def test_routing():

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -114,8 +114,10 @@ def test_stats():
     G.add_node(0, x=location_point[1], y=location_point[0])
     _ = ox.bearing.calculate_bearing(0, 0, 1, 1)
     G = ox.add_edge_bearings(G)
+    G = ox.add_edge_bearings(G, precision=2)
     G_proj = ox.project_graph(G)
     G_proj = ox.distance.add_edge_lengths(G_proj, edges=tuple(G_proj.edges)[0:3])
+    G_proj = ox.distance.add_edge_lengths(G_proj, edges=tuple(G_proj.edges)[0:3], precision=2)
 
     # calculate stats
     cspn = ox.stats.count_streets_per_node(G)
@@ -191,7 +193,7 @@ def test_elevation():
     rasters = list(Path("tests/input_data").glob("elevation*.tif"))
 
     # add node elevations from a single raster file (some nodes will be null)
-    G = ox.elevation.add_node_elevations_raster(G, rasters[0], cpus=1)
+    G = ox.elevation.add_node_elevations_raster(G, rasters[0], precision=2, cpus=1)
 
     # add node elevations from multiple raster files
     G = ox.elevation.add_node_elevations_raster(G, rasters)
@@ -206,8 +208,9 @@ def test_routing():
 
     # give each edge speed and travel time attributes
     G = ox.add_edge_speeds(G)
-    G = ox.add_edge_speeds(G, hwy_speeds={"motorway": 100})
+    G = ox.add_edge_speeds(G, hwy_speeds={"motorway": 100}, precision=2)
     G = ox.add_edge_travel_times(G)
+    G = ox.add_edge_travel_times(G, precision=2)
 
     # test value cleaning
     assert _clean_maxspeed("100,2") == 100.2


### PR DESCRIPTION
We currently use precision arguments and rounding functionality when adding new graph node/edge attributes in several modules. This is meant to eventually minimize file size when serializing graphs to disk that otherwise would have attributes with arbitrarily fine precision. However, the functionality is clunky and hardly used. If it even is useful, the precision rounding should occur in the `io` module directly when saving data to disk (like the `osm_xml` module does now). It may even be worth considering moving "precision" to the settings module at some point.

This PR deprecates the `precision` parameter in the functions in the `bearing`, `distance`, `elevation`, and `speed` modules. It also deprecates the similar `round_geometry_coords` function in the `utils_geo` module that is unused throughout the package.