### PR TITLE
Make api_key argument optional

### DIFF
--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -111,7 +111,7 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
 
 def add_node_elevations_google(
     G,
-    api_key,
+    api_key=None,
     max_locations_per_batch=350,
     pause_duration=0,
     precision=None,
@@ -132,8 +132,8 @@ def add_node_elevations_google(
     ----------
     G : networkx.MultiDiGraph
         input graph
-    api_key : string
-        a valid API key
+    api_key : Optional[string]
+        a valid API key, сan be omitted if the API does not require a key
     max_locations_per_batch : int
         max number of coordinate pairs to submit in each API call (if this is
         too high, the server will reject the request because its character


### PR DESCRIPTION
Imagine a situation where you need to use, for example, the OpenTopoData APIs that do not require an API key. For now, since `api_key` is a required argument, users will have to look at the source code of the library and see if they can use this method at all. As a result, if someone is lucky enough and gets to the line 
```python3
url = url_template.format(locations, api_key) # api_key = None
# if api_key is None and formatted string only contains one {},
# api_key will be ignored and no exception occures
```
he will understand that `api_key` can be declared `None`, but the method call still looks awkward, as `api_key` is not an optional argument we need to explicitly indicate that `api_key` is `None`:
```python3
G = ox.add_node_elevations_google(
  G,
  api_key = None,
  max_locations_per_batch = 100,
  url_template = "https://api.opentopodata.org/v1/aster30m?locations={}"
)
```
A more pythonic way would be to declare `api_key` as an optional parameter. In this case, calls to an API which does not require a key will be concise and simple:
```python3
G = ox.add_node_elevations_google(
  G,
  max_locations_per_batch = 100,
  url_template = "https://api.opentopodata.org/v1/aster30m?locations={}"
)
```
At the same time, after following change the call syntax for requests to the Google Elevations API will not change in any way:
```python3
G = ox.add_node_elevations_google(
  G,
  api_key = "foobar",
  max_locations_per_batch = 100
)
```