### PR TITLE
update docs and descriptions to use features terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # OSMnx
 
-**OSMnx** is a Python package that lets you download geospatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks and any other geospatial entities. You can download and model walking, driving, or biking networks with a single line of code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, speed/travel time, and routing.
+**OSMnx** is a Python package to download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap. You can download and model walking, driving, or biking networks with a single line of code then easily analyze and visualize them. You can just as easily work with urban amenities/points of interest, building footprints, transit stops, elevation data, street orientations, speed/travel time, and routing.
 
 ## Citation
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -26,9 +26,9 @@ Overview
 
 OSMnx is pronounced as the initialism: "oh-ess-em-en-ex". It is built on top of NetworkX and GeoPandas, and interacts with `OpenStreetMap`_ APIs to:
 
-* Download and model street networks or other networked infrastructure anywhere in the world with a single line of code
-* Download any other geospatial entities (e.g., political boundaries, building footprints, grocery stores, transit stops) as a GeoDataFrame
-* Download by city name, polygon, bounding box, or point/address + distance
+* Download and model street networks or other infrastructure anywhere in the world with a single line of code
+* Download geospatial features (e.g., political boundaries, building footprints, grocery stores, transit stops) as a GeoDataFrame
+* Query by city name, polygon, bounding box, or point/address + distance
 * Model driving, walking, biking, and other travel modes
 * Download node elevations and calculate edge grades (inclines)
 * Impute missing speeds and calculate graph edge travel times
@@ -53,14 +53,14 @@ You can configure OSMnx using the :code:`settings` module. Here you can adjust l
 Geocoding and Querying
 ^^^^^^^^^^^^^^^^^^^^^^
 
-OSMnx geocodes place names and addresses with the OpenStreetMap Nominatim API. You can use the :code:`geocoder` module to geocode place names or addresses to lat-lng coordinates. Or, you can retrieve places (or any other geospatial entities) by name or by OpenStreetMap ID.
+OSMnx geocodes place names and addresses with the OpenStreetMap Nominatim API. You can use the :code:`geocoder` module to geocode place names or addresses to lat-lng coordinates. Or, you can retrieve places or any other geospatial features by name or OpenStreetMap ID.
 
-Using the :code:`geometries` and :code:`graph` modules (as described below), you can download data by lat-lng point, address, bounding box, bounding polygon, or place name (e.g., neighborhood, city, county, etc).
+Using the :code:`geometries` and :code:`graph` modules, as described below, you can download data by lat-lng point, address, bounding box, bounding polygon, or place name (e.g., neighborhood, city, county, etc).
 
 Urban Amenities
 ^^^^^^^^^^^^^^^
 
-Using OSMnx's :code:`geometries` module, you can search for and download any geospatial objects (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap Overpass API as a GeoPandas GeoDataFrame. This uses :code:`tag:value` pairs to search for matching objects.
+Using OSMnx's :code:`geometries` module, you can search for and download any geospatial `features`_ (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap Overpass API as a GeoPandas GeoDataFrame. This uses OpenStreetMap :code:`tag:value` pairs to search for matching features.
 
 Modeling a Network
 ^^^^^^^^^^^^^^^^^^
@@ -137,6 +137,7 @@ Frequently Asked Questions
 .. _GeoPandas: https://geopandas.org/
 .. _NetworkX: https://networkx.org/
 .. _OpenStreetMap: https://www.openstreetmap.org/
+.. _features: https://wiki.openstreetmap.org/wiki/Map_features
 .. _Change Log: https://github.com/gboeing/osmnx/blob/main/CHANGELOG.md
 .. _projects: https://geoffboeing.com/2018/03/osmnx-features-roundup/
 .. _StackOverflow: https://stackoverflow.com/search?q=osmnx

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,8 +1,8 @@
 Getting Started
 ===============
 
-Get Started in Four Steps
--------------------------
+Get Started in 4 Steps
+----------------------
 
 1. Install OSMnx by following the :doc:`installation` guide.
 
@@ -86,7 +86,7 @@ It can also convert a MultiDiGraph to/from GeoPandas node and edge GeoDataFrames
 
 You can easily project your graphs to different coordinate reference systems using the :code:`projection` module. If you're unsure which CRS you want to project to, OSMnx can automatically determine an appropriate UTM CRS for you.
 
-You can save your OSMnx graph to disk as a GraphML file or GeoPackage using the :code:`io` module.
+You can save your OSMnx graph to disk as a GraphML file or GeoPackage using the :code:`io` module. Use the GraphML format whenever saving a graph for later work with OSMnx.
 
 Working with Elevation
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -30,16 +30,15 @@ OSMnx is pronounced as the initialism: "oh-ess-em-en-ex". It is built on top of 
 * Download geospatial features (e.g., political boundaries, building footprints, grocery stores, transit stops) as a GeoDataFrame
 * Query by city name, polygon, bounding box, or point/address + distance
 * Model driving, walking, biking, and other travel modes
-* Download node elevations and calculate edge grades (inclines)
+* Attach node elevations from a local raster file or web service and calculate edge grades
 * Impute missing speeds and calculate graph edge travel times
 * Simplify and correct the network's topology to clean-up nodes and consolidate complex intersections
 * Fast map-matching of points, routes, or trajectories to nearest graph edges or nodes
-* Save networks to disk as GeoPackages or GraphML files
-* Save/load a street network to/from a .osm XML file
+* Save/load network to/from disk as GraphML, GeoPackage, or .osm XML file
 * Conduct topological and spatial analyses to automatically calculate dozens of indicators
 * Calculate and visualize street bearings and orientations
 * Calculate and visualize shortest-path routes that minimize distance, travel time, elevation, etc
-* Explore street networks as a static map or interactive web map
+* Explore street networks and geospatial features as a static map or interactive web map
 * Visualize travel distance and travel time with isoline and isochrone maps
 * Plot figure-ground diagrams of street networks and building footprints
 
@@ -60,7 +59,7 @@ Using the :code:`geometries` and :code:`graph` modules, as described below, you 
 Urban Amenities
 ^^^^^^^^^^^^^^^
 
-Using OSMnx's :code:`geometries` module, you can search for and download any geospatial `features`_ (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap Overpass API as a GeoPandas GeoDataFrame. This uses OpenStreetMap :code:`tag:value` pairs to search for matching features.
+Using OSMnx's :code:`geometries` module, you can search for and download any geospatial `features`_ (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap Overpass API as a GeoPandas GeoDataFrame. This uses OpenStreetMap `tags`_ to search for matching features.
 
 Modeling a Network
 ^^^^^^^^^^^^^^^^^^
@@ -85,14 +84,14 @@ OSMnx can convert a MultiDiGraph to a MultiGraph if you prefer an undirected rep
 
 It can also convert a MultiDiGraph to/from GeoPandas node and edge GeoDataFrames. This allows you to load arbitrary node/edge ShapeFiles or GeoPackage layers as GeoDataFrames then model them as a MultiDiGraph for graph analysis.
 
-You can easily project your graphs to different coordinate reference systems using the :code:`projection` module. If you're unsure which CRS you want to project to, OSMnx will automatically determine an appropriate UTM zone CRS for you.
+You can easily project your graphs to different coordinate reference systems using the :code:`projection` module. If you're unsure which CRS you want to project to, OSMnx can automatically determine an appropriate UTM CRS for you.
 
 You can save your OSMnx graph to disk as a GraphML file or GeoPackage using the :code:`io` module.
 
 Working with Elevation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Using the :code:`elevation` module, you can automatically attach elevation data to the graph's nodes from a local raster file or web service such as the Google Maps Elevation API. You can also calculate edge grades (i.e., inclines).
+Using the :code:`elevation` module, you can automatically attach elevations to the graph's nodes from a local raster file or web service such as the Google Maps Elevation API. You can also calculate edge grades (i.e., rise-over-run).
 
 Network Statistics
 ^^^^^^^^^^^^^^^^^^
@@ -104,21 +103,19 @@ You can use NetworkX directly to calculate additional topological network measur
 Routing
 ^^^^^^^
 
-The :code:`speed` module can impute missing speeds to the graph edges. It can also calculate free-flow travel times for each edge. This imputation can obviously be imprecise, and the user can override it by passing in arguments that define local speed limits.
+The :code:`speed` module can impute missing speeds to the graph edges. This imputation can obviously be imprecise, and the user can override it by passing in arguments that define local speed limits. It can also calculate free-flow travel times for each edge.
 
-The :code:`distance` module can find the nearest node(s) or edge(s) to coordinates using a very fast spatial index. It can also solve shortest paths for network routing, parallelized with multiprocessing, using different weights (e.g., length, travel time, elevation change, etc).
+The :code:`distance` module can find the nearest node(s) or edge(s) to coordinates using a fast spatial index. It can also solve shortest paths for network routing, parallelized with multiprocessing, using different weights (e.g., distance, travel time, elevation change, etc).
 
 Visualization
 ^^^^^^^^^^^^^
 
-You can plot graphs, routes, network figure-ground diagrams, building footprints, and street network orientation rose diagrams (polar histograms) with the :code:`plot` module. You can also explore street networks, routes, or urban amenities as interactive folium/leaflet web maps.
+You can plot graphs, routes, network figure-ground diagrams, building footprints, and street network orientation rose diagrams (polar histograms) with the :code:`plot` module. You can also explore street networks, routes, or geospatial features as interactive folium/leaflet web maps.
 
 More Info
 ---------
 
-All of this functionality is demonstrated step-by-step in the `OSMnx Examples`_ gallery, and usage is detailed in the :doc:`user-reference`.
-
-More feature development details are in the `Change Log`_. Consult the :doc:`further-reading` resources for additional technical details and research.
+All of this functionality is demonstrated step-by-step in the `OSMnx Examples`_ gallery, and usage is detailed in the :doc:`user-reference`. More feature development details are in the `Change Log`_. Consult the :doc:`further-reading` resources for additional technical details and research.
 
 Frequently Asked Questions
 --------------------------
@@ -138,6 +135,7 @@ Frequently Asked Questions
 .. _NetworkX: https://networkx.org/
 .. _OpenStreetMap: https://www.openstreetmap.org/
 .. _features: https://wiki.openstreetmap.org/wiki/Map_features
+.. _tags: https://wiki.openstreetmap.org/wiki/Tags
 .. _Change Log: https://github.com/gboeing/osmnx/blob/main/CHANGELOG.md
 .. _projects: https://geoffboeing.com/2018/03/osmnx-features-roundup/
 .. _StackOverflow: https://stackoverflow.com/search?q=osmnx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 OSMnx |version|
 ===============
 
-OSMnx is a Python package that lets you download geospatial data from OpenStreetMap and model, project, visualize, and analyze real-world street networks and any other geospatial entities. You can download and model walking, driving, or biking networks with a single line of code then easily analyze and visualize them. You can just as easily download and work with other infrastructure types, amenities/points of interest, building footprints, elevation data, street bearings/orientations, speed/travel time, and routing.
+**OSMnx** is a Python package to download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap. You can download and model walking, driving, or biking networks with a single line of code then easily analyze and visualize them. You can just as easily work with urban amenities/points of interest, building footprints, transit stops, elevation data, street orientations, speed/travel time, and routing.
 
 Citation
 --------

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -1,5 +1,5 @@
 """
-Download geospatial entities' geometries and attributes from OpenStreetMap.
+Download geospatial features' geometries and attributes from OpenStreetMap.
 
 Retrieve points of interest, building footprints, transit lines/stops, or any
 other objects from OSM, including their geometries and attribute data, and
@@ -75,7 +75,7 @@ _POLYGON_FEATURES = {
 
 def geometries_from_bbox(north, south, east, west, tags):
     """
-    Create a GeoDataFrame of OSM entities within a N, S, E, W bounding box.
+    Create a GeoDataFrame of OSM features within a N, S, E, W bounding box.
 
     Parameters
     ----------
@@ -120,7 +120,7 @@ def geometries_from_bbox(north, south, east, west, tags):
 
 def geometries_from_point(center_point, tags, dist=1000):
     """
-    Create GeoDataFrame of OSM entities within some distance N, S, E, W of a point.
+    Create GeoDataFrame of OSM features within some distance N, S, E, W of a point.
 
     Parameters
     ----------
@@ -164,7 +164,7 @@ def geometries_from_point(center_point, tags, dist=1000):
 
 def geometries_from_address(address, tags, dist=1000):
     """
-    Create GeoDataFrame of OSM entities within some distance N, S, E, W of address.
+    Create GeoDataFrame of OSM features within some distance N, S, E, W of address.
 
     Parameters
     ----------
@@ -206,7 +206,7 @@ def geometries_from_address(address, tags, dist=1000):
 
 def geometries_from_place(query, tags, which_result=None, buffer_dist=None):
     """
-    Create GeoDataFrame of OSM entities within boundaries of geocodable place(s).
+    Create GeoDataFrame of OSM features within boundaries of geocodable place(s).
 
     The query must be geocodable and OSM must have polygon boundaries for the
     geocode result. If OSM does not have a polygon for this place, you can
@@ -277,7 +277,7 @@ def geometries_from_place(query, tags, which_result=None, buffer_dist=None):
 
 def geometries_from_polygon(polygon, tags):
     """
-    Create GeoDataFrame of OSM entities within boundaries of a (multi)polygon.
+    Create GeoDataFrame of OSM features within boundaries of a (multi)polygon.
 
     Parameters
     ----------
@@ -327,7 +327,7 @@ def geometries_from_polygon(polygon, tags):
 
 def geometries_from_xml(filepath, polygon=None, tags=None):
     """
-    Create a GeoDataFrame of OSM entities in an OSM-formatted XML file.
+    Create a GeoDataFrame of OSM features in an OSM-formatted XML file.
 
     Because this function creates a GeoDataFrame of geometries from an
     OSM-formatted XML file that has already been downloaded (i.e. no query is

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -587,7 +587,7 @@ def plot_footprints(
     dpi=600,
 ):
     """
-    Visualize a GeoDataFrame of geospatial entities' footprints.
+    Visualize a GeoDataFrame of geospatial features' footprints.
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "requests>=2.25",
     "shapely>=2.0",
 ]
-description = "Retrieve, model, analyze, and visualize OpenStreetMap street networks and other geospatial data"
+description = "Download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap"
 dynamic = ["version"]
 keywords = ["GIS", "Networks", "OpenStreetMap", "Routing"]
 license = {text = "MIT License"}


### PR DESCRIPTION
Our documentation and docstrings have long had a disjointed way of referring to OSM [features](https://wiki.openstreetmap.org/wiki/Map_features) as "geometries" or "entities" or "objects." This PR makes use of "features" terminology consistent.