### PR TITLE
deprecate interpolate param and make downloader module private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
   - fix bug in save_graph_xml due to roundabout ways
   - make API key properly optional in elevation.add_node_elevations_google function
-  - remove internal \_polygon_features module and move its data to geometries module
+  - remove private \_polygon_features module and move its data to geometries module
+  - make the internal downloader module private
+  - deprecate interpolate parameter in distance.nearest_edges function
   - migrate from setup.py, setup.cfg, and requirements.txt to pyproject.toml
   - pin optional dependencies to minimum required versions
   - adopt NEP 29 policy for minimum required Python and NumPy versions

--- a/docs/internals-reference.rst
+++ b/docs/internals-reference.rst
@@ -27,7 +27,7 @@ osmnx.distance module
     :private-members:
     :noindex:
 
-osmnx.downloader module
+osmnx._downloader module
 -----------------------
 
 .. automodule:: osmnx.downloader

--- a/docs/internals-reference.rst
+++ b/docs/internals-reference.rst
@@ -28,9 +28,9 @@ osmnx.distance module
     :noindex:
 
 osmnx._downloader module
------------------------
+------------------------
 
-.. automodule:: osmnx.downloader
+.. automodule:: osmnx._downloader
     :members:
     :private-members:
     :noindex:

--- a/docs/user-reference.rst
+++ b/docs/user-reference.rst
@@ -19,12 +19,6 @@ osmnx.distance module
 .. automodule:: osmnx.distance
     :members:
 
-osmnx.downloader module
------------------------
-
-.. automodule:: osmnx.downloader
-    :members:
-
 osmnx.elevation module
 ----------------------
 

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -556,7 +556,7 @@ def _osm_network_download(polygon, network_type, custom_filter):
     # time. The '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
         query_str = f"{overpass_settings};(way{osm_filter}(poly:{polygon_coord_str!r});>;);out;"
-        response_json = overpass_request(data={"data": query_str})
+        response_json = _overpass_request(data={"data": query_str})
         response_jsons.append(response_json)
     utils.log(
         f"Got all network data within polygon from API in {len(polygon_coord_strs)} request(s)"
@@ -592,7 +592,7 @@ def _osm_geometries_download(polygon, tags):
     # pass exterior coordinates of each polygon in list to API, one at a time
     for polygon_coord_str in polygon_coord_strs:
         query_str = _create_overpass_query(polygon_coord_str, tags)
-        response_json = overpass_request(data={"data": query_str})
+        response_json = _overpass_request(data={"data": query_str})
         response_jsons.append(response_json)
 
     utils.log(
@@ -651,11 +651,11 @@ def _osm_place_download(query, by_osmid=False, limit=1, polygon_geojson=1):
             raise TypeError("query must be a dict or a string")
 
     # request the URL, return the JSON
-    response_json = nominatim_request(params=params, request_type=request_type)
+    response_json = _nominatim_request(params=params, request_type=request_type)
     return response_json
 
 
-def nominatim_request(params, request_type="search", pause=1, error_pause=60):
+def _nominatim_request(params, request_type="search", pause=1, error_pause=60):
     """
     Send a HTTP GET request to the Nominatim API and return JSON response.
 
@@ -726,7 +726,7 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
                 # re-trying until we get a valid response from the server
                 utils.log(f"{domain} returned {sc}: retry in {error_pause} secs", level=lg.WARNING)
                 time.sleep(error_pause)
-                response_json = nominatim_request(params, request_type, pause, error_pause)
+                response_json = _nominatim_request(params, request_type, pause, error_pause)
 
             else:
                 # else, this was an unhandled status code, throw an exception
@@ -739,7 +739,7 @@ def nominatim_request(params, request_type="search", pause=1, error_pause=60):
         return response_json
 
 
-def overpass_request(data, pause=None, error_pause=60):
+def _overpass_request(data, pause=None, error_pause=60):
     """
     Send a HTTP POST request to the Overpass API and return JSON response.
 
@@ -806,7 +806,7 @@ def overpass_request(data, pause=None, error_pause=60):
                 this_pause = error_pause + _get_pause(base_endpoint)
                 utils.log(f"{domain} returned {sc}: retry in {this_pause} secs", level=lg.WARNING)
                 time.sleep(this_pause)
-                response_json = overpass_request(data, pause, error_pause)
+                response_json = _overpass_request(data, pause, error_pause)
 
             else:
                 # else, this was an unhandled status code, throw an exception

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -253,20 +253,9 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
 
     If `X` and `Y` are single coordinate values, this will return the nearest
     edge to that point. If `X` and `Y` are lists of coordinate values, this
-    will return the nearest edge to each point.
-
-    If `interpolate` is None, search for the nearest edge to each point, one
-    at a time, using an R-tree and minimizing the euclidean distances from the
-    point to the possible matches. For accuracy, use a projected graph and
-    points. This method is precise and fast, particularly when searching for
-    relatively few points compared to the graph's size.
-
-    For an alternative method, use the `interpolate` argument to interpolate
-    points along the edges and index them. If the graph is projected, this
-    uses a k-d tree for euclidean nearest neighbor search, which requires that
-    scipy is installed as an optional dependency. If graph is unprojected,
-    this uses a ball tree for haversine nearest neighbor search, which
-    requires that scikit-learn is installed as an optional dependency.
+    will return the nearest edge to each point. This function uses an R-tree
+    spatial index and minimizes the euclidean distance from each point to the
+    possible matches. For accurate results, use a projected graph and points.
 
     Parameters
     ----------
@@ -279,8 +268,7 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
         points' y (latitude) coordinates, in same CRS/units as graph and
         containing no nulls
     interpolate : float
-        spacing distance between interpolated points, in same units as graph.
-        smaller values generate more points.
+        deprecated, do not use
     return_dist : bool
         optionally also return distance between points and nearest edges
 
@@ -303,10 +291,10 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
 
     # if no interpolation distance was provided
     if interpolate is None:
-        # build the r-tree spatial index by position for subsequent iloc
+        # build an r-tree spatial index by position for subsequent iloc
         rtree = STRtree(geoms)
 
-        # use r-tree to find each point's nearest neighbor and distance
+        # use the r-tree to find each point's nearest neighbor and distance
         points = [Point(xy) for xy in zip(X, Y)]
         pos, dist = rtree.query_nearest(points, all_matches=False, return_distance=True)
 
@@ -317,6 +305,11 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
 
     # otherwise, if interpolation distance was provided
     else:
+        warn(
+            "The `interpolate` parameter has been deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
+
         # interpolate points along edges to index with k-d tree or ball tree
         uvk_xy = []
         for uvk, geom in zip(geoms.index, geoms.values):

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import requests
 
-from . import downloader
+from . import _downloader
 from . import utils
 from . import utils_graph
 
@@ -179,7 +179,7 @@ def add_node_elevations_google(
         url = url_template.format(locations, api_key)
 
         # check if this request is already in the cache (if global use_cache=True)
-        cached_response_json = downloader._retrieve_from_cache(url)
+        cached_response_json = _downloader._retrieve_from_cache(url)
         if cached_response_json is not None:
             response_json = cached_response_json
         else:
@@ -189,7 +189,7 @@ def add_node_elevations_google(
             response = requests.get(url)
             if response.status_code == 200:
                 response_json = response.json()
-                downloader._save_to_cache(url, response_json, response.status_code)
+                _downloader._save_to_cache(url, response_json, response.status_code)
             else:
                 raise Exception(
                     f"Server responded with {response.status_code}: {response.reason} \n{response.json()}"

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 import geopandas as gpd
 import pandas as pd
 
-from . import downloader
+from . import _downloader
 from . import projection
 from . import settings
 from . import utils
@@ -32,7 +32,7 @@ def geocode(query):
     params["limit"] = 1
     params["dedupe"] = 0  # prevent deduping to get precise number of results
     params["q"] = query
-    response_json = downloader.nominatim_request(params=params)
+    response_json = _downloader._nominatim_request(params=params)
 
     # if results were returned, parse lat and lng out of the result
     if response_json and "lat" in response_json[0] and "lon" in response_json[0]:
@@ -153,7 +153,7 @@ def _geocode_query_to_gdf(query, which_result, by_osmid):
     else:
         limit = which_result
 
-    results = downloader._osm_place_download(query, by_osmid=by_osmid, limit=limit)
+    results = _downloader._osm_place_download(query, by_osmid=by_osmid, limit=limit)
 
     # choose the right result from the JSON response
     if not results:
@@ -215,7 +215,7 @@ def _get_first_polygon(results, query):
     Parameters
     ----------
     results : list
-        list of results from downloader._osm_place_download
+        list of results from _downloader._osm_place_download
     query : str
         the query string or structured dict that was geocoded
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -23,7 +23,7 @@ from shapely.geometry import Polygon
 from shapely.ops import linemerge
 from shapely.ops import polygonize
 
-from . import downloader
+from . import _downloader
 from . import geocoder
 from . import osm_xml
 from . import settings
@@ -312,7 +312,7 @@ def geometries_from_polygon(polygon, tags):
         )
 
     # download the geometry data from OSM
-    response_jsons = downloader._osm_geometries_download(polygon, tags)
+    response_jsons = _downloader._osm_geometries_download(polygon, tags)
 
     # create GeoDataFrame from the downloaded data
     gdf = _create_gdf(response_jsons, polygon, tags)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -127,8 +127,7 @@ def graph_from_point(
     dist_type : string {"network", "bbox"}
         if "bbox", retain only those nodes within a bounding box of the
         distance parameter. if "network", retain only those nodes within some
-        network distance from the center-most node (requires that scikit-learn
-        is installed as an optional dependency).
+        network distance from the center-most node.
     network_type : string, {"all_private", "all", "bike", "drive", "drive_service", "walk"}
         what type of street network to get if custom_filter is None
     simplify : bool
@@ -218,8 +217,7 @@ def graph_from_address(
     dist_type : string {"network", "bbox"}
         if "bbox", retain only those nodes within a bounding box of the
         distance parameter. if "network", retain only those nodes within some
-        network distance from the center-most node (requires that scikit-learn
-        is installed as an optional dependency).
+        network distance from the center-most node.
     network_type : string {"all_private", "all", "bike", "drive", "drive_service", "walk"}
         what type of street network to get if custom_filter is None
     simplify : bool

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -7,8 +7,8 @@ import networkx as nx
 from shapely.geometry import MultiPolygon
 from shapely.geometry import Polygon
 
+from . import _downloader
 from . import distance
-from . import downloader
 from . import geocoder
 from . import osm_xml
 from . import projection
@@ -442,7 +442,7 @@ def graph_from_polygon(
         poly_buff, _ = projection.project_geometry(poly_proj_buff, crs=crs_utm, to_latlong=True)
 
         # download the network data from OSM within buffered polygon
-        response_jsons = downloader._osm_network_download(poly_buff, network_type, custom_filter)
+        response_jsons = _downloader._osm_network_download(poly_buff, network_type, custom_filter)
 
         # create buffered graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types
@@ -474,7 +474,7 @@ def graph_from_polygon(
     # if clean_periphery=False, just use the polygon as provided
     else:
         # download the network data from OSM
-        response_jsons = downloader._osm_network_download(polygon, network_type, custom_filter)
+        response_jsons = _downloader._osm_network_download(polygon, network_type, custom_filter)
 
         # create graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -1,4 +1,4 @@
-"""Project spatial geometries and spatial networks."""
+"""Reproject a graph, GeoDataFrame, or geometry to a different CRS."""
 
 import geopandas as gpd
 import numpy as np

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -341,14 +341,14 @@ def test_find_nearest():
 
 
 def test_api_endpoints():
-    ip = ox.downloader._resolve_host_via_doh("overpass-api.de")
-    ip = ox.downloader._resolve_host_via_doh("AAAAAAAAAAA")
+    ip = ox._downloader._resolve_host_via_doh("overpass-api.de")
+    ip = ox._downloader._resolve_host_via_doh("AAAAAAAAAAA")
 
     _doh_url_template_default = ox.settings.doh_url_template
     ox.settings.doh_url_template = "http://aaaaaa.hostdoesntexist.org/nothinguseful"
-    ip = ox.downloader._resolve_host_via_doh("overpass-api.de")
+    ip = ox._downloader._resolve_host_via_doh("overpass-api.de")
     ox.settings.doh_url_template = None
-    ip = ox.downloader._resolve_host_via_doh("overpass-api.de")
+    ip = ox._downloader._resolve_host_via_doh("overpass-api.de")
     ox.settings.doh_url_template = _doh_url_template_default
 
     params = OrderedDict()
@@ -357,11 +357,11 @@ def test_api_endpoints():
 
     # Bad Address - should return an empty response
     params["q"] = "AAAAAAAAAAA"
-    response_json = ox.downloader.nominatim_request(params=params, request_type="search")
+    response_json = ox._downloader._nominatim_request(params=params, request_type="search")
 
     # Good Address - should return a valid response with a valid osm_id
     params["q"] = "Newcastle A186 Westgate Rd"
-    response_json = ox.downloader.nominatim_request(params=params, request_type="search")
+    response_json = ox._downloader._nominatim_request(params=params, request_type="search")
 
     # Lookup
     params = OrderedDict()
@@ -369,11 +369,11 @@ def test_api_endpoints():
     params["address_details"] = 0
     params["osm_ids"] = "W68876073"
 
-    response_json = ox.downloader.nominatim_request(params=params, request_type="lookup")
+    response_json = ox._downloader._nominatim_request(params=params, request_type="lookup")
 
     # Invalid nominatim query type
     with pytest.raises(ValueError):
-        response_json = ox.downloader.nominatim_request(params=params, request_type="xyz")
+        response_json = ox._downloader._nominatim_request(params=params, request_type="xyz")
 
     default_key = ox.settings.nominatim_key
     default_nominatim_endpoint = ox.settings.nominatim_endpoint
@@ -381,7 +381,7 @@ def test_api_endpoints():
 
     # Searching on public nominatim should work even if a key was provided
     ox.settings.nominatim_key = "NOT_A_KEY"
-    response_json = ox.downloader.nominatim_request(params=params, request_type="search")
+    response_json = ox._downloader._nominatim_request(params=params, request_type="search")
 
     # Test changing the endpoint.
     # This should fail because we didn't provide a valid endpoint


### PR DESCRIPTION
This PR:

  - deprecates the `interpolate` parameter of the `nearest_edges` function: the STRtree is essentially as fast as using scipy/scikit-learn here, so there's no point in maintaining 3 different search techniques anymore.
  - makes the `downloader` module private: I just realized that this internal module was left public, even though it's not part of the public API. Made it private now to correct that.