### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
 
     steps:
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Lint code
         run: |
-          pre-commit run --all-files
+          SKIP=no-commit-to-branch pre-commit run --all-files
           hatch build --clean
           twine check --strict ./dist/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash
+        shell: bash -elo pipefail {0}
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,7 @@ jobs:
           twine check --strict ./dist/*
 
       - name: Test code
-        run: |
-          coverage run --source ./osmnx --module pytest --verbose
-          coverage xml -i
-          coverage report -m
+        run: pytest --cov=./osmnx --cov-report=xml --cov-report=term-missing --verbose
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -48,7 +48,4 @@ jobs:
           twine check --strict ./dist/*
 
       - name: Test code
-        run: pytest --cov=./osmnx --cov-report=xml --cov-report=term-missing --verbose
-
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        run: pytest --cov=./osmnx --cov-report=term-missing --verbose

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -18,7 +18,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash
+        shell: bash -elo pipefail {0}
 
     steps:
 

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -48,10 +48,7 @@ jobs:
           twine check --strict ./dist/*
 
       - name: Test code
-        run: |
-          coverage run --source ./osmnx --module pytest --verbose
-          coverage xml
-          coverage report -m
+        run: pytest --cov=./osmnx --cov-report=xml --cov-report=term-missing --verbose
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -18,7 +18,7 @@ jobs:
 
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash
 
     steps:
 
@@ -43,14 +43,14 @@ jobs:
 
       - name: Lint code
         run: |
-          pre-commit run --all-files
+          SKIP=no-commit-to-branch pre-commit run --all-files
           hatch build --clean
           twine check --strict ./dist/*
 
       - name: Test code
         run: |
           coverage run --source ./osmnx --module pytest --verbose
-          coverage xml -i
+          coverage xml
           coverage report -m
 
       - name: Upload coverage report

--- a/environments/tests/env-ci.yml
+++ b/environments/tests/env-ci.yml
@@ -23,10 +23,10 @@ dependencies:
 
   # linting/testing
   - black=23
-  - coverage
   - hatch
   - pre-commit
   - pytest
+  - pytest-cov
   - ruff
   - twine
 

--- a/environments/tests/env-test-minimal.yml
+++ b/environments/tests/env-test-minimal.yml
@@ -26,13 +26,13 @@ dependencies:
 
   # linting/testing
   - black=23
-  - coverage
   - hatch
   - pre-commit
   - pytest
+  - pytest-cov
   - ruff
   - twine
 
   # docs
   - furo
-  - sphinx=6  # pin to version from docs/requirements.txt
+  - sphinx=6  # pin to version from /docs/requirements.txt

--- a/tests/lint_test.sh
+++ b/tests/lint_test.sh
@@ -18,11 +18,8 @@ pre-commit run --all-files
 # make -C ./docs html
 # python -m sphinx -b linkcheck docs/ docs/_build/linkcheck
 
-# run the tests
-coverage run --source ./osmnx --module pytest --verbose
-
-# report the test coverage
-coverage report -m
+# run the tests and report the test coverage
+pytest --cov=./osmnx --cov-report=term-missing --verbose
 
 # delete temp files and folders
 rm -r -f .coverage .pytest_cache .temp ./dist/ ./docs/_build osmnx/__pycache__ tests/__pycache__

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -18,7 +18,7 @@ mamba update conda-smithy --yes --no-banner
 VERSION=$(hatch version)
 
 # build and validate the distribution then get its SHA256
-rm -rf ./build ./dist
+rm -rf ./dist
 hatch build --clean
 twine check --strict ./dist/*
 SHA=$(openssl dgst -sha256 -r "./dist/$PACKAGE-$VERSION.tar.gz"  | awk '{print $1}')
@@ -51,7 +51,7 @@ cd ../$PACKAGE
 git tag -a "v$VERSION" -m "v$VERSION"
 git push origin --tags
 twine upload ./dist/*
-rm -rf ./build ./dist
+rm -rf ./dist
 
 # all done
 echo ""


### PR DESCRIPTION
CI was using a [shell](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference) such that only the *final* exit code generated by a step could cause a failure (i.e., if a line in the middle of a step's `run` definition exited with a non-zero, the step would "succeed" anyway. This behavior only started a few days ago, and I just noticed it. Prior to that, tests were failing appropriately up until ~5 days ago. In the meantime, tests were silently failing while appearing to be passing.