### PR TITLE
Stream downloads to save memory

### DIFF
--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -553,8 +553,8 @@ def _osm_network_download(polygon, network_type, custom_filter):
     # time. The '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
         query_str = f"{overpass_settings};(way{osm_filter}(poly:{polygon_coord_str!r});>;);out;"
-        response_json = _overpass_request(data={"data": query_str})
-        yield response_json
+        yield _overpass_request(data={"data": query_str})
+        
 
     if settings.cache_only_mode:  # pragma: no cover
         raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -554,7 +554,6 @@ def _osm_network_download(polygon, network_type, custom_filter):
     for polygon_coord_str in polygon_coord_strs:
         query_str = f"{overpass_settings};(way{osm_filter}(poly:{polygon_coord_str!r});>;);out;"
         yield _overpass_request(data={"data": query_str})
-        
 
     if settings.cache_only_mode:  # pragma: no cover
         raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -530,10 +530,10 @@ def _osm_network_download(polygon, network_type, custom_filter):
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
 
-    Returns
-    -------
-    response_jsons : list
-        list of JSON responses from the Overpass server
+    Yields
+    ------
+    response_json : dict
+        JSON response from the Overpass server
     """
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type, if provided, otherwise use custom_filter
@@ -541,8 +541,6 @@ def _osm_network_download(polygon, network_type, custom_filter):
         osm_filter = custom_filter
     else:
         osm_filter = _get_osm_filter(network_type)
-
-    response_jsons = []
 
     # create overpass settings string
     overpass_settings = _make_overpass_settings()
@@ -556,15 +554,10 @@ def _osm_network_download(polygon, network_type, custom_filter):
     for polygon_coord_str in polygon_coord_strs:
         query_str = f"{overpass_settings};(way{osm_filter}(poly:{polygon_coord_str!r});>;);out;"
         response_json = _overpass_request(data={"data": query_str})
-        response_jsons.append(response_json)
-    utils.log(
-        f"Got all network data within polygon from API in {len(polygon_coord_strs)} request(s)"
-    )
+        yield response_json
 
     if settings.cache_only_mode:  # pragma: no cover
         raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")
-
-    return response_jsons
 
 
 def _osm_features_download(polygon, tags):

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -562,11 +562,6 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     """
     utils.log("Creating graph from downloaded OSM data...")
 
-    # make sure we got data back from the server request(s)
-    if not any(rj["elements"] for rj in response_jsons):  # pragma: no cover
-        msg = "There are no data elements in the server response. Check log and query location/filters."
-        raise EmptyOverpassResponse(msg)
-
     # create the graph as a MultiDiGraph and set its meta-attributes
     metadata = {
         "created_date": utils.ts(),
@@ -585,6 +580,11 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
 
         # add each osm way (ie, a path of edges) to the graph
         _add_paths(G, paths.values(), bidirectional)
+
+    # make sure we got data back from the server request(s)
+    if not any(G.nodes()):  # pragma: no cover
+        msg = "There are no data elements in the server response. Check log and query location/filters."
+        raise EmptyOverpassResponse(msg)
 
     # retain only the largest connected component if retain_all is False
     if not retain_all:

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -548,8 +548,8 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
 
     Parameters
     ----------
-    response_jsons : list
-        list of dicts of JSON responses from from the Overpass API
+    response_jsons : iterable
+        iterable of dicts of JSON responses from from the Overpass API
     retain_all : bool
         if True, return the entire graph even if it is not connected.
         otherwise, retain only the largest weakly connected component.
@@ -576,19 +576,15 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     G = nx.MultiDiGraph(**metadata)
 
     # extract nodes and paths from the downloaded osm data
-    nodes = {}
-    paths = {}
     for response_json in response_jsons:
-        nodes_temp, paths_temp = _parse_nodes_paths(response_json)
-        nodes.update(nodes_temp)
-        paths.update(paths_temp)
+        nodes, paths = _parse_nodes_paths(response_json)
 
-    # add each osm node to the graph
-    for node, data in nodes.items():
-        G.add_node(node, **data)
+        # add each osm node to the graph
+        for node, data in nodes.items():
+            G.add_node(node, **data)
 
-    # add each osm way (ie, a path of edges) to the graph
-    _add_paths(G, paths.values(), bidirectional)
+        # add each osm way (ie, a path of edges) to the graph
+        _add_paths(G, paths.values(), bidirectional)
 
     # retain only the largest connected component if retain_all is False
     if not retain_all:


### PR DESCRIPTION
This addresses #1016.

The changes were way simpler than I thought, but it only saves about 33% of memory. That's still quite good, I think.

Due to the streaming, I had to remove a log message, as it is no longer possible to count the downloaded data before consuming it.

Any suggestions for code improvements are welcome, and I have not run any benchmarks yet, on how much memory it is saving. The 33% come from looking at the memory usage of Python in my system monitor. 