### PR TITLE
problematic utf-c-char in a description

### DIFF
--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -133,7 +133,7 @@ def add_node_elevations_google(
     G : networkx.MultiDiGraph
         input graph
     api_key : string
-        a valid API key, сan be None if the API does not require a key
+        a valid API key, can be None if the API does not require a key
     max_locations_per_batch : int
         max number of coordinate pairs to submit in each API call (if this is
         too high, the server will reject the request because its character


### PR DESCRIPTION
The add_node_elevations_google procedure description contains a UTF-8 'c' that gets problematic when the latex source generated by sphinx is processed. This patch replaces the problematic UTF-8 'c' with a ASCII 'c' char.
