### PR TITLE
Better memory efficiency when downloading/constructing graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+  - improve memory efficiency during graph creation
   - adopt NEP 29 policy for minimum required Python and NumPy versions
 
 ## 1.5.0 (2023-06-28)

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -531,8 +531,8 @@ def _osm_network_download(polygon, network_type, custom_filter):
 
     Yields
     ------
-    response_jsons : generator
-        generator of JSON response dicts from the Overpass server
+    response_json : dict
+        JSON response from the Overpass server
     """
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type, if provided, otherwise use custom_filter

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -18,7 +18,6 @@ from . import projection
 from . import settings
 from . import utils
 from . import utils_geo
-from ._errors import CacheOnlyModeInterrupt
 
 # capture getaddrinfo function to use original later after mutating it
 _original_getaddrinfo = socket.getaddrinfo
@@ -532,8 +531,8 @@ def _osm_network_download(polygon, network_type, custom_filter):
 
     Yields
     ------
-    response_json : dict
-        JSON response from the Overpass server
+    response_jsons : generator
+        generator of JSON response dicts from the Overpass server
     """
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type, if provided, otherwise use custom_filter
@@ -554,9 +553,6 @@ def _osm_network_download(polygon, network_type, custom_filter):
     for polygon_coord_str in polygon_coord_strs:
         query_str = f"{overpass_settings};(way{osm_filter}(poly:{polygon_coord_str!r});>;);out;"
         yield _overpass_request(data={"data": query_str})
-
-    if settings.cache_only_mode:  # pragma: no cover
-        raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")
 
 
 def _osm_features_download(polygon, tags):

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -580,12 +580,13 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     utils.log(f"Retrieved all data from API in {response_count} request(s)")
     if settings.cache_only_mode:  # pragma: no cover
         # after consuming all response_jsons in loop, raise exception to catch
-        raise CacheOnlyModeInterrupt("settings.cache_only_mode=True")
+        raise CacheOnlyModeInterrupt("Interrupted because `settings.cache_only_mode=True`")
 
     # ensure we got some node/way data back from the server request(s)
     if (len(nodes) == 0) and (len(paths) == 0):  # pragma: no cover
-        msg = "There are no data elements in the server response. Check log and query location/filters."
-        raise EmptyOverpassResponse(msg)
+        raise EmptyOverpassResponse(
+            "No data elements in server response. Check query location/filters and log."
+        )
 
     # create the MultiDiGraph and set its graph-level attributes
     metadata = {
@@ -596,7 +597,7 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
     G = nx.MultiDiGraph(**metadata)
 
     # add each OSM node and way (a path of edges) to the graph
-    utils.log(f"Adding {len(nodes):,} OSM nodes and {len(paths):,} OSM ways to graph...")
+    utils.log(f"Creating graph from {len(nodes):,} OSM nodes and {len(paths):,} OSM ways...")
     for node, data in nodes.items():
         G.add_node(node, **data)
     _add_paths(G, paths.values(), bidirectional)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -598,8 +598,7 @@ def _create_graph(response_jsons, retain_all=False, bidirectional=False):
 
     # add each OSM node and way (a path of edges) to the graph
     utils.log(f"Creating graph from {len(nodes):,} OSM nodes and {len(paths):,} OSM ways...")
-    for node, data in nodes.items():
-        G.add_node(node, **data)
+    G.add_nodes_from(nodes.items())
     _add_paths(G, paths.values(), bidirectional)
 
     # retain only the largest connected component if retain_all=False


### PR DESCRIPTION
Builds on #1021 and resolves #1016.

@McToel I merged your PR into a feature branch for more testing. There were a couple of bugs:
  - it broke `ox.settings.cache_only_mode=True` functionality
  - it added duplicate edges to a graph when making multiple requests to the server

I addressed both of those issues in this PR and restored a log message. It's slightly less memory efficient that your branch, but more memory efficient than main currently is.

You can use a code snippet like this to test:
```python
import osmnx as ox
ox.settings.log_console = True
ox.settings.use_cache = True
ox.settings.cache_only_mode = False
place = "Los Angeles County, CA, USA"
G = ox.graph.graph_from_place(place, network_type="drive")
len(G.nodes), len(G.edges)
```

The result should be `(174692, 461602)` but on your branch it was `(186022, 512722)` due to edge duplication. The solution necessitated accumulating nodes/paths as dicts in a for loop while consuming the `response_jsons` generator, which increases memory, but not by a lot because the dicts themselves are relatively compact and memory efficient.

Please take a look and test it out.