### PR TITLE
Add kwargs to _getaddrinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix DNS resolution in Dask clusters
 - minor under-the-hood code clean-up
 - adopt NEP 29 policy for minimum required Python and NumPy versions
 

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -331,12 +331,12 @@ def _config_dns(url):
         ip = _resolve_host_via_doh(hostname)
 
     # mutate socket.getaddrinfo to map hostname -> IP address
-    def _getaddrinfo(*args):
+    def _getaddrinfo(*args, **kwargs):
         if args[0] == hostname:
             utils.log(f"Resolved {hostname!r} to {ip!r}")
-            return _original_getaddrinfo(ip, *args[1:])
+            return _original_getaddrinfo(ip, *args[1:], **kwargs)
         else:
-            return _original_getaddrinfo(*args)
+            return _original_getaddrinfo(*args, **kwargs)
 
     socket.getaddrinfo = _getaddrinfo
 


### PR DESCRIPTION
**Read these instructions carefully**

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests.

In this pull request, please include:

- a reference to related issue(s)
- a description of the changes proposed in the pull request
- an example code snippet illustrating usage of the new functionality

We defined some keyword only arguments in dask/distributed. This will raise exceptions if you download data before triggering a Dask computation on a cluster. A related post is here: https://stackoverflow.com/questions/75763037/dask-throws-dns-typeerror-if-osmnx-download-data-beforehand

Adding kwargs should be neutral for osmnx but would make this work together with a dask cluster.
