### PR TITLE
deprecate buffer_dist and clean_periphery arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - fix DNS resolution in Dask clusters (#1039)
 - improve memory efficiency during features GeoDataFrame creation (#1043)
 - handle the optional settings.cache_only_mode in the features module (#1043)
+- deprecate the buffer_dist and clean_periphery function parameters throughout (#1044)
 - introduce more descriptive exceptions: ResponseStatusCodeError and GraphSimplificationError (#1041)
 - replace CacheOnlyModeInterrupt exception with CacheOnlyInterruptError exception (#1041)
 - replace EmptyOverpassResponse exception with InsufficientResponseError exception (#1041)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -68,10 +68,12 @@ Using OSMnx's :code:`graph` module, you can retrieve any spatial network data (s
 
 Thus, a one-way street will be represented with a single directed edge from node *u* to node *v*, but a bidirectional street will be represented with two reciprocal directed edges (with identical geometries): one from node *u* to node *v* and another from *v* to *u*, to represent both possible directions of flow. Because these graphs are nonplanar, they correctly model the topology of interchanges, bridges, and tunnels. That is, edge crossings in a two-dimensional plane are not intersections in an OSMnx model unless they represent true junctions in the three-dimensional real world.
 
+Under the hood, OSMnx does several things to generate the best possible model. It initially creates a 500m-buffered graph before truncating it to your desired query area, to ensure accurate streets-per-node stats and to attenuate graph perimeter effects. It also simplifies the graph topology as discussed in the following section.
+
 Topology Clean-Up
 ^^^^^^^^^^^^^^^^^
 
-OSMnx's :code:`simplification` module automatically processes network topology from the original raw OpenStreetMap data such that nodes represent intersections/dead-ends and edges represent the street segments that link them. This takes two primary forms: graph simplification and intersection consolidation.
+The :code:`simplification` module automatically processes network topology from the original raw OpenStreetMap data such that nodes represent intersections/dead-ends and edges represent the street segments that link them. This takes two primary forms: graph simplification and intersection consolidation.
 
 **Graph simplification** cleans up the graph's topology so that nodes represent intersections or dead-ends and edges represent street segments. This is important because in OpenStreetMap raw data, ways comprise sets of straight-line segments between nodes: that is, nodes are vertices for streets' curving line geometries, not just intersections and dead-ends. By default, OSMnx simplifies this topology by discarding non-intersection/dead-end nodes while retaining the complete true edge geometry as an edge attribute.
 
@@ -96,9 +98,9 @@ Using the :code:`elevation` module, you can automatically attach elevations to t
 Network Statistics
 ^^^^^^^^^^^^^^^^^^
 
-You can use the :code:`stats` module to calculate a variety of geometric and topological measures as well as street network bearing/orientation statistics. These measures define streets as the edges in an undirected representation of the graph to prevent double-counting bidirectional edges of a two-way street.
+You can use the :code:`stats` module to calculate a variety of geometric and topological measures as well as street network bearing/orientation statistics. These measures define streets as the edges in an undirected representation of the graph to prevent double-counting bidirectional edges of a two-way street. You can easily generate common stats in transportation studies, urban design, and network science, including intersection density, circuity, average node degree (connectedness), betweenness centrality, and much more.
 
-You can use NetworkX directly to calculate additional topological network measures.
+You can also use NetworkX directly to calculate additional topological network measures.
 
 Routing
 ^^^^^^^

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -59,7 +59,7 @@ Using the :code:`features` and :code:`graph` modules, as described below, you ca
 Urban Amenities
 ^^^^^^^^^^^^^^^
 
-Using OSMnx's :code:`features` module, you can search for and download any geospatial `features`_ (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap `Overpass`_ API as a GeoPandas GeoDataFrame. This uses OpenStreetMap `tags`_ to search for matching `elements`_.
+Using OSMnx's :code:`features` module, you can search for and download geospatial `features`_ (such as building footprints, grocery stores, schools, public parks, transit stops, etc) from the OpenStreetMap `Overpass`_ API as a GeoPandas GeoDataFrame. This uses OpenStreetMap `tags`_ to search for matching `elements`_.
 
 Modeling a Network
 ^^^^^^^^^^^^^^^^^^

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -13,6 +13,7 @@ https://wiki.openstreetmap.org/wiki/Elements
 
 import logging as lg
 import warnings
+from warnings import warn
 
 import geopandas as gpd
 import pandas as pd
@@ -247,12 +248,19 @@ def features_from_place(query, tags, which_result=None, buffer_dist=None):
         which geocoding result to use. if None, auto-select the first
         (Multi)Polygon or raise an error if OSM doesn't return one.
     buffer_dist : float
-        distance to buffer around the place geometry, in meters
+        deprecated, do not use
 
     Returns
     -------
     gdf : geopandas.GeoDataFrame
     """
+    if buffer_dist is not None:
+        warn(
+            "The buffer_dist argument as been deprecated and will be removed "
+            "in a future release. Buffer your query area directly, if desired.",
+            stacklevel=2,
+        )
+
     # create a GeoDataFrame with the spatial boundaries of the place(s)
     if isinstance(query, (str, dict)):
         # if it is a string (place name) or dict (structured place query),

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -8,6 +8,7 @@ https://nominatim.org/.
 
 import logging as lg
 from collections import OrderedDict
+from warnings import warn
 
 import geopandas as gpd
 import pandas as pd
@@ -89,13 +90,20 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
     by_osmid : bool
         if True, treat query as an OSM ID lookup rather than text search
     buffer_dist : float
-        distance to buffer around the place geometry, in meters
+        deprecated, do not use
 
     Returns
     -------
     gdf : geopandas.GeoDataFrame
         a GeoDataFrame with one row for each query
     """
+    if buffer_dist is not None:
+        warn(
+            "The buffer_dist argument as been deprecated and will be removed "
+            "in a future release. Buffer your results directly, if desired.",
+            stacklevel=2,
+        )
+
     if not isinstance(query, (str, dict, list)):  # pragma: no cover
         msg = "query must be a string or dict or list"
         raise TypeError(msg)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -322,7 +322,7 @@ def graph_from_place(
         which geocoding result to use. if None, auto-select the first
         (Multi)Polygon or raise an error if OSM doesn't return one.
     buffer_dist : float
-        distance to buffer around the place geometry, in meters
+        deprecated, do not use
     clean_periphery : bool
         if True, buffer 500m to get a graph larger than requested, then
         simplify, then truncate it to requested spatial boundaries
@@ -342,6 +342,13 @@ def graph_from_place(
     function to automatically make multiple requests: see that function's
     documentation for caveats.
     """
+    if buffer_dist is not None:
+        warn(
+            "The buffer_dist argument as been deprecated and will be removed "
+            "in a future release. Buffer your query area directly, if desired.",
+            stacklevel=2,
+        )
+
     # create a GeoDataFrame with the spatial boundaries of the place(s)
     if isinstance(query, (str, dict)):
         # if it is a string (place name) or dict (structured place query),

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -33,7 +33,7 @@ def graph_from_bbox(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    clean_periphery=True,
+    clean_periphery=None,
     custom_filter=None,
 ):
     """
@@ -64,8 +64,7 @@ def graph_from_bbox(
         if True, retain nodes outside bounding box if at least one of node's
         neighbors is within the bounding box
     clean_periphery : bool
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
+        deprecated, do not use
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
@@ -108,7 +107,7 @@ def graph_from_point(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    clean_periphery=True,
+    clean_periphery=None,
     custom_filter=None,
 ):
     """
@@ -140,8 +139,7 @@ def graph_from_point(
         if True, retain nodes outside bounding box if at least one of node's
         neighbors is within the bounding box
     clean_periphery : bool,
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
+        deprecated, do not use
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
@@ -198,7 +196,7 @@ def graph_from_address(
     retain_all=False,
     truncate_by_edge=False,
     return_coords=False,
-    clean_periphery=True,
+    clean_periphery=None,
     custom_filter=None,
 ):
     """
@@ -232,9 +230,8 @@ def graph_from_address(
         neighbors is within the bounding box
     return_coords : bool
         optionally also return the geocoded coordinates of the address
-    clean_periphery : bool,
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
+    clean_periphery : bool
+        deprecated, do not use
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
@@ -282,7 +279,7 @@ def graph_from_place(
     truncate_by_edge=False,
     which_result=None,
     buffer_dist=None,
-    clean_periphery=True,
+    clean_periphery=None,
     custom_filter=None,
 ):
     """
@@ -324,8 +321,7 @@ def graph_from_place(
     buffer_dist : float
         deprecated, do not use
     clean_periphery : bool
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
+        deprecated, do not use
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
@@ -388,7 +384,7 @@ def graph_from_polygon(
     simplify=True,
     retain_all=False,
     truncate_by_edge=False,
-    clean_periphery=True,
+    clean_periphery=None,
     custom_filter=None,
 ):
     """
@@ -414,8 +410,7 @@ def graph_from_polygon(
         if True, retain nodes outside boundary polygon if at least one of
         node's neighbors is within the polygon
     clean_periphery : bool
-        if True, buffer 500m to get a graph larger than requested, then
-        simplify, then truncate it to requested spatial boundaries
+        deprecated, do not use
     custom_filter : string
         a custom ways filter to be used instead of the network_type presets
         e.g., '["power"~"line"]' or '["highway"~"motorway|trunk"]'. Also pass
@@ -432,6 +427,15 @@ def graph_from_polygon(
     function to automatically make multiple requests: see that function's
     documentation for caveats.
     """
+    if clean_periphery is None:
+        clean_periphery = True
+    else:
+        warn(
+            "The clean_periphery argument has been deprecated and will be removed in "
+            "a future release. Future behavior will be as though clean_periphery=True.",
+            stacklevel=2,
+        )
+
     # verify that the geometry is valid and is a shapely Polygon/MultiPolygon
     # before proceeding
     if not polygon.is_valid:  # pragma: no cover

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -491,7 +491,7 @@ def test_graph_from_functions():
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 
     # graph from list of places
-    G = ox.graph_from_place([place1], network_type="all", clean_periphery=False)
+    G = ox.graph_from_place([place1], network_type="all", buffer_dist=0, clean_periphery=False)
 
     # graph from polygon
     G = ox.graph_from_polygon(polygon, network_type="walk", truncate_by_edge=True, simplify=False)
@@ -536,7 +536,7 @@ def test_features():
 
     # geometries_from_place - includes test of list of places
     tags = {"amenity": True, "landuse": ["retail", "commercial"], "highway": "bus_stop"}
-    gdf = ox.geometries_from_place(place1, tags=tags)
+    gdf = ox.geometries_from_place(place1, tags=tags, buffer_dist=0)
     gdf = ox.geometries_from_place([place1], tags=tags)
 
     # geometries_from_polygon


### PR DESCRIPTION
This PR:
  - deprecates the `buffer_dist` function parameter in the `graph`, `features`, and `geocoder` modules. It is seldom used, it clutters the codebase, and its functionality is easily reproduced by the user with ~1 line of code.
  - deprecates the `clean_periphery` function parameter in the `graph` module: the equivalent of `clean_periphery=True` will the the uniform behavior going forward. This is the only way to generate an accurate graph on the perimeter, and the only way to get accurate stats, so it really makes no sense to have a `False` option here. See also (#775).
  - updates the docs with some explanatory details regarding (now-standard) periphery cleaning