### PR TITLE
fix link to CONTRIBUTING doc in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
     id: contributing
     attributes:
       label: Contributing guidelines
-      description: Before you proceed, read the [contributing guidelines](../../CONTRIBUTING.md) regarding where to ask usage questions and how to file a bug report.
+      description: Before you proceed, read the [contributing guidelines](../CONTRIBUTING.md) regarding where to ask usage questions and how to file a bug report.
       options:
         - label: I understand the contributing guidelines
           required: true


### PR DESCRIPTION
When I went to file issue #1050, I noticed that the link to the CONTRIBUTING doc was broken - it went to `https://github.com/gboeing/CONTRIBUTING.md` instead of `https://github.com/gboeing/osmnx/CONTRIBUTING.md`

Fix the link
