### PR TITLE
refactor projection module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.2"
+    rev: "v3.0.3"
     hooks:
       - id: prettier
         types_or: [markdown, yaml]
@@ -35,6 +35,6 @@ repos:
       - id: black
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.0.285"
+    rev: "v0.0.287"
     hooks:
       - id: ruff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- fix the projection module to correctly identify southern hemisphere UTM zones (#1057)
+- add a to_latlong parameter in the projection.project_graph function (#1057)
+- add projection.coords_to_utm_zone function for calculating UTM zones from points (#1057)
+- under-the-hood code clean-up (#1047)
+
 ## 1.6.0 (2023-07-28)
 
 - fix DNS resolution in Dask clusters (#1039)

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -481,8 +481,8 @@ def _is_same_geometry(ls1, ls2):
     # reverse the first LineString's coordinates' direction
     geom1_r = [tuple(reversed(coords)) for coords in ls1.xy]
 
-    # if first geometry matches second in either direction, return True
-    return geom1 == geom2 or geom1_r == geom2
+    # if second geometry matches first in either direction, return True
+    return geom2 in (geom1, geom1_r)
 
 
 def _update_edge_keys(G):

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -318,6 +318,7 @@ def test_plots():
     """Test visualization methods."""
     G = ox.graph_from_point(location_point, dist=500, network_type="drive")
     Gp = ox.project_graph(G)
+    G = ox.project_graph(G, to_latlong=True)
 
     # test getting colors
     co = ox.plot.get_colors(n=5, return_hex=True)


### PR DESCRIPTION
This PR:
  - refactors the `projection` module and improves its docstrings
  - exposes a `to_latlong` parameter in the `projection.project_graph` function
  - adds a `projection.coords_to_utm_zone` function for calculating UTM zones from points
  - makes the `projection` module correctly identify southern hemisphere UTM zones