### PR TITLE
Package-wide consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- deprecate precision parameter in io.save_graph_xml for consistency with rest of package (#1068)
 - refer to latitude and longitude parameters as lat and lon consistently across package (#1068)
 
 ## 1.7.0 (2023-10-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- deprecate precision parameter in io.save_graph_xml for consistency with rest of package (#1068)
+- refer to latitude and longitude parameters as lat and lon consistently across package (#1068)
+
 ## 1.7.0 (2023-10-11)
 
 - improve automatic UTM handling in the projection module (#1059)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -105,7 +105,7 @@ Routing
 
 The :code:`speed` module can impute missing speeds to the graph edges. This imputation can obviously be imprecise, and the user can override it by passing in arguments that define local speed limits. It can also calculate free-flow travel times for each edge.
 
-The :code:`distance` module can find the nearest node(s) or edge(s) to coordinates using a fast spatial index. It can also solve shortest paths for network routing, parallelized with multiprocessing, using different weights (e.g., distance, travel time, elevation change, etc).
+The :code:`distance` module can find the nearest node(s) or edge(s) to coordinates using a fast spatial index. The :code:`routing` module can solve shortest paths for network routing, parallelized with multiprocessing, using different weights (e.g., distance, travel time, elevation change, etc).
 
 Visualization
 ^^^^^^^^^^^^^

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -195,7 +195,7 @@ def _make_overpass_polygon_coord_strs(polygon):
     Subdivide query polygon and return list of coordinate strings.
 
     Project to utm, divide polygon up into sub-polygons if area exceeds a
-    max size (in meters), project back to lat-lng, then get a list of
+    max size (in meters), project back to lat-lon, then get a list of
     polygon(s) exterior coordinates
 
     Parameters
@@ -220,7 +220,7 @@ def _create_overpass_query(polygon_coord_str, tags):
     Parameters
     ----------
     polygon_coord_str : list
-        list of lat lng coordinates
+        list of lat lon coordinates
     tags : dict
         dict of tags used for finding elements in the search area
 

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -15,24 +15,24 @@ except ImportError:  # pragma: no cover
     scipy = None
 
 
-def calculate_bearing(lat1, lng1, lat2, lng2):
+def calculate_bearing(lat1, lon1, lat2, lon2):
     """
-    Calculate the compass bearing(s) between pairs of lat-lng points.
+    Calculate the compass bearing(s) between pairs of lat-lon points.
 
     Vectorized function to calculate initial bearings between two points'
     coordinates or between arrays of points' coordinates. Expects coordinates
     in decimal degrees. Bearing represents the clockwise angle in degrees
-    between north and the geodesic line from (lat1, lng1) to (lat2, lng2).
+    between north and the geodesic line from (lat1, lon1) to (lat2, lon2).
 
     Parameters
     ----------
     lat1 : float or numpy.array of float
         first point's latitude coordinate
-    lng1 : float or numpy.array of float
+    lon1 : float or numpy.array of float
         first point's longitude coordinate
     lat2 : float or numpy.array of float
         second point's latitude coordinate
-    lng2 : float or numpy.array of float
+    lon2 : float or numpy.array of float
         second point's longitude coordinate
 
     Returns
@@ -43,11 +43,11 @@ def calculate_bearing(lat1, lng1, lat2, lng2):
     # get the latitudes and the difference in longitudes, in radians
     lat1 = np.radians(lat1)
     lat2 = np.radians(lat2)
-    d_lng = np.radians(lng2 - lng1)
+    d_lon = np.radians(lon2 - lon1)
 
     # calculate initial bearing from -180 degrees to +180 degrees
-    y = np.sin(d_lng) * np.cos(lat2)
-    x = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(d_lng)
+    y = np.sin(d_lon) * np.cos(lat2)
+    x = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(d_lon)
     initial_bearing = np.degrees(np.arctan2(y, x))
 
     # normalize to 0-360 degrees to get compass bearing

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -40,14 +40,14 @@ def calculate_bearing(lat1, lon1, lat2, lon2):
     bearing : float or numpy.array of float
         the bearing(s) in decimal degrees
     """
-    # get the latitudes and the difference in longitudes, in radians
+    # get the latitudes and the difference in longitudes, all in radians
     lat1 = np.radians(lat1)
     lat2 = np.radians(lat2)
-    d_lon = np.radians(lon2 - lon1)
+    delta_lon = np.radians(lon2 - lon1)
 
     # calculate initial bearing from -180 degrees to +180 degrees
-    y = np.sin(d_lon) * np.cos(lat2)
-    x = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(d_lon)
+    y = np.sin(delta_lon) * np.cos(lat2)
+    x = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(delta_lon)
     initial_bearing = np.degrees(np.arctan2(y, x))
 
     # normalize to 0-360 degrees to get compass bearing

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
 EARTH_RADIUS_M = 6_371_009
 
 
-def great_circle(lat1, lng1, lat2, lng2, earth_radius=EARTH_RADIUS_M):
+def great_circle(lat1, lon1, lat2, lon2, earth_radius=EARTH_RADIUS_M):
     """
     Calculate great-circle distances between pairs of points.
 
@@ -41,11 +41,11 @@ def great_circle(lat1, lng1, lat2, lng2, earth_radius=EARTH_RADIUS_M):
     ----------
     lat1 : float or numpy.array of float
         first point's latitude coordinate
-    lng1 : float or numpy.array of float
+    lon1 : float or numpy.array of float
         first point's longitude coordinate
     lat2 : float or numpy.array of float
         second point's latitude coordinate
-    lng2 : float or numpy.array of float
+    lon2 : float or numpy.array of float
         second point's longitude coordinate
     earth_radius : float
         earth's radius in units in which distance will be returned (default is
@@ -54,15 +54,15 @@ def great_circle(lat1, lng1, lat2, lng2, earth_radius=EARTH_RADIUS_M):
     Returns
     -------
     dist : float or numpy.array of float
-        distance from each (lat1, lng1) to each (lat2, lng2) in units of
+        distance from each (lat1, lon1) to each (lat2, lon2) in units of
         earth_radius
     """
     y1 = np.deg2rad(lat1)
     y2 = np.deg2rad(lat2)
     dy = y2 - y1
 
-    x1 = np.deg2rad(lng1)
-    x2 = np.deg2rad(lng2)
+    x1 = np.deg2rad(lon1)
+    x2 = np.deg2rad(lon2)
     dx = x2 - x1
 
     h = np.sin(dy / 2) ** 2 + np.cos(y1) * np.cos(y2) * np.sin(dx / 2) ** 2
@@ -294,7 +294,7 @@ def nearest_nodes(G, X, Y, return_dist=False):
         if BallTree is None:  # pragma: no cover
             msg = "scikit-learn must be installed to search an unprojected graph"
             raise ImportError(msg)
-        # haversine requires lat, lng coords in radians
+        # haversine requires lat, lon coords in radians
         nodes_rad = np.deg2rad(nodes[["y", "x"]])
         points_rad = np.deg2rad(np.array([Y, X]).T)
         dist, pos = BallTree(nodes_rad, metric="haversine").query(points_rad, k=1)
@@ -399,7 +399,7 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
             if BallTree is None:  # pragma: no cover
                 msg = "scikit-learn must be installed to search an unprojected graph"
                 raise ImportError(msg)
-            # haversine requires lat, lng coords in radians
+            # haversine requires lat, lon coords in radians
             vertices_rad = np.deg2rad(vertices[["y", "x"]])
             points_rad = np.deg2rad(np.array([Y, X]).T)
             dist, pos = BallTree(vertices_rad, metric="haversine").query(points_rad, k=1)

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -59,13 +59,13 @@ def great_circle(lat1, lon1, lat2, lon2, earth_radius=EARTH_RADIUS_M):
     """
     y1 = np.deg2rad(lat1)
     y2 = np.deg2rad(lat2)
-    dy = y2 - y1
+    delta_y = y2 - y1
 
     x1 = np.deg2rad(lon1)
     x2 = np.deg2rad(lon2)
-    dx = x2 - x1
+    delta_x = x2 - x1
 
-    h = np.sin(dy / 2) ** 2 + np.cos(y1) * np.cos(y2) * np.sin(dx / 2) ** 2
+    h = np.sin(delta_y / 2) ** 2 + np.cos(y1) * np.cos(y2) * np.sin(delta_x / 2) ** 2
     h = np.minimum(1, h)  # protect against floating point errors
     arc = 2 * np.arcsin(np.sqrt(h))
 

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -213,7 +213,7 @@ def add_node_elevations_google(
             stacklevel=2,
         )
 
-    # make a pandas series of all the nodes' coordinates as 'lat,lng'
+    # make a pandas series of all the nodes' coordinates as 'lat,lon'
     # round coordinates to 5 decimal places (approx 1 meter) to be able to fit
     # in more locations per API call
     node_points = pd.Series(
@@ -224,7 +224,7 @@ def add_node_elevations_google(
     utils.log(f"Requesting node elevations from {domain!r} in {n_calls} request(s)")
 
     # break the series of coordinates into chunks of size max_locations_per_batch
-    # API format is locations=lat,lng|lat,lng|lat,lng|lat,lng...
+    # API format is locations=lat,lon|lat,lon|lat,lon|lat,lon...
     results = []
     for i in range(0, len(node_points), max_locations_per_batch):
         chunk = node_points.iloc[i : i + max_locations_per_batch]

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -134,7 +134,7 @@ def features_from_point(center_point, tags, dist=1000):
     Parameters
     ----------
     center_point : tuple
-        the (lat, lng) center point around which to get the features
+        the (lat, lon) center point around which to get the features
     tags : dict
         Dict of tags used for finding elements in the selected area. Results
         returned are the union, not intersection of each individual tag.
@@ -198,7 +198,7 @@ def features_from_address(address, tags, dist=1000):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    # geocode the address string to a (lat, lng) point
+    # geocode the address string to a (lat, lon) point
     center_point = geocoder.geocode(query=address)
 
     # create GeoDataFrame of features around this point

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -177,7 +177,7 @@ def _plot_folium(gdf, m, popup_attribute, tiles, zoom, fit_bounds, **kwargs):
         pl.add_to(m)
 
     # if fit_bounds is True, fit the map to the bounds of the route by passing
-    # list of lat-lng points as [southwest, northeast]
+    # list of lat-lon points as [southwest, northeast]
     if fit_bounds and isinstance(m, folium.Map):
         tb = gdf.total_bounds
         m.fit_bounds([(tb[1], tb[0]), (tb[3], tb[2])])
@@ -203,8 +203,8 @@ def _make_folium_polyline(geom, popup_val=None, **kwargs):
     pl : folium.PolyLine
     """
     # locations is a list of points for the polyline folium takes coords in
-    # lat,lng but geopandas provides them in lng,lat so we must reverse them
-    locations = [(lat, lng) for lng, lat in geom.coords]
+    # lat,lon but geopandas provides them in lon,lat so we must reverse them
+    locations = [(lat, lon) for lon, lat in geom.coords]
 
     # create popup if popup_val is not None
     if popup_val is None:

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -22,7 +22,7 @@ from ._errors import InsufficientResponseError
 
 def geocode(query):
     """
-    Geocode place names or addresses to (lat, lng) with the Nominatim API.
+    Geocode place names or addresses to (lat, lon) with the Nominatim API.
 
     This geocodes the query via the Nominatim "search" endpoint.
 
@@ -34,7 +34,7 @@ def geocode(query):
     Returns
     -------
     point : tuple
-        the (lat, lng) coordinates returned by the geocoder
+        the (lat, lon) coordinates returned by the geocoder
     """
     # define the parameters
     params = OrderedDict()
@@ -44,11 +44,11 @@ def geocode(query):
     params["q"] = query
     response_json = _nominatim._nominatim_request(params=params)
 
-    # if results were returned, parse lat and lng out of the result
+    # if results were returned, parse lat and lon out of the result
     if response_json and "lat" in response_json[0] and "lon" in response_json[0]:
         lat = float(response_json[0]["lat"])
-        lng = float(response_json[0]["lon"])
-        point = (lat, lng)
+        lon = float(response_json[0]["lon"])
+        point = (lat, lon)
         utils.log(f"Geocoded {query!r} to {point}")
         return point
 
@@ -141,7 +141,7 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
     gdf = gdf.set_crs(settings.default_crs)
 
     # if buffer_dist was passed in, project the geometry to UTM, buffer it in
-    # meters, then project it back to lat-lng
+    # meters, then project it back to lat-lon
     if buffer_dist is not None and len(gdf) > 0:
         gdf_utm = projection.project_gdf(gdf)
         gdf_utm["geometry"] = gdf_utm["geometry"].buffer(buffer_dist)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -111,7 +111,7 @@ def graph_from_point(
     custom_filter=None,
 ):
     """
-    Download and create a graph within some distance of a (lat, lng) point.
+    Download and create a graph within some distance of a (lat, lon) point.
 
     You can use the `settings` module to retrieve a snapshot of historical OSM
     data as of a certain date, or to configure the Overpass server timeout,
@@ -120,7 +120,7 @@ def graph_from_point(
     Parameters
     ----------
     center_point : tuple
-        the (lat, lng) center point around which to construct the graph
+        the (lat, lon) center point around which to construct the graph
     dist : int
         retain only those nodes within this many meters of the center of the
         graph, with distance determined according to dist_type argument
@@ -240,7 +240,7 @@ def graph_from_address(
 
     Returns
     -------
-    networkx.MultiDiGraph or optionally (networkx.MultiDiGraph, (lat, lng))
+    networkx.MultiDiGraph or optionally (networkx.MultiDiGraph, (lat, lon))
 
     Notes
     -----
@@ -248,7 +248,7 @@ def graph_from_address(
     function to automatically make multiple requests: see that function's
     documentation for caveats.
     """
-    # geocode the address string to a (lat, lng) point
+    # geocode the address string to a (lat, lon) point
     point = geocoder.geocode(query=address)
 
     # then create a graph from this point

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -290,7 +290,7 @@ def save_graph_xml(
     merge_edges=True,
     edge_tag_aggs=None,
     api_version=0.6,
-    precision=None,
+    precision=6,
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.
@@ -359,19 +359,12 @@ def save_graph_xml(
     api_version : float
         OpenStreetMap API version to write to the XML file header
     precision : int
-        do not use, deprecated
+        number of decimal places to round latitude and longitude values
 
     Returns
     -------
     None
     """
-    if precision is None:
-        precision = 6
-    else:
-        warn(
-            "the `precision` parameter is deprecated and will be removed in a future release",
-            stacklevel=2,
-        )
     osm_xml._save_graph_xml(
         data,
         filepath,

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -190,12 +190,12 @@ def load_graphml(
     to properly handle "True"/"False" string literals as True/False booleans:
     `ox.load_graphml(fp, node_dtypes={my_attr: ox.io._convert_bool_string})`.
 
+    If you manually configured the `all_oneway=True` setting, you may need to
+    manually specify here that edge `oneway` attributes should be type `str`.
+
     Note that you must pass one and only one of `filepath` or `graphml_str`.
     If passing `graphml_str`, you may need to decode the bytes read from your
     file before converting to string to pass to this function.
-
-    If you manually configured the `all_oneway=True` setting, you may need to
-    manually specify here that edge `oneway` attributes should be type `str`.
 
     Parameters
     ----------
@@ -256,13 +256,18 @@ def load_graphml(
     if edge_dtypes is not None:
         default_edge_dtypes.update(edge_dtypes)
 
-    # load graphml from file on disk or from a string
     if filepath is not None:
-        source = data = filepath
+        # read the graphml file from disk
+        source = filepath
+        G = nx.read_graphml(
+            Path(filepath), node_type=default_node_dtypes["osmid"], force_multigraph=True
+        )
     else:
+        # parse the graphml string
         source = "string"
-        data = graphml_str
-    G = nx.parse_graphml(data, node_type=default_node_dtypes["osmid"], force_multigraph=True)
+        G = nx.parse_graphml(
+            graphml_str, node_type=default_node_dtypes["osmid"], force_multigraph=True
+        )
 
     # convert graph/node/edge attribute data types
     utils.log("Converting node, edge, and graph-level attribute data types")

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -190,12 +190,12 @@ def load_graphml(
     to properly handle "True"/"False" string literals as True/False booleans:
     `ox.load_graphml(fp, node_dtypes={my_attr: ox.io._convert_bool_string})`.
 
-    If you manually configured the `all_oneway=True` setting, you may need to
-    manually specify here that edge `oneway` attributes should be type `str`.
-
     Note that you must pass one and only one of `filepath` or `graphml_str`.
     If passing `graphml_str`, you may need to decode the bytes read from your
     file before converting to string to pass to this function.
+
+    If you manually configured the `all_oneway=True` setting, you may need to
+    manually specify here that edge `oneway` attributes should be type `str`.
 
     Parameters
     ----------
@@ -256,18 +256,13 @@ def load_graphml(
     if edge_dtypes is not None:
         default_edge_dtypes.update(edge_dtypes)
 
+    # load graphml from file on disk or from a string
     if filepath is not None:
-        # read the graphml file from disk
-        source = filepath
-        G = nx.read_graphml(
-            Path(filepath), node_type=default_node_dtypes["osmid"], force_multigraph=True
-        )
+        source = data = filepath
     else:
-        # parse the graphml string
         source = "string"
-        G = nx.parse_graphml(
-            graphml_str, node_type=default_node_dtypes["osmid"], force_multigraph=True
-        )
+        data = graphml_str
+    G = nx.parse_graphml(data, node_type=default_node_dtypes["osmid"], force_multigraph=True)
 
     # convert graph/node/edge attribute data types
     utils.log("Converting node, edge, and graph-level attribute data types")

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -285,7 +285,7 @@ def save_graph_xml(
     merge_edges=True,
     edge_tag_aggs=None,
     api_version=0.6,
-    precision=6,
+    precision=None,
 ):
     """
     Save graph to disk as an OSM-formatted XML .osm file.
@@ -354,12 +354,19 @@ def save_graph_xml(
     api_version : float
         OpenStreetMap API version to write to the XML file header
     precision : int
-        number of decimal places to round latitude and longitude values
+        do not use, deprecated
 
     Returns
     -------
     None
     """
+    if precision is None:
+        precision = 6
+    else:
+        warn(
+            "the `precision` parameter is deprecated and will be removed in a future release",
+            stacklevel=2,
+        )
     osm_xml._save_graph_xml(
         data,
         filepath,

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -477,8 +477,8 @@ def plot_figure_ground(
     # if G was passed in, plot it centered on its node centroid
     if G is not None:
         gdf_nodes = utils_graph.graph_to_gdfs(G, edges=False, node_geometry=True)
-        lnglat_point = gdf_nodes.unary_union.centroid.coords[0]
-        point = tuple(reversed(lnglat_point))
+        lonlat_point = gdf_nodes.unary_union.centroid.coords[0]
+        point = tuple(reversed(lonlat_point))
 
     # otherwise get network by address or point (whichever was passed) using a
     # dist multiplier to ensure we get more than enough network. simplify in
@@ -505,7 +505,7 @@ def plot_figure_ground(
         )
         G = simplification.simplify_graph(G, strict=False)
     else:  # pragma: no cover
-        msg = "You must pass an address or lat-lng point or graph."
+        msg = "You must pass an address or lat-lon point or graph."
         raise ValueError(msg)
 
     # we need an undirected graph to find every edge incident on a node

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -135,7 +135,7 @@ def project_graph(G, to_crs=None, to_latlong=False):
     # STEP 1: PROJECT THE NODES
     gdf_nodes = utils_graph.graph_to_gdfs(G, edges=False)
 
-    # create new lat/lng columns to preserve lat/lng for later reference if
+    # create new lat/lon columns to preserve lat/lon for later reference if
     # cols do not already exist (ie, don't overwrite in later re-projections)
     if "lon" not in gdf_nodes.columns or "lat" not in gdf_nodes.columns:
         gdf_nodes["lon"] = gdf_nodes["x"]

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -246,7 +246,7 @@ def circuity_avg(Gu):
     if projection.is_projected(Gu.graph["crs"]):
         sl_dists = distance.euclidean(y1=y1, x1=x1, y2=y2, x2=x2)
     else:
-        sl_dists = distance.great_circle(lat1=y1, lng1=x1, lat2=y2, lng2=x2)
+        sl_dists = distance.great_circle(lat1=y1, lon1=x1, lat2=y2, lon2=x2)
 
     # return the ratio, handling possible division by zero
     sl_dists_total = sl_dists[~np.isnan(sl_dists)].sum()

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -426,7 +426,7 @@ def _intersect_index_quadrats(geometries, polygon, quadrat_width=0.05, min_num=3
 
 def bbox_from_point(point, dist=1000, project_utm=False, return_crs=False):
     """
-    Create a bounding box from a (lat, lng) center point.
+    Create a bounding box from a (lat, lon) center point.
 
     Create a bounding box some distance in each direction (north, south, east,
     and west) from the center point and optionally project it.
@@ -434,7 +434,7 @@ def bbox_from_point(point, dist=1000, project_utm=False, return_crs=False):
     Parameters
     ----------
     point : tuple
-        the (lat, lng) center point to create the bounding box around
+        the (lat, lon) center point to create the bounding box around
     dist : int
         bounding box distance in meters from the center point
     project_utm : bool
@@ -448,14 +448,14 @@ def bbox_from_point(point, dist=1000, project_utm=False, return_crs=False):
         (north, south, east, west) or (north, south, east, west, crs_proj)
     """
     earth_radius = 6_371_009  # meters
-    lat, lng = point
+    lat, lon = point
 
     delta_lat = (dist / earth_radius) * (180 / np.pi)
-    delta_lng = (dist / earth_radius) * (180 / np.pi) / np.cos(lat * np.pi / 180)
+    delta_lon = (dist / earth_radius) * (180 / np.pi) / np.cos(lat * np.pi / 180)
     north = lat + delta_lat
     south = lat - delta_lat
-    east = lng + delta_lng
-    west = lng - delta_lng
+    east = lon + delta_lon
+    west = lon - delta_lon
 
     if project_utm:
         bbox_poly = bbox_to_poly(north, south, east, west)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -185,7 +185,7 @@ def test_osm_xml():
     ox.save_graph_xml(G, merge_edges=False, filepath=Path(ox.settings.data_folder) / "graph.osm")
 
     # test osm xml output merge edges
-    ox.save_graph_xml(G, merge_edges=True, edge_tag_aggs=[("length", "sum")])
+    ox.io.save_graph_xml(G, merge_edges=True, edge_tag_aggs=[("length", "sum")], precision=5)
 
     # test osm xml output from gdfs
     nodes, edges = ox.graph_to_gdfs(G)


### PR DESCRIPTION
"longitude" is referred to as both "lon" and "lng" inconsistently throughout the package. This PR consistently refers to it as `lon` in function parameter names, docstrings, and internal code/comments throughout the package.
