### PR TITLE
resolve deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - formally support Python 3.12 (#1082)
 - fix Windows-specific character encoding issue when reading XML files (#1084)
-- resolve pandas future warning in simplification module
+- resolve pandas and gdal future warnings
 - rename add_node_elevations_google function's max_locations_per_batch parameter, with deprecation warning (#1088)
 - move add_node_elevations_google function's url_template parameter to settings module, with deprecation warning (#1088)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - formally support Python 3.12 (#1082)
 - fix Windows-specific character encoding issue when reading XML files (#1084)
+- resolve pandas future warning in simplification module
 - rename add_node_elevations_google function's max_locations_per_batch parameter, with deprecation warning (#1088)
 - move add_node_elevations_google function's url_template parameter to settings module, with deprecation warning (#1088)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - formally support Python 3.12 (#1082)
 - fix Windows-specific character encoding issue when reading XML files (#1084)
-- resolve pandas and gdal future warnings
+- resolve pandas and gdal future warnings (#1089)
+- use spawn instead of fork for multiprocessing to resolve Python 3.12 deprecation warning (#1089)
 - rename add_node_elevations_google function's max_locations_per_batch parameter, with deprecation warning (#1088)
 - move add_node_elevations_google function's url_template parameter to settings module, with deprecation warning (#1088)
 

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -149,11 +149,8 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
         # divide nodes into equal-sized chunks for multiprocessing
         size = int(np.ceil(len(nodes) / cpus))
         args = ((nodes.iloc[i : i + size], filepath, band) for i in range(0, len(nodes), size))
-        pool = mp.Pool(cpus)
-        sma = pool.starmap_async(_query_raster, args)
-        results = sma.get()
-        pool.close()
-        pool.join()
+        with mp.Pool(cpus) as pool:
+            results = pool.starmap_async(_query_raster, args).get()
         elevs = {k: v for kv in results for k, v in kv}
 
     assert len(G) == len(elevs)

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -149,7 +149,7 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
         # divide nodes into equal-sized chunks for multiprocessing
         size = int(np.ceil(len(nodes) / cpus))
         args = ((nodes.iloc[i : i + size], filepath, band) for i in range(0, len(nodes), size))
-        with mp.Pool(cpus) as pool:
+        with mp.get_context("spawn").Pool(cpus) as pool:
             results = pool.starmap_async(_query_raster, args).get()
         elevs = {k: v for kv in results for k, v in kv}
 

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -139,6 +139,7 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
         filepaths = [str(p) for p in filepath]
         sha = sha1(str(filepaths).encode("utf-8")).hexdigest()
         filepath = f"./.osmnx_{sha}.vrt"
+        gdal.UseExceptions()
         gdal.BuildVRT(filepath, filepaths).FlushCache()
 
     nodes = utils_graph.graph_to_gdfs(G, edges=False, node_geometry=False)[["x", "y"]]

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -258,7 +258,7 @@ def features_from_place(query, tags, which_result=None, buffer_dist=None):
     """
     if buffer_dist is not None:
         warn(
-            "The buffer_dist argument as been deprecated and will be removed "
+            "The buffer_dist argument has been deprecated and will be removed "
             "in a future release. Buffer your query area directly, if desired.",
             stacklevel=2,
         )

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -100,7 +100,7 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
     """
     if buffer_dist is not None:
         warn(
-            "The buffer_dist argument as been deprecated and will be removed "
+            "The buffer_dist argument has been deprecated and will be removed "
             "in a future release. Buffer your results directly, if desired.",
             stacklevel=2,
         )

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -348,7 +348,7 @@ def graph_from_place(
     """
     if buffer_dist is not None:
         warn(
-            "The buffer_dist argument as been deprecated and will be removed "
+            "The buffer_dist argument has been deprecated and will be removed "
             "in a future release. Buffer your query area directly, if desired.",
             stacklevel=2,
         )

--- a/osmnx/routing.py
+++ b/osmnx/routing.py
@@ -75,11 +75,8 @@ def shortest_path(G, orig, dest, weight="length", cpus=1):
     # if multi-threading, calculate shortest paths in parallel
     else:
         args = ((G, o, d, weight) for o, d in zip(orig, dest))
-        pool = mp.Pool(cpus)
-        sma = pool.starmap_async(_single_shortest_path, args)
-        paths = sma.get()
-        pool.close()
-        pool.join()
+        with mp.Pool(cpus) as pool:
+            paths = pool.starmap_async(_single_shortest_path, args).get()
 
     return paths
 

--- a/osmnx/routing.py
+++ b/osmnx/routing.py
@@ -75,7 +75,7 @@ def shortest_path(G, orig, dest, weight="length", cpus=1):
     # if multi-threading, calculate shortest paths in parallel
     else:
         args = ((G, o, d, weight) for o, d in zip(orig, dest))
-        with mp.Pool(cpus) as pool:
+        with mp.get_context("spawn").Pool(cpus) as pool:
             paths = pool.starmap_async(_single_shortest_path, args).get()
 
     return paths

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -505,10 +505,11 @@ def _consolidate_intersections_rebuild_graph(G, tolerance=10, reconnect_edges=Tr
     # STEP 2
     # attach each node to its cluster of merged nodes. first get the original
     # graph's node points then spatial join to give each node the label of
-    # cluster it's within
+    # cluster it's within. make cluster labels type string.
     node_points = utils_graph.graph_to_gdfs(G, edges=False)[["geometry"]]
     gdf = gpd.sjoin(node_points, node_clusters, how="left", predicate="within")
     gdf = gdf.drop(columns="geometry").rename(columns={"index_right": "cluster"})
+    gdf["cluster"] = gdf["cluster"].astype(str)
 
     # STEP 3
     # if a cluster contains multiple components (i.e., it's not connected)


### PR DESCRIPTION
This PR:
  - resolves pandas future warning in simplification module
  - resolves gdal future warning in elevation module
  - uses the "spawn" instead of "fork" start method consistently for multiprocessing to resolve python 3.12 deprecation warning
  - streamlines internal multiprocessing code