### PR TITLE
fix bug in osm_xml module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix a bug arising from the save_graph_xml function (#1093)
 - under-the-hood code clean-up (#1092)
 
 ## 1.8.0 (2023-11-30)

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -420,6 +420,7 @@ def _append_nodes_as_edge_attrs(xml_edge, sample_edge, all_edges_df):
         ET.SubElement(xml_edge, "nd", attrib={"ref": sample_edge["v"]})
     else:
         # topological sort
+        all_edges_df = all_edges_df.reset_index()
         try:
             ordered_nodes = _get_unique_nodes_ordered_from_way(all_edges_df)
         except nx.NetworkXUnfeasible:
@@ -516,7 +517,6 @@ def _get_unique_nodes_ordered_from_way(df_way_edges):
         design schema.
     """
     G = nx.MultiDiGraph()
-    df_way_edges.reset_index(inplace=True)  # noqa: PD002
     all_nodes = list(df_way_edges["u"].to_numpy()) + list(df_way_edges["v"].to_numpy())
 
     G.add_nodes_from(all_nodes)


### PR DESCRIPTION
This PR fixes a silent and tough to diagnose bug in the `osm_xml` module where the `_append_nodes_as_edge_attrs` function had passed a pandas DataFrame into the `_get_unique_nodes_ordered_from_way` function, which reset its index in-place before returning some other value back to `_append_nodes_as_edge_attrs`. The `_append_nodes_as_edge_attrs` function then continued to operate on that DataFrame *and expected it to have a reset index*, which only works in-place. This PR moves that index reset to the `_append_nodes_as_edge_attrs` function and does not perform it in-place.