### PR TITLE
warning and optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix a bug arising from the save_graph_xml function (#1093)
+- warn user if their query area is significantly larger than max query area size (#1101)
 - refactor utils_geo module and deprecate quadrat_width and min_num function arguments (#1100)
 - under-the-hood code clean-up (#1092 #1099)
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -274,6 +274,17 @@ def _consolidate_subdivide_geometry(geometry):
     ):
         geometry = geometry.convex_hull
 
+    # warn user if they passed a geometry with area much larger than max size
+    ratio = int(geometry.area / mqas)
+    warning_threshold = 10
+    if ratio > warning_threshold:
+        msg = (
+            f"This area is {ratio:,} times your configured Overpass max query "
+            "area size. It will automatically be divided up into multiple "
+            "sub-queries accordingly. This may take a long time."
+        )
+        warn(msg, stacklevel=2)
+
     # if geometry area exceeds max size, subdivide it into smaller subpolygons
     # that are no greater than settings.max_query_area_size in size
     if geometry.area > mqas:

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -408,7 +408,7 @@ def test_find_nearest():
     ne2 = ox.distance.nearest_edges(G, X[0], Y[0], interpolate=50, return_dist=True)
 
 
-def test_endpoints():
+def test_api_endpoints():
     """Test different API endpoints."""
     default_timeout = ox.settings.timeout
     default_key = ox.settings.nominatim_key
@@ -563,6 +563,11 @@ def test_graph_save_load():
 
 def test_graph_from_functions():
     """Test downloading graphs from Overpass."""
+    # test subdividing a large geometry (raises a UserWarning)
+    bbox = ox.utils_geo.bbox_from_point((0, 0), dist=1e5, project_utm=True)
+    poly = ox.utils_geo.bbox_to_poly(*bbox)
+    _ = ox.utils_geo._consolidate_subdivide_geometry(poly)
+
     # graph from bounding box
     _ = ox.utils_geo.bbox_from_point(location_point, project_utm=True, return_crs=True)
     north, south, east, west = ox.utils_geo.bbox_from_point(location_point, dist=500)


### PR DESCRIPTION
This PR:

  - optimizes the `_make_overpass_polygon_coord_strs` function with some refactoring
  - warns user if the geometry (boundary area) is much larger than max query area size because this can cause slow performance a) during quadrat cutting to subdivide the geometry, and b) during Overpass downloading because OSMnx must make many requests.