### PR TITLE
fix removal of inner_polygons from outer_polygons

### DIFF
--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -892,7 +892,7 @@ def _subtract_inner_polygons_from_outer_polygons(element, outer_polygons, inner_
         for inner_polygon in inner_polygons:
             if inner_polygon.within(outer_polygon):
                 try:
-                    outer_polygon_diff = outer_polygon.difference(inner_polygon)
+                    outer_polygon_diff = outer_polygon_diff.difference(inner_polygon)
                 except TopologicalError:  # pragma: no cover
                     utils.log(
                         f"relation https://www.openstreetmap.org/relation/{element['id']} "


### PR DESCRIPTION
This is a fix for issue #1098. As described by @orrsim, the difference in the inner loop was referring back to the original `outer_polygon` rather than the result of any previous difference `outer_polygon_diff`.

With this fix,
`
ox.features_from_point(
    (60.4436,10.2364),
    tags = {'natural' : 'water'},
    dist = 100
)
`
returns Fjorda with the islands removed.

@orrsim, thanks for pointing this out and also for identifying the bug.