### PR TITLE
add type annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: make -C ./docs html
 
       - name: Test code
-        run: pytest --cov=./osmnx --cov-report=xml --cov-report=term-missing --verbose
+        run: pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=term-missing --verbose
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, typing]
+    branches: [main]
   pull_request:
     branches: [main, v2]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: make -C ./docs html
 
       - name: Test code
-        run: pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=term-missing --verbose
+        run: pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=xml --cov-report=term-missing --verbose
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test-minimal.yml
+++ b/.github/workflows/test-minimal.yml
@@ -50,4 +50,4 @@ jobs:
           python -m sphinx -b linkcheck ./docs/source ./docs/build/linkcheck
 
       - name: Test code
-        run: pytest --cov=./osmnx --cov-report=term-missing --verbose
+        run: pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=term-missing --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,16 +40,4 @@ repos:
     rev: "v1.8.0"
     hooks:
       - id: mypy
-        additional_dependencies:
-          [
-            gdal,
-            geopandas,
-            matplotlib,
-            networkx,
-            numpy,
-            rasterio,
-            scikit-learn,
-            scipy,
-            pandas-stubs,
-            types-requests,
-          ]
+        additional_dependencies: [matplotlib, pandas-stubs, types-requests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         types_or: [markdown, yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.9"
+    rev: "v0.1.11"
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         types_or: [markdown, yaml]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.11"
+    rev: "v0.1.13"
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,16 @@ repos:
     rev: "v1.8.0"
     hooks:
       - id: mypy
-        additional_dependencies: [pandas-stubs, types-requests]
+        additional_dependencies:
+          [
+            gdal,
+            geopandas,
+            matplotlib,
+            networkx,
+            numpy,
+            rasterio,
+            scikit-learn,
+            scipy,
+            pandas-stubs,
+            types-requests,
+          ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- add type annotations throughout the package for user type hinting and type checking (#1107)
 - fix a bug in the features module's polygon handling (#1104)
 - deprecate return_coords argument in graph.graph_from_address function (#1105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Unreleased
+## 2.0.0 (Unreleased)
 
 - add type annotations throughout the package for user type hinting and type checking (#1107)
+
+## 1.x.x (Unreleased)
+
 - fix a bug in the features module's polygon handling (#1104)
 - deprecate return_coords argument in graph.graph_from_address function (#1105)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import sys
 from pathlib import Path
+from typing import Any
 
 # go up two levels from current working dir (/docs/source) to package root
 pkg_root_path = str(Path.cwd().parent.parent)
@@ -46,9 +47,9 @@ language = "en"
 needs_sphinx = "7"  # same value as pinned in /docs/requirements.txt
 root_doc = "index"
 source_suffix = ".rst"
-templates_path: list = []
+templates_path: list[Any] = []
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-html_static_path: list = []
+html_static_path: list[Any] = []
 html_theme = "furo"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,19 +5,17 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-# -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import sys
 from pathlib import Path
-from typing import Any
+
+# project info
+author = "Geoff Boeing"
+copyright = "2016-2024, Geoff Boeing"  # noqa: A001
+project = "OSMnx"
 
 # go up two levels from current working dir (/docs/source) to package root
 pkg_root_path = str(Path.cwd().parent.parent)
 sys.path.insert(0, pkg_root_path)
-
-author = "Geoff Boeing"
-copyright = "2016-2024, Geoff Boeing"  # noqa: A001
-project = "OSMnx"
 
 # dynamically load version from /osmnx/_version.py
 with Path.open(Path("../../osmnx/_version.py")) as f:
@@ -39,17 +37,14 @@ autodoc_mock_imports = [
     "sklearn",
 ]
 
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+# general configuration and options for HTML output
+# see https://www.sphinx-doc.org/en/master/usage/configuration.html
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon"]
+html_static_path: list[str] = []
+html_theme = "furo"
 language = "en"
 needs_sphinx = "7"  # same value as pinned in /docs/requirements.txt
 root_doc = "index"
 source_suffix = ".rst"
-templates_path: list[Any] = []
-
-# -- Options for HTML output -------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
-html_static_path: list[Any] = []
-html_theme = "furo"
+templates_path: list[str] = []

--- a/environments/docker/requirements.txt
+++ b/environments/docker/requirements.txt
@@ -33,6 +33,7 @@ twine
 # typing
 mypy
 pandas-stubs
+typeguard
 types-requests
 
 # linting/testing

--- a/environments/docker/requirements.txt
+++ b/environments/docker/requirements.txt
@@ -30,6 +30,11 @@ hatch
 pip
 twine
 
+# typing
+mypy
+pandas-stubs
+types-requests
+
 # linting/testing
 nbdime
 nbqa

--- a/environments/linux/create-environment.sh
+++ b/environments/linux/create-environment.sh
@@ -3,7 +3,7 @@ set -e
 ENV=ox
 PACKAGE=osmnx
 eval "$(conda shell.bash hook)"
-conda deactivate
+conda activate base
 mamba env remove -n $ENV --yes
 mamba clean --all --yes --quiet --no-banner
 mamba create -c conda-forge --strict-channel-priority -n $ENV --file "../docker/requirements.txt" --yes --no-banner

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -136,7 +136,7 @@ def _retrieve_from_cache(url: str, check_remark: bool = True) -> dict | None:
 
 
 def _get_http_headers(
-    user_agent: str = None, referer: str = None, accept_language: str = None
+    user_agent: str | None = None, referer: str | None = None, accept_language: str | None = None
 ) -> dict:
     """
     Update the default requests HTTP headers with OSMnx info.

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -215,7 +215,7 @@ def _resolve_host_via_doh(hostname: str) -> str:
         utils.log(err_msg, level=lg.ERROR)
         return hostname
 
-    # if there were no exceptions, return
+    # if there were no request exceptions, return
     else:
         if response.ok and data["Status"] == 0:
             # status 0 means NOERROR, so return the IP address

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -290,7 +290,7 @@ def _hostname_from_url(url: str) -> str:
     return urlparse(url).netloc.split(":")[0]
 
 
-def _parse_response(response: requests.Response) -> dict[Any, Any] | list[Any]:
+def _parse_response(response: requests.Response) -> dict[Any, Any] | list[dict[str, Any]]:
     """
     Parse JSON from a requests response and log the details.
 
@@ -302,6 +302,8 @@ def _parse_response(response: requests.Response) -> dict[Any, Any] | list[Any]:
     Returns
     -------
     response_json : dict or list
+        Value will be a dict if the response is from the Google or Overpass
+        APIs, and a list if the response is from the Nominatim API.
     """
     # log the response size and domain
     domain = _hostname_from_url(response.url)

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -328,4 +328,8 @@ def _parse_response(response: requests.Response) -> dict[str, Any] | list[dict[s
     if isinstance(response_json, dict) and "remark" in response_json:  # pragma: no cover
         utils.log(f'{domain!r} remarked: {response_json["remark"]!r}', level=lg.WARNING)
 
+    # log if the response status_code is not OK
+    if not response.ok:
+        utils.log(f"{domain!r} returned HTTP status code {response.status_code}", level=lg.WARNING)
+
     return response_json

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -294,7 +294,7 @@ def _hostname_from_url(url: str) -> str:
     return urlparse(url).netloc.split(":")[0]
 
 
-def _parse_response(response: requests.Response) -> dict[Any, Any] | list[dict[str, Any]]:
+def _parse_response(response: requests.Response) -> dict[str, Any] | list[dict[str, Any]]:
     """
     Parse JSON from a requests response and log the details.
 

--- a/osmnx/_downloader.py
+++ b/osmnx/_downloader.py
@@ -22,7 +22,9 @@ from ._errors import ResponseStatusCodeError
 _original_getaddrinfo = socket.getaddrinfo
 
 
-def _save_to_cache(url: str, response_json: dict[Any, Any] | list[Any], ok: bool) -> None:
+def _save_to_cache(
+    url: str, response_json: dict[str, Any] | list[dict[str, Any]], ok: bool
+) -> None:
     """
     Save a HTTP response JSON object to a file in the cache folder.
 
@@ -98,7 +100,9 @@ def _url_in_cache(url: str) -> Path | None:
     return filepath if filepath.is_file() else None
 
 
-def _retrieve_from_cache(url: str, check_remark: bool = True) -> dict[Any, Any] | list[Any] | None:
+def _retrieve_from_cache(
+    url: str, check_remark: bool = True
+) -> dict[str, Any] | list[dict[str, Any]] | None:
     """
     Retrieve a HTTP response JSON object from the cache, if it exists.
 
@@ -120,7 +124,7 @@ def _retrieve_from_cache(url: str, check_remark: bool = True) -> dict[Any, Any] 
         # return cached response for this url if exists, otherwise return None
         cache_filepath = _url_in_cache(url)
         if cache_filepath is not None:
-            response_json: dict[Any, Any] | list[Any] = json.loads(
+            response_json: dict[str, Any] | list[dict[str, Any]] = json.loads(
                 cache_filepath.read_text(encoding="utf-8")
             )
 
@@ -312,7 +316,7 @@ def _parse_response(response: requests.Response) -> dict[Any, Any] | list[dict[s
 
     # parse the response to JSON and log/raise exceptions
     try:
-        response_json: dict[Any, Any] | list[Any] = response.json()
+        response_json: dict[str, Any] | list[dict[str, Any]] = response.json()
     except JSONDecodeError as e:  # pragma: no cover
         msg = f"{domain!r} responded: {response.status_code} {response.reason} {response.text}"
         utils.log(msg, level=lg.ERROR)

--- a/osmnx/_nominatim.py
+++ b/osmnx/_nominatim.py
@@ -31,7 +31,7 @@ def _download_nominatim_element(
         if True, treat query as an OSM ID lookup rather than text search
     limit : int
         max number of results to return
-    polygon_geojson : int
+    polygon_geojson : bool
         whether to retrieve the place's geometry from the API
 
     Returns

--- a/osmnx/_nominatim.py
+++ b/osmnx/_nominatim.py
@@ -15,8 +15,11 @@ from . import utils
 
 
 def _download_nominatim_element(
-    query: str | dict, by_osmid: bool = False, limit: int = 1, polygon_geojson: bool = True
-) -> dict:
+    query: str | dict[str, str],
+    by_osmid: bool = False,
+    limit: int = 1,
+    polygon_geojson: bool = True,
+) -> dict[Any, Any] | list[Any]:
     """
     Retrieve an OSM element from the Nominatim API.
 
@@ -33,11 +36,11 @@ def _download_nominatim_element(
 
     Returns
     -------
-    response_json : dict
+    response_json : dict or list
         JSON response from the Nominatim server
     """
     # define the parameters
-    params: OrderedDict[Any] = OrderedDict()
+    params: OrderedDict[str, Any] = OrderedDict()
     params["format"] = "json"
     params["polygon_geojson"] = int(polygon_geojson)
 
@@ -70,8 +73,11 @@ def _download_nominatim_element(
 
 
 def _nominatim_request(
-    params: OrderedDict, request_type: str = "search", pause: float = 1, error_pause: float = 60
-) -> dict:
+    params: OrderedDict[str, Any],
+    request_type: str = "search",
+    pause: float = 1,
+    error_pause: float = 60,
+) -> dict[Any, Any] | list[Any]:
     """
     Send a HTTP GET request to the Nominatim API and return response.
 
@@ -89,7 +95,7 @@ def _nominatim_request(
 
     Returns
     -------
-    response_json : dict
+    response_json : dict or list
     """
     if request_type not in {"search", "reverse", "lookup"}:  # pragma: no cover
         msg = 'Nominatim request_type must be "search", "reverse", or "lookup"'

--- a/osmnx/_nominatim.py
+++ b/osmnx/_nominatim.py
@@ -12,6 +12,7 @@ import requests
 from . import _downloader
 from . import settings
 from . import utils
+from ._errors import InsufficientResponseError
 
 
 def _download_nominatim_element(
@@ -143,6 +144,6 @@ def _nominatim_request(
     response_json = _downloader._parse_response(response)
     if not isinstance(response_json, list):
         msg = "Nominatim API did not return a list of results."
-        raise TypeError(msg)
+        raise InsufficientResponseError(msg)
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/_nominatim.py
+++ b/osmnx/_nominatim.py
@@ -19,7 +19,7 @@ def _download_nominatim_element(
     by_osmid: bool = False,
     limit: int = 1,
     polygon_geojson: bool = True,
-) -> dict[Any, Any] | list[Any]:
+) -> list[dict[str, Any]]:
     """
     Retrieve an OSM element from the Nominatim API.
 
@@ -36,7 +36,7 @@ def _download_nominatim_element(
 
     Returns
     -------
-    response_json : dict or list
+    response_json : list
         JSON response from the Nominatim server
     """
     # define the parameters
@@ -77,7 +77,7 @@ def _nominatim_request(
     request_type: str = "search",
     pause: float = 1,
     error_pause: float = 60,
-) -> dict[Any, Any] | list[Any]:
+) -> list[dict[str, Any]]:
     """
     Send a HTTP GET request to the Nominatim API and return response.
 
@@ -95,7 +95,7 @@ def _nominatim_request(
 
     Returns
     -------
-    response_json : dict or list
+    response_json : list
     """
     if request_type not in {"search", "reverse", "lookup"}:  # pragma: no cover
         msg = 'Nominatim request_type must be "search", "reverse", or "lookup"'
@@ -106,7 +106,10 @@ def _nominatim_request(
     params["key"] = settings.nominatim_key
     prepared_url = str(requests.Request("GET", url, params=params).prepare().url)
 
-    if (cached_response_json := _downloader._retrieve_from_cache(prepared_url)) is not None:
+    cached_response_json: list[dict[str, Any]] | None = _downloader._retrieve_from_cache(
+        prepared_url
+    )  # type: ignore[assignment]
+    if cached_response_json is not None:
         return cached_response_json
 
     # pause then request this URL
@@ -134,6 +137,6 @@ def _nominatim_request(
         time.sleep(error_pause)
         return _nominatim_request(params, request_type, pause, error_pause)
 
-    response_json = _downloader._parse_response(response)
+    response_json: list[dict[str, Any]] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -395,8 +395,8 @@ def _overpass_request(
     # prepare the Overpass API URL and see if request already exists in cache
     url = settings.overpass_endpoint.rstrip("/") + "/interpreter"
     prepared_url = str(requests.Request("GET", url, params=data).prepare().url)
-    cached_response_json: dict[str, Any] | None = _downloader._retrieve_from_cache(prepared_url)  # type: ignore[assignment]
-    if cached_response_json is not None:
+    cached_response_json = _downloader._retrieve_from_cache(prepared_url)
+    if isinstance(cached_response_json, dict):
         return cached_response_json
 
     # pause then request this URL
@@ -427,9 +427,9 @@ def _overpass_request(
         time.sleep(this_pause)
         return _overpass_request(data, pause, error_pause)
 
-    response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
-    _downloader._save_to_cache(prepared_url, response_json, response.ok)
+    response_json = _downloader._parse_response(response)
     if not isinstance(response_json, dict):
         msg = "Overpass API did not return a dict of results."
         raise TypeError(msg)
+    _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -303,7 +303,7 @@ def _create_overpass_query(polygon_coord_str: list, tags: dict) -> str:
 
 
 def _download_overpass_network(
-    polygon: Polygon | MultiPolygon, network_type: str, custom_filter: str
+    polygon: Polygon | MultiPolygon, network_type: str, custom_filter: str | None
 ) -> Generator:
     """
     Retrieve networked ways and nodes within boundary from the Overpass API.

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -304,7 +304,7 @@ def _create_overpass_query(polygon_coord_str: str, tags: dict[str, bool | str | 
 
 def _download_overpass_network(
     polygon: Polygon | MultiPolygon, network_type: str, custom_filter: str | None
-) -> Generator[dict[Any, Any], None, None]:
+) -> Generator[dict[str, Any], None, None]:
     """
     Retrieve networked ways and nodes within boundary from the Overpass API.
 
@@ -342,7 +342,7 @@ def _download_overpass_network(
 
 def _download_overpass_features(
     polygon: Polygon, tags: dict[str, bool | str | list[str]]
-) -> Generator[dict[Any, Any], None, None]:
+) -> Generator[dict[str, Any], None, None]:
     """
     Retrieve OSM features within some boundary polygon from the Overpass API.
 
@@ -370,7 +370,7 @@ def _download_overpass_features(
 
 def _overpass_request(
     data: OrderedDict[str, Any], pause: float | None = None, error_pause: float = 60
-) -> dict[Any, Any]:
+) -> dict[str, Any]:
     """
     Send a HTTP POST request to the Overpass API and return response.
 

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -304,7 +304,7 @@ def _create_overpass_query(polygon_coord_str: str, tags: dict[str, bool | str | 
 
 def _download_overpass_network(
     polygon: Polygon | MultiPolygon, network_type: str, custom_filter: str | None
-) -> Generator[dict[Any, Any] | list[Any], None, None]:
+) -> Generator[dict[Any, Any], None, None]:
     """
     Retrieve networked ways and nodes within boundary from the Overpass API.
 
@@ -342,7 +342,7 @@ def _download_overpass_network(
 
 def _download_overpass_features(
     polygon: Polygon, tags: dict[str, bool | str | list[str]]
-) -> Generator[dict[Any, Any] | list[Any], None, None]:
+) -> Generator[dict[Any, Any], None, None]:
     """
     Retrieve OSM features within boundary from the Overpass API.
 
@@ -370,7 +370,7 @@ def _download_overpass_features(
 
 def _overpass_request(
     data: OrderedDict[str, Any], pause: float | None = None, error_pause: float = 60
-) -> dict[Any, Any] | list[Any]:
+) -> dict[Any, Any]:
     """
     Send a HTTP POST request to the Overpass API and return response.
 
@@ -395,7 +395,7 @@ def _overpass_request(
     # prepare the Overpass API URL and see if request already exists in cache
     url = settings.overpass_endpoint.rstrip("/") + "/interpreter"
     prepared_url = str(requests.Request("GET", url, params=data).prepare().url)
-    cached_response_json = _downloader._retrieve_from_cache(prepared_url)
+    cached_response_json: dict[Any, Any] | None = _downloader._retrieve_from_cache(prepared_url)  # type: ignore[assignment]
     if cached_response_json is not None:
         return cached_response_json
 
@@ -427,6 +427,6 @@ def _overpass_request(
         time.sleep(this_pause)
         return _overpass_request(data, pause, error_pause)
 
-    response_json = _downloader._parse_response(response)
+    response_json: dict[Any, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -33,7 +33,7 @@ def _get_network_filter(network_type: str) -> str:
 
     Returns
     -------
-    filtr : string
+    overpass_filter : string
         the Overpass query filter
     """
     # define built-in queries to send to the API. specifying way["highway"]
@@ -100,12 +100,12 @@ def _get_network_filter(network_type: str) -> str:
     )
 
     if network_type in filters:
-        osm_filter = filters[network_type]
+        overpass_filter = filters[network_type]
     else:  # pragma: no cover
         msg = f"Unrecognized network_type {network_type!r}"
         raise ValueError(msg)
 
-    return osm_filter
+    return overpass_filter
 
 
 def _get_overpass_pause(
@@ -131,7 +131,7 @@ def _get_overpass_pause(
     Returns
     -------
     pause : float
-        the current pause duration demanded by the Overpass status endpoint
+        the current pause duration specified by the Overpass status endpoint
     """
     if not settings.overpass_rate_limit:
         # if overpass rate limiting is False, then there is zero pause
@@ -344,7 +344,7 @@ def _download_overpass_features(
     polygon: Polygon, tags: dict[str, bool | str | list[str]]
 ) -> Generator[dict[Any, Any], None, None]:
     """
-    Retrieve OSM features within boundary from the Overpass API.
+    Retrieve OSM features within some boundary polygon from the Overpass API.
 
     Parameters
     ----------

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -366,7 +366,9 @@ def _download_overpass_features(polygon: Polygon, tags: dict) -> Generator:
         yield _overpass_request(OrderedDict(data=query_str))
 
 
-def _overpass_request(data: OrderedDict, pause: float = None, error_pause: float = 60) -> dict:
+def _overpass_request(
+    data: OrderedDict, pause: float | None = None, error_pause: float = 60
+) -> dict:
     """
     Send a HTTP POST request to the Overpass API and return response.
 

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -199,7 +199,7 @@ def _make_overpass_settings() -> str:
     return settings.overpass_settings.format(timeout=settings.timeout, maxsize=maxsize)
 
 
-def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list:
+def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list[str]:
     """
     Subdivide query polygon and return list of coordinate strings.
 
@@ -235,14 +235,14 @@ def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list:
     return coord_strs
 
 
-def _create_overpass_query(polygon_coord_str: list, tags: dict) -> str:
+def _create_overpass_query(polygon_coord_str: str, tags: dict[str, bool | str | list[str]]) -> str:
     """
     Create an Overpass features query string based on passed tags.
 
     Parameters
     ----------
-    polygon_coord_str : list
-        list of lat lon coordinates
+    polygon_coord_str : st
+        string of lat lon coordinates
     tags : dict
         dict of tags used for finding elements in the search area
 
@@ -258,7 +258,7 @@ def _create_overpass_query(polygon_coord_str: list, tags: dict) -> str:
     if not isinstance(tags, dict):  # pragma: no cover
         raise TypeError(err_msg)
 
-    tags_dict: dict[Any] = {}
+    tags_dict: dict[str, bool | str | list[str]] = {}
     for key, value in tags.items():
         if isinstance(value, bool):
             tags_dict[key] = value
@@ -275,7 +275,7 @@ def _create_overpass_query(polygon_coord_str: list, tags: dict) -> str:
             raise TypeError(err_msg)
 
     # convert the tags dict into a list of {tag:value} dicts
-    tags_list = []
+    tags_list: list[dict[str, bool | str | list[str]]] = []
     for key, value in tags_dict.items():
         if isinstance(value, bool):
             tags_list.append({key: value})
@@ -304,7 +304,7 @@ def _create_overpass_query(polygon_coord_str: list, tags: dict) -> str:
 
 def _download_overpass_network(
     polygon: Polygon | MultiPolygon, network_type: str, custom_filter: str | None
-) -> Generator:
+) -> Generator[dict[Any, Any] | list[Any], None, None]:
     """
     Retrieve networked ways and nodes within boundary from the Overpass API.
 
@@ -340,7 +340,9 @@ def _download_overpass_network(
         yield _overpass_request(OrderedDict(data=query_str))
 
 
-def _download_overpass_features(polygon: Polygon, tags: dict) -> Generator:
+def _download_overpass_features(
+    polygon: Polygon, tags: dict[str, bool | str | list[str]]
+) -> Generator[dict[Any, Any] | list[Any], None, None]:
     """
     Retrieve OSM features within boundary from the Overpass API.
 
@@ -367,8 +369,8 @@ def _download_overpass_features(polygon: Polygon, tags: dict) -> Generator:
 
 
 def _overpass_request(
-    data: OrderedDict, pause: float | None = None, error_pause: float = 60
-) -> dict:
+    data: OrderedDict[str, Any], pause: float | None = None, error_pause: float = 60
+) -> dict[Any, Any] | list[Any]:
     """
     Send a HTTP POST request to the Overpass API and return response.
 
@@ -385,7 +387,7 @@ def _overpass_request(
 
     Returns
     -------
-    response_json : dict
+    response_json : dict or list
     """
     # resolve url to same IP even if there is server round-robin redirecting
     _downloader._config_dns(settings.overpass_endpoint)

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -395,7 +395,7 @@ def _overpass_request(
     # prepare the Overpass API URL and see if request already exists in cache
     url = settings.overpass_endpoint.rstrip("/") + "/interpreter"
     prepared_url = str(requests.Request("GET", url, params=data).prepare().url)
-    cached_response_json: dict[Any, Any] | None = _downloader._retrieve_from_cache(prepared_url)  # type: ignore[assignment]
+    cached_response_json: dict[str, Any] | None = _downloader._retrieve_from_cache(prepared_url)  # type: ignore[assignment]
     if cached_response_json is not None:
         return cached_response_json
 
@@ -427,6 +427,6 @@ def _overpass_request(
         time.sleep(this_pause)
         return _overpass_request(data, pause, error_pause)
 
-    response_json: dict[Any, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
+    response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -429,4 +429,7 @@ def _overpass_request(
 
     response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
+    if not isinstance(response_json, dict):
+        msg = "Overpass API did not return a dict of results."
+        raise TypeError(msg)
     return response_json

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -20,6 +20,7 @@ from . import projection
 from . import settings
 from . import utils
 from . import utils_geo
+from ._errors import InsufficientResponseError
 
 
 def _get_network_filter(network_type: str) -> str:
@@ -428,8 +429,8 @@ def _overpass_request(
         return _overpass_request(data, pause, error_pause)
 
     response_json = _downloader._parse_response(response)
-    if not isinstance(response_json, dict):
+    if not isinstance(response_json, dict):  # pragma: no cover
         msg = "Overpass API did not return a dict of results."
-        raise TypeError(msg)
+        raise InsufficientResponseError(msg)
     _downloader._save_to_cache(prepared_url, response_json, response.ok)
     return response_json

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover
 
 
 # if coords are all floats, return float
-@overload
+@overload  # pragma: no cover
 def calculate_bearing(
     lat1: float,
     lon1: float,
@@ -30,7 +30,7 @@ def calculate_bearing(
 
 
 # if coords are all arrays, return array
-@overload
+@overload  # pragma: no cover
 def calculate_bearing(
     lat1: NDArray[np.float64],
     lon1: NDArray[np.float64],

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -84,7 +84,7 @@ def calculate_bearing(
     return bearing
 
 
-def add_edge_bearings(G: nx.MultiDiGraph, precision: int = None) -> nx.MultiDiGraph:
+def add_edge_bearings(G: nx.MultiDiGraph, precision: int | None = None) -> nx.MultiDiGraph:
     """
     Add compass `bearing` attributes to all graph edges.
 
@@ -134,7 +134,7 @@ def add_edge_bearings(G: nx.MultiDiGraph, precision: int = None) -> nx.MultiDiGr
 
 
 def orientation_entropy(
-    Gu: nx.MultiGraph, num_bins: int = 36, min_length: float = 0, weight: str = None
+    Gu: nx.MultiGraph, num_bins: int = 36, min_length: float = 0, weight: str | None = None
 ) -> float:
     """
     Calculate undirected graph's orientation entropy.
@@ -178,7 +178,7 @@ def orientation_entropy(
 
 
 def _extract_edge_bearings(
-    Gu: nx.MultiGraph, min_length: float = 0, weight: str = None
+    Gu: nx.MultiGraph, min_length: float = 0, weight: str | None = None
 ) -> np.ndarray:
     """
     Extract undirected graph's bidirectional edge bearings.
@@ -226,7 +226,7 @@ def _extract_edge_bearings(
 
 
 def _bearings_distribution(
-    Gu: nx.MultiGraph, num_bins: int, min_length: float = 0, weight: str = None
+    Gu: nx.MultiGraph, num_bins: int, min_length: float = 0, weight: str | None = None
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute distribution of bearings across evenly spaced bins.

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -6,6 +6,7 @@ from warnings import warn
 
 import networkx as nx
 import numpy as np
+from numpy.typing import NDArray
 
 from . import plot
 from . import projection
@@ -31,20 +32,20 @@ def calculate_bearing(
 # if coords are all arrays, return array
 @overload
 def calculate_bearing(
-    lat1: np.ndarray,
-    lon1: np.ndarray,
-    lat2: np.ndarray,
-    lon2: np.ndarray,
-) -> np.ndarray:
+    lat1: NDArray[np.float64],
+    lon1: NDArray[np.float64],
+    lat2: NDArray[np.float64],
+    lon2: NDArray[np.float64],
+) -> NDArray[np.float64]:
     ...
 
 
 def calculate_bearing(
-    lat1: float | np.ndarray,
-    lon1: float | np.ndarray,
-    lat2: float | np.ndarray,
-    lon2: float | np.ndarray,
-) -> float | np.ndarray:
+    lat1: float | NDArray[np.float64],
+    lon1: float | NDArray[np.float64],
+    lat2: float | NDArray[np.float64],
+    lon2: float | NDArray[np.float64],
+) -> float | NDArray[np.float64]:
     """
     Calculate the compass bearing(s) between pairs of lat-lon points.
 
@@ -80,7 +81,7 @@ def calculate_bearing(
     initial_bearing = np.degrees(np.arctan2(y, x))
 
     # normalize to 0-360 degrees to get compass bearing
-    bearing: float | np.ndarray = initial_bearing % 360
+    bearing: float | NDArray[np.float64] = initial_bearing % 360
     return bearing
 
 
@@ -179,7 +180,7 @@ def orientation_entropy(
 
 def _extract_edge_bearings(
     Gu: nx.MultiGraph, min_length: float = 0, weight: str | None = None
-) -> np.ndarray:
+) -> NDArray[np.float64]:
     """
     Extract undirected graph's bidirectional edge bearings.
 
@@ -201,7 +202,7 @@ def _extract_edge_bearings(
 
     Returns
     -------
-    bearings : numpy.array
+    bearings : numpy.array of float
         the graph's bidirectional edge bearings
     """
     if nx.is_directed(Gu) or projection.is_projected(Gu.graph["crs"]):  # pragma: no cover
@@ -227,7 +228,7 @@ def _extract_edge_bearings(
 
 def _bearings_distribution(
     Gu: nx.MultiGraph, num_bins: int, min_length: float = 0, weight: str | None = None
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """
     Compute distribution of bearings across evenly spaced bins.
 
@@ -254,7 +255,7 @@ def _bearings_distribution(
 
     Returns
     -------
-    bin_counts, bin_edges : tuple of numpy.array
+    bin_counts, bin_edges : tuple of numpy.array of float
         counts of bearings per bin and the bins edges
     """
     n = num_bins * 2

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -389,7 +389,7 @@ def nearest_nodes(
         between each point and its nearest node
     """
     # make coordinates arrays whether user passed iterable values or not
-    if not (hasattr(X, "__iter__") and hasattr(Y, "__iter__")):
+    if not (isinstance(X, Iterable) and isinstance(Y, Iterable)):
         is_scalar = True
         X_arr = np.array([X])
         Y_arr = np.array([Y])
@@ -531,7 +531,7 @@ def nearest_edges(
         of ID(s) and distance(s) between each point and its nearest edge
     """
     # make coordinates arrays whether user passed iterable values or not
-    if not (hasattr(X, "__iter__") and hasattr(Y, "__iter__")):
+    if not (isinstance(X, Iterable) and isinstance(Y, Iterable)):
         is_scalar = True
         X_arr = np.array([X])
         Y_arr = np.array([Y])

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -239,7 +239,9 @@ def euclidean_dist_vec(y1, x1, y2, x2):  # type: ignore[no-untyped-def]
 
 
 def add_edge_lengths(
-    G: nx.MultiDiGraph, precision: int | None = None, edges: tuple[int, int, int] | None = None
+    G: nx.MultiDiGraph,
+    precision: int | None = None,
+    edges: Iterable[tuple[int, int, int]] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Add `length` attribute (in meters) to each edge.
@@ -266,9 +268,9 @@ def add_edge_lengths(
         unprojected, unsimplified input graph
     precision : int
         deprecated, do not use
-    edges : tuple
-        tuple of (u, v, k) tuples representing subset of edges to add length
-        attributes to. if None, add lengths to all edges.
+    edges : iterable of tuples
+        iterable of (u, v, k) tuples representing subset of edges to add
+        length attributes to. if None, add lengths to all edges.
 
     Returns
     -------
@@ -283,7 +285,7 @@ def add_edge_lengths(
             stacklevel=2,
         )
 
-    uvk = tuple(G.edges) if edges is None else edges
+    uvk = G.edges if edges is None else edges
 
     # extract edge IDs and corresponding coordinates from their nodes
     x = G.nodes(data="x")

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -36,19 +36,19 @@ EARTH_RADIUS_M = 6_371_009
 
 
 # if coords are all floats, return float
-@overload
+@overload  # pragma: no cover
 def great_circle(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     ...
 
 
 # if coords are all floats (and optional arg is provided), return float
-@overload
+@overload  # pragma: no cover
 def great_circle(lat1: float, lon1: float, lat2: float, lon2: float, earth_radius: float) -> float:
     ...
 
 
 # if coords are all arrays, return array
-@overload
+@overload  # pragma: no cover
 def great_circle(
     lat1: NDArray[np.float64],
     lon1: NDArray[np.float64],
@@ -59,7 +59,7 @@ def great_circle(
 
 
 # if coords are all arrays (and optional arg is provided), return array
-@overload
+@overload  # pragma: no cover
 def great_circle(
     lat1: NDArray[np.float64],
     lon1: NDArray[np.float64],
@@ -122,13 +122,13 @@ def great_circle(
 
 
 # if coords are all floats, return float
-@overload
+@overload  # pragma: no cover
 def euclidean(y1: float, x1: float, y2: float, x2: float) -> float:
     ...
 
 
 # if coords are all arrays, return array
-@overload
+@overload  # pragma: no cover
 def euclidean(
     y1: NDArray[np.float64],
     x1: NDArray[np.float64],
@@ -309,19 +309,19 @@ def add_edge_lengths(
 
 
 # if X and Y are floats and return_dist is not provided (defaults False)
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float) -> int:
     ...
 
 
 # if X and Y are floats and return_dist is provided/False
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[False]) -> int:
     ...
 
 
 # if X and Y are floats and return_dist is provided/True
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(
     G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[True]
 ) -> tuple[NDArray[np.int64], NDArray[np.float64]]:
@@ -329,13 +329,13 @@ def nearest_nodes(
 
 
 # if X and Y are iterable and return_dist is not provided (defaults False)
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float]) -> NDArray[np.int64]:
     ...
 
 
 # if X and Y are iterable and return_dist is provided/False
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(
     G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], return_dist: Literal[False]
 ) -> NDArray[np.int64]:
@@ -343,7 +343,7 @@ def nearest_nodes(
 
 
 # if X and Y are iterable and return_dist is provided/True
-@overload
+@overload  # pragma: no cover
 def nearest_nodes(
     G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], return_dist: Literal[True]
 ) -> tuple[NDArray[np.int64], NDArray[np.float64]]:
@@ -443,13 +443,13 @@ def nearest_nodes(
 
 
 # if X and Y are floats and return_dist is not provided (defaults False)
-@overload
+@overload  # pragma: no cover
 def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float) -> tuple[int, int, int]:
     ...
 
 
 # if X and Y are floats and return_dist is provided/False
-@overload
+@overload  # pragma: no cover
 def nearest_edges(
     G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[False]
 ) -> tuple[int, int, int]:
@@ -457,7 +457,7 @@ def nearest_edges(
 
 
 # if X and Y are floats and return_dist is provided/True
-@overload
+@overload  # pragma: no cover
 def nearest_edges(
     G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[True]
 ) -> tuple[tuple[int, int, int], float]:
@@ -465,7 +465,7 @@ def nearest_edges(
 
 
 # if X and Y are iterable and return_dist is not provided (defaults False)
-@overload
+@overload  # pragma: no cover
 def nearest_edges(
     G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float]
 ) -> NDArray[np.object_]:
@@ -473,7 +473,7 @@ def nearest_edges(
 
 
 # if X and Y are iterable and return_dist is provided/False
-@overload
+@overload  # pragma: no cover
 def nearest_edges(
     G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], *, return_dist: Literal[False]
 ) -> NDArray[np.object_]:
@@ -481,7 +481,7 @@ def nearest_edges(
 
 
 # if X and Y are iterable and return_dist is provided/True
-@overload
+@overload  # pragma: no cover
 def nearest_edges(
     G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], *, return_dist: Literal[True]
 ) -> tuple[NDArray[np.object_], NDArray[np.float64]]:

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -10,6 +10,7 @@ from warnings import warn
 import networkx as nx
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 from shapely.geometry import Point
 from shapely.strtree import STRtree
 
@@ -49,33 +50,33 @@ def great_circle(lat1: float, lon1: float, lat2: float, lon2: float, earth_radiu
 # if coords are all arrays, return array
 @overload
 def great_circle(
-    lat1: np.ndarray,
-    lon1: np.ndarray,
-    lat2: np.ndarray,
-    lon2: np.ndarray,
-) -> np.ndarray:
+    lat1: NDArray[np.float64],
+    lon1: NDArray[np.float64],
+    lat2: NDArray[np.float64],
+    lon2: NDArray[np.float64],
+) -> NDArray[np.float64]:
     ...
 
 
 # if coords are all arrays (and optional arg is provided), return array
 @overload
 def great_circle(
-    lat1: np.ndarray,
-    lon1: np.ndarray,
-    lat2: np.ndarray,
-    lon2: np.ndarray,
+    lat1: NDArray[np.float64],
+    lon1: NDArray[np.float64],
+    lat2: NDArray[np.float64],
+    lon2: NDArray[np.float64],
     earth_radius: float,
-) -> np.ndarray:
+) -> NDArray[np.float64]:
     ...
 
 
 def great_circle(
-    lat1: float | np.ndarray,
-    lon1: float | np.ndarray,
-    lat2: float | np.ndarray,
-    lon2: float | np.ndarray,
+    lat1: float | NDArray[np.float64],
+    lon1: float | NDArray[np.float64],
+    lat2: float | NDArray[np.float64],
+    lon2: float | NDArray[np.float64],
     earth_radius: float = EARTH_RADIUS_M,
-) -> float | np.ndarray:
+) -> float | NDArray[np.float64]:
     """
     Calculate great-circle distances between pairs of points.
 
@@ -116,7 +117,7 @@ def great_circle(
     arc = 2 * np.arcsin(np.sqrt(h))
 
     # return distance in units of earth_radius
-    dist: float | np.ndarray = arc * earth_radius
+    dist: float | NDArray[np.float64] = arc * earth_radius
     return dist
 
 
@@ -129,17 +130,20 @@ def euclidean(y1: float, x1: float, y2: float, x2: float) -> float:
 # if coords are all arrays, return array
 @overload
 def euclidean(
-    y1: np.ndarray,
-    x1: np.ndarray,
-    y2: np.ndarray,
-    x2: np.ndarray,
-) -> np.ndarray:
+    y1: NDArray[np.float64],
+    x1: NDArray[np.float64],
+    y2: NDArray[np.float64],
+    x2: NDArray[np.float64],
+) -> NDArray[np.float64]:
     ...
 
 
 def euclidean(
-    y1: float | np.ndarray, x1: float | np.ndarray, y2: float | np.ndarray, x2: float | np.ndarray
-) -> float | np.ndarray:
+    y1: float | NDArray[np.float64],
+    x1: float | NDArray[np.float64],
+    y2: float | NDArray[np.float64],
+    x2: float | NDArray[np.float64],
+) -> float | NDArray[np.float64]:
     """
     Calculate Euclidean distances between pairs of points.
 
@@ -164,7 +168,7 @@ def euclidean(
         distance from each (x1, y1) to each (x2, y2) in coordinates' units
     """
     # pythagorean theorem
-    dist: float | np.ndarray = ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
+    dist: float | NDArray[np.float64] = ((x1 - x2) ** 2 + (y1 - y2) ** 2) ** 0.5
     return dist
 
 
@@ -235,7 +239,7 @@ def euclidean_dist_vec(y1, x1, y2, x2):  # type: ignore[no-untyped-def]
 
 
 def add_edge_lengths(
-    G: nx.MultiDiGraph, precision: int | None = None, edges: tuple | None = None
+    G: nx.MultiDiGraph, precision: int | None = None, edges: tuple[int, int, int] | None = None
 ) -> nx.MultiDiGraph:
     """
     Add `length` attribute (in meters) to each edge.
@@ -316,35 +320,40 @@ def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[F
 
 # if X and Y are floats and return_dist is provided/True
 @overload
-def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[True]) -> tuple:
+def nearest_nodes(
+    G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[True]
+) -> tuple[NDArray[np.int64], NDArray[np.float64]]:
     ...
 
 
 # if X and Y are iterable and return_dist is not provided (defaults False)
 @overload
-def nearest_nodes(G: nx.MultiDiGraph, X: Iterable, Y: Iterable) -> np.ndarray:
+def nearest_nodes(G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float]) -> NDArray[np.int64]:
     ...
 
 
 # if X and Y are iterable and return_dist is provided/False
 @overload
 def nearest_nodes(
-    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, return_dist: Literal[False]
-) -> np.ndarray:
+    G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], return_dist: Literal[False]
+) -> NDArray[np.int64]:
     ...
 
 
 # if X and Y are iterable and return_dist is provided/True
 @overload
 def nearest_nodes(
-    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, return_dist: Literal[True]
-) -> tuple:
+    G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], return_dist: Literal[True]
+) -> tuple[NDArray[np.int64], NDArray[np.float64]]:
     ...
 
 
 def nearest_nodes(
-    G: nx.MultiDiGraph, X: float | Iterable, Y: float | Iterable, return_dist: bool = False
-) -> int | np.ndarray | tuple:
+    G: nx.MultiDiGraph,
+    X: float | Iterable[float],
+    Y: float | Iterable[float],
+    return_dist: bool = False,
+) -> int | NDArray[np.int64] | tuple[int, float] | tuple[NDArray[np.int64], NDArray[np.float64]]:
     """
     Find the nearest node to a point or to each of several points.
 
@@ -377,17 +386,15 @@ def nearest_nodes(
         nearest node ID(s) or optionally a tuple of ID(s) and distance(s)
         between each point and its nearest node
     """
-    is_scalar = False
-
-    # make coordinates iterable if user passed non-iterable values
+    # make coordinates arrays whether user passed iterable values or not
     if not (hasattr(X, "__iter__") and hasattr(Y, "__iter__")):
         is_scalar = True
-        X = [X]
-        Y = [Y]
-
-    # make coordinates arrays
-    X_arr = np.array(X)
-    Y_arr = np.array(Y)
+        X_arr = np.array([X])
+        Y_arr = np.array([Y])
+    else:
+        is_scalar = False
+        X_arr = np.array(X)
+        Y_arr = np.array(Y)
 
     if np.isnan(X_arr).any() or np.isnan(Y_arr).any():  # pragma: no cover
         msg = "`X` and `Y` cannot contain nulls"
@@ -400,7 +407,7 @@ def nearest_nodes(
             msg = "scipy must be installed to search a projected graph"
             raise ImportError(msg)
         dist, pos = cKDTree(nodes).query(np.array([X_arr, Y_arr]).T, k=1)
-        nn: np.ndarray = nodes.index[pos].to_numpy()
+        nn: NDArray[np.int64] = nodes.index[pos].to_numpy()
 
     else:
         # if unprojected, use ball tree for haversine nearest-neighbor search
@@ -428,51 +435,62 @@ def nearest_nodes(
 
 # if X and Y are floats and return_dist is not provided (defaults False)
 @overload
-def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float) -> tuple:
+def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float) -> tuple[int, int, int]:
     ...
 
 
 # if X and Y are floats and return_dist is provided/False
 @overload
-def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[False]) -> tuple:
+def nearest_edges(
+    G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[False]
+) -> tuple[int, int, int]:
     ...
 
 
 # if X and Y are floats and return_dist is provided/True
 @overload
-def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[True]) -> tuple:
+def nearest_edges(
+    G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[True]
+) -> tuple[tuple[int, int, int], float]:
     ...
 
 
 # if X and Y are iterable and return_dist is not provided (defaults False)
 @overload
-def nearest_edges(G: nx.MultiDiGraph, X: Iterable, Y: Iterable) -> np.ndarray:
+def nearest_edges(
+    G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float]
+) -> NDArray[np.object_]:
     ...
 
 
 # if X and Y are iterable and return_dist is provided/False
 @overload
 def nearest_edges(
-    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, *, return_dist: Literal[False]
-) -> np.ndarray:
+    G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], *, return_dist: Literal[False]
+) -> NDArray[np.object_]:
     ...
 
 
 # if X and Y are iterable and return_dist is provided/True
 @overload
 def nearest_edges(
-    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, *, return_dist: Literal[True]
-) -> tuple:
+    G: nx.MultiDiGraph, X: Iterable[float], Y: Iterable[float], *, return_dist: Literal[True]
+) -> tuple[NDArray[np.object_], NDArray[np.float64]]:
     ...
 
 
 def nearest_edges(
     G: nx.MultiDiGraph,
-    X: float | Iterable,
-    Y: float | Iterable,
+    X: float | Iterable[float],
+    Y: float | Iterable[float],
     interpolate: float | None = None,
     return_dist: bool = False,
-) -> tuple | np.ndarray:
+) -> (
+    tuple[int, int, int]
+    | NDArray[np.object_]
+    | tuple[tuple[int, int, int], float]
+    | tuple[NDArray[np.object_], NDArray[np.float64]]
+):
     """
     Find the nearest edge to a point or to each of several points.
 
@@ -503,17 +521,15 @@ def nearest_edges(
         nearest edge ID(s) (as `u`, `v`, `key` tuples) or optionally a tuple
         of ID(s) and distance(s) between each point and its nearest edge
     """
-    is_scalar = False
-
-    # make coordinates iterable if user passed non-iterable values
+    # make coordinates arrays whether user passed iterable values or not
     if not (hasattr(X, "__iter__") and hasattr(Y, "__iter__")):
         is_scalar = True
-        X = [X]
-        Y = [Y]
-
-    # make coordinates arrays
-    X_arr = np.array(X)
-    Y_arr = np.array(Y)
+        X_arr = np.array([X])
+        Y_arr = np.array([Y])
+    else:
+        is_scalar = False
+        X_arr = np.array(X)
+        Y_arr = np.array(Y)
 
     if np.isnan(X_arr).any() or np.isnan(Y_arr).any():  # pragma: no cover
         msg = "`X` and `Y` cannot contain nulls"
@@ -532,7 +548,7 @@ def nearest_edges(
         # if user passed X/Y lists, the 2nd subarray contains geom indices
         if len(pos.shape) > 1:
             pos = pos[1]
-        ne: np.ndarray = geoms.iloc[pos].index.to_numpy()
+        ne: NDArray[np.object_] = geoms.iloc[pos].index.to_numpy()
 
     # otherwise, if interpolation distance was provided
     else:
@@ -542,7 +558,7 @@ def nearest_edges(
         )
 
         # interpolate points along edges to index with k-d tree or ball tree
-        uvk_xy: list = []
+        uvk_xy: list = []  # type: ignore[type-arg]
         for uvk, geom in zip(geoms.index, geoms.to_numpy()):
             uvk_xy.extend((uvk, xy) for xy in utils_geo.interpolate_points(geom, interpolate))
         labels, xy = zip(*uvk_xy)

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -499,7 +499,7 @@ def nearest_edges(
 
     Returns
     -------
-    ne or (ne, dist) : tuple or np.array or a tuple of (int/np.array, float/np.array)
+    ne or (ne, dist) : tuple or np.array or a tuple of (tuple/np.array, float/np.array)
         nearest edge ID(s) (as `u`, `v`, `key` tuples) or optionally a tuple
         of ID(s) and distance(s) between each point and its nearest edge
     """

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -235,7 +235,7 @@ def euclidean_dist_vec(y1, x1, y2, x2):  # type: ignore[no-untyped-def]
 
 
 def add_edge_lengths(
-    G: nx.MultiDiGraph, precision: int = None, edges: tuple = None
+    G: nx.MultiDiGraph, precision: int | None = None, edges: tuple | None = None
 ) -> nx.MultiDiGraph:
     """
     Add `length` attribute (in meters) to each edge.
@@ -470,7 +470,7 @@ def nearest_edges(
     G: nx.MultiDiGraph,
     X: float | Iterable,
     Y: float | Iterable,
-    interpolate: float = None,
+    interpolate: float | None = None,
     return_dist: bool = False,
 ) -> tuple | np.ndarray:
     """

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Literal
 from typing import overload
 from warnings import warn
 
@@ -301,6 +302,46 @@ def add_edge_lengths(
     return G
 
 
+# if X and Y are floats and return_dist is not provided (defaults False)
+@overload
+def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float) -> int:
+    ...
+
+
+# if X and Y are floats and return_dist is provided/False
+@overload
+def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[False]) -> int:
+    ...
+
+
+# if X and Y are floats and return_dist is provided/True
+@overload
+def nearest_nodes(G: nx.MultiDiGraph, X: float, Y: float, return_dist: Literal[True]) -> tuple:
+    ...
+
+
+# if X and Y are iterable and return_dist is not provided (defaults False)
+@overload
+def nearest_nodes(G: nx.MultiDiGraph, X: Iterable, Y: Iterable) -> np.ndarray:
+    ...
+
+
+# if X and Y are iterable and return_dist is provided/False
+@overload
+def nearest_nodes(
+    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, return_dist: Literal[False]
+) -> np.ndarray:
+    ...
+
+
+# if X and Y are iterable and return_dist is provided/True
+@overload
+def nearest_nodes(
+    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, return_dist: Literal[True]
+) -> tuple:
+    ...
+
+
 def nearest_nodes(
     G: nx.MultiDiGraph, X: float | Iterable, Y: float | Iterable, return_dist: bool = False
 ) -> int | np.ndarray | tuple:
@@ -332,7 +373,7 @@ def nearest_nodes(
 
     Returns
     -------
-    nn or (nn, dist) : int or np.array or a tuple of ints/np.arrays
+    nn or (nn, dist) : tuple or np.array or a tuple of (int/np.array, float/np.array)
         nearest node ID(s) or optionally a tuple of ID(s) and distance(s)
         between each point and its nearest node
     """
@@ -385,6 +426,46 @@ def nearest_nodes(
     return nn
 
 
+# if X and Y are floats and return_dist is not provided (defaults False)
+@overload
+def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float) -> tuple:
+    ...
+
+
+# if X and Y are floats and return_dist is provided/False
+@overload
+def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[False]) -> tuple:
+    ...
+
+
+# if X and Y are floats and return_dist is provided/True
+@overload
+def nearest_edges(G: nx.MultiDiGraph, X: float, Y: float, *, return_dist: Literal[True]) -> tuple:
+    ...
+
+
+# if X and Y are iterable and return_dist is not provided (defaults False)
+@overload
+def nearest_edges(G: nx.MultiDiGraph, X: Iterable, Y: Iterable) -> np.ndarray:
+    ...
+
+
+# if X and Y are iterable and return_dist is provided/False
+@overload
+def nearest_edges(
+    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, *, return_dist: Literal[False]
+) -> np.ndarray:
+    ...
+
+
+# if X and Y are iterable and return_dist is provided/True
+@overload
+def nearest_edges(
+    G: nx.MultiDiGraph, X: Iterable, Y: Iterable, *, return_dist: Literal[True]
+) -> tuple:
+    ...
+
+
 def nearest_edges(
     G: nx.MultiDiGraph,
     X: float | Iterable,
@@ -418,7 +499,7 @@ def nearest_edges(
 
     Returns
     -------
-    ne or (ne, dist) : tuple or np.array or a tuple of ints/np.arrays
+    ne or (ne, dist) : tuple or np.array or a tuple of (int/np.array, float/np.array)
         nearest edge ID(s) (as `u`, `v`, `key` tuples) or optionally a tuple
         of ID(s) and distance(s) between each point and its nearest edge
     """

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -7,6 +7,7 @@ import time
 from collections.abc import Iterable
 from hashlib import sha1
 from pathlib import Path
+from typing import Any
 from warnings import warn
 
 import networkx as nx
@@ -80,7 +81,7 @@ def add_edge_grades(
     return G
 
 
-def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip:
+def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip[Any]:
     """
     Query a raster for values at coordinates in a DataFrame's x/y columns.
 
@@ -262,7 +263,11 @@ def add_node_elevations_google(
 
         # download and append these elevation results to list of all results
         response_json = _elevation_request(url, pause)
-        if "results" in response_json and len(response_json["results"]) > 0:
+        if (
+            isinstance(response_json, dict)
+            and "results" in response_json
+            and len(response_json["results"]) > 0
+        ):
             results.extend(response_json["results"])
         else:
             raise InsufficientResponseError(str(response_json))
@@ -284,7 +289,7 @@ def add_node_elevations_google(
     return G
 
 
-def _elevation_request(url: str, pause: float) -> dict:
+def _elevation_request(url: str, pause: float) -> dict[Any, Any] | list[Any]:
     """
     Send a HTTP GET request to Google Maps-style Elevation API.
 
@@ -297,7 +302,7 @@ def _elevation_request(url: str, pause: float) -> dict:
 
     Returns
     -------
-    response_json : dict
+    response_json : dict or list
     """
     # check if request already exists in cache
     cached_response_json = _downloader._retrieve_from_cache(url)

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -303,8 +303,8 @@ def _elevation_request(url: str, pause: float) -> dict[str, Any]:
     response_json : dict
     """
     # check if request already exists in cache
-    cached_response_json: dict[str, Any] | None = _downloader._retrieve_from_cache(url)  # type: ignore[assignment]
-    if cached_response_json is not None:
+    cached_response_json = _downloader._retrieve_from_cache(url)
+    if isinstance(cached_response_json, dict):
         return cached_response_json
 
     # pause then request this URL
@@ -321,9 +321,9 @@ def _elevation_request(url: str, pause: float) -> dict[str, Any]:
         **settings.requests_kwargs,
     )
 
-    response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
-    _downloader._save_to_cache(url, response_json, response.ok)
+    response_json = _downloader._parse_response(response)
     if not isinstance(response_json, dict):
         msg = "Elevation API did not return a dict of results."
         raise TypeError(msg)
+    _downloader._save_to_cache(url, response_json, response.ok)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -81,7 +81,7 @@ def add_edge_grades(
     return G
 
 
-def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip[Any]:
+def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip[tuple[int, Any]]:
     """
     Query a raster for values at coordinates in a DataFrame's x/y columns.
 
@@ -285,7 +285,7 @@ def add_node_elevations_google(
     return G
 
 
-def _elevation_request(url: str, pause: float) -> dict[Any, Any]:
+def _elevation_request(url: str, pause: float) -> dict[str, Any]:
     """
     Send a HTTP GET request to Google Maps-style Elevation API.
 

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -301,7 +301,7 @@ def _elevation_request(url: str, pause: float) -> dict[Any, Any]:
     response_json : dict
     """
     # check if request already exists in cache
-    cached_response_json: dict[Any, Any] | None = _downloader._retrieve_from_cache(url)  # type: ignore[assignment]
+    cached_response_json: dict[str, Any] | None = _downloader._retrieve_from_cache(url)  # type: ignore[assignment]
     if cached_response_json is not None:
         return cached_response_json
 
@@ -319,6 +319,6 @@ def _elevation_request(url: str, pause: float) -> dict[Any, Any]:
         **settings.requests_kwargs,
     )
 
-    response_json: dict[Any, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
+    response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(url, response_json, response.ok)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -322,7 +322,7 @@ def _elevation_request(url: str, pause: float) -> dict[str, Any]:
     )
 
     response_json = _downloader._parse_response(response)
-    if not isinstance(response_json, dict):
+    if not isinstance(response_json, dict):  # pragma: no cover
         msg = "Elevation API did not return a dict of results."
         raise InsufficientResponseError(msg)
     _downloader._save_to_cache(url, response_json, response.ok)

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -171,12 +171,12 @@ def add_node_elevations_raster(
 
 def add_node_elevations_google(
     G: nx.MultiDiGraph,
-    api_key: str | None = None,
+    api_key: str = None,
     batch_size: int = 350,
     pause: float = 0,
-    max_locations_per_batch: int | None = None,
-    precision: int | None = None,
-    url_template: str | None = None,
+    max_locations_per_batch: int = None,
+    precision: int = None,
+    url_template: str = None,
 ) -> nx.MultiDiGraph:
     """
     Add an `elevation` (meters) attribute to each node using a web service.

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import time
+from collections.abc import Iterable
 from hashlib import sha1
 from pathlib import Path
 from warnings import warn
@@ -106,14 +107,14 @@ def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip:
 
 def add_node_elevations_raster(
     G: nx.MultiDiGraph,
-    filepath: str | Path | list[str | Path],
+    filepath: str | Path | Iterable[str | Path],
     band: int = 1,
     cpus: int | None = None,
 ) -> nx.MultiDiGraph:
     """
     Add `elevation` attribute to each node from local raster file(s).
 
-    If `filepath` is a list of paths, this will generate a virtual raster
+    If `filepath` is an iterable of paths, this will generate a virtual raster
     composed of the files at those paths as an intermediate step.
 
     See also the `add_edge_grades` function.
@@ -122,8 +123,8 @@ def add_node_elevations_raster(
     ----------
     G : networkx.MultiDiGraph
         input graph, in same CRS as raster
-    filepath : string or pathlib.Path or list of strings/Paths
-        the path (or list of paths) to the raster file(s) to query
+    filepath : string or pathlib.Path or iterable of strings/Paths
+        the path(s) to the raster file(s) to query
     band : int
         which raster band to query
     cpus : int
@@ -143,8 +144,8 @@ def add_node_elevations_raster(
     cpus = min(cpus, mp.cpu_count())
     utils.log(f"Attaching elevations with {cpus} CPUs...")
 
-    # if a list of filepaths is passed, compose them all as a virtual raster
-    # use the sha1 hash of the filepaths list as the vrt filename
+    # if multiple filepaths are passed in, compose them as a virtual raster
+    # use the sha1 hash of the filepaths object as the vrt filename
     if not isinstance(filepath, (str, Path)):
         filepaths = [str(p) for p in filepath]
         sha = sha1(str(filepaths).encode("utf-8")).hexdigest()

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -263,11 +263,7 @@ def add_node_elevations_google(
 
         # download and append these elevation results to list of all results
         response_json = _elevation_request(url, pause)
-        if (
-            isinstance(response_json, dict)
-            and "results" in response_json
-            and len(response_json["results"]) > 0
-        ):
+        if "results" in response_json and len(response_json["results"]) > 0:
             results.extend(response_json["results"])
         else:
             raise InsufficientResponseError(str(response_json))
@@ -289,7 +285,7 @@ def add_node_elevations_google(
     return G
 
 
-def _elevation_request(url: str, pause: float) -> dict[Any, Any] | list[Any]:
+def _elevation_request(url: str, pause: float) -> dict[Any, Any]:
     """
     Send a HTTP GET request to Google Maps-style Elevation API.
 
@@ -302,10 +298,10 @@ def _elevation_request(url: str, pause: float) -> dict[Any, Any] | list[Any]:
 
     Returns
     -------
-    response_json : dict or list
+    response_json : dict
     """
     # check if request already exists in cache
-    cached_response_json = _downloader._retrieve_from_cache(url)
+    cached_response_json: dict[Any, Any] | None = _downloader._retrieve_from_cache(url)  # type: ignore[assignment]
     if cached_response_json is not None:
         return cached_response_json
 
@@ -323,6 +319,6 @@ def _elevation_request(url: str, pause: float) -> dict[Any, Any] | list[Any]:
         **settings.requests_kwargs,
     )
 
-    response_json = _downloader._parse_response(response)
+    response_json: dict[Any, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(url, response_json, response.ok)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -81,7 +81,9 @@ def add_edge_grades(
     return G
 
 
-def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip[tuple[int, Any]]:
+def _query_raster(
+    nodes: pd.DataFrame, filepath: str | Path, band: int
+) -> Iterable[tuple[int, Any]]:
     """
     Query a raster for values at coordinates in a DataFrame's x/y columns.
 
@@ -321,4 +323,7 @@ def _elevation_request(url: str, pause: float) -> dict[str, Any]:
 
     response_json: dict[str, Any] = _downloader._parse_response(response)  # type: ignore[assignment]
     _downloader._save_to_cache(url, response_json, response.ok)
+    if not isinstance(response_json, dict):
+        msg = "Elevation API did not return a dict of results."
+        raise TypeError(msg)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -1,5 +1,7 @@
 """Add node elevations from raster files or web APIs, and calculate edge grades."""
 
+from __future__ import annotations
+
 import multiprocessing as mp
 import time
 from hashlib import sha1
@@ -25,7 +27,9 @@ except ImportError:  # pragma: no cover
     rasterio = gdal = None
 
 
-def add_edge_grades(G, add_absolute=True, precision=None):
+def add_edge_grades(
+    G: nx.MultiDiGraph, add_absolute: bool = True, precision: int = None
+) -> nx.MultiDiGraph:
     """
     Add `grade` attribute to each graph edge.
 
@@ -75,7 +79,7 @@ def add_edge_grades(G, add_absolute=True, precision=None):
     return G
 
 
-def _query_raster(nodes, filepath, band):
+def _query_raster(nodes: pd.DataFrame, filepath: str | Path, band: int) -> zip:
     """
     Query a raster for values at coordinates in a DataFrame's x/y columns.
 
@@ -100,7 +104,12 @@ def _query_raster(nodes, filepath, band):
         return zip(nodes.index, values)
 
 
-def add_node_elevations_raster(G, filepath, band=1, cpus=None):
+def add_node_elevations_raster(
+    G: nx.MultiDiGraph,
+    filepath: str | Path | list[str | Path],
+    band: int = 1,
+    cpus: int | None = None,
+) -> nx.MultiDiGraph:
     """
     Add `elevation` attribute to each node from local raster file(s).
 
@@ -114,7 +123,7 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
     G : networkx.MultiDiGraph
         input graph, in same CRS as raster
     filepath : string or pathlib.Path or list of strings/Paths
-        path (or list of paths) to the raster file(s) to query
+        the path (or list of paths) to the raster file(s) to query
     band : int
         which raster band to query
     cpus : int
@@ -161,14 +170,14 @@ def add_node_elevations_raster(G, filepath, band=1, cpus=None):
 
 
 def add_node_elevations_google(
-    G,
-    api_key=None,
-    batch_size=350,
-    pause=0,
-    max_locations_per_batch=None,
-    precision=None,
-    url_template=None,
-):
+    G: nx.MultiDiGraph,
+    api_key: str | None = None,
+    batch_size: int = 350,
+    pause: float = 0,
+    max_locations_per_batch: int | None = None,
+    precision: int | None = None,
+    url_template: str | None = None,
+) -> nx.MultiDiGraph:
     """
     Add an `elevation` (meters) attribute to each node using a web service.
 
@@ -274,7 +283,7 @@ def add_node_elevations_google(
     return G
 
 
-def _elevation_request(url, pause):
+def _elevation_request(url: str, pause: float) -> dict:
     """
     Send a HTTP GET request to Google Maps-style Elevation API.
 
@@ -309,5 +318,5 @@ def _elevation_request(url, pause):
     )
 
     response_json = _downloader._parse_response(response)
-    _downloader._save_to_cache(url, response_json, response.status_code)
+    _downloader._save_to_cache(url, response_json, response.ok)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -324,6 +324,6 @@ def _elevation_request(url: str, pause: float) -> dict[str, Any]:
     response_json = _downloader._parse_response(response)
     if not isinstance(response_json, dict):
         msg = "Elevation API did not return a dict of results."
-        raise TypeError(msg)
+        raise InsufficientResponseError(msg)
     _downloader._save_to_cache(url, response_json, response.ok)
     return response_json

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
 
 
 def add_edge_grades(
-    G: nx.MultiDiGraph, add_absolute: bool = True, precision: int = None
+    G: nx.MultiDiGraph, add_absolute: bool = True, precision: int | None = None
 ) -> nx.MultiDiGraph:
     """
     Add `grade` attribute to each graph edge.
@@ -172,12 +172,12 @@ def add_node_elevations_raster(
 
 def add_node_elevations_google(
     G: nx.MultiDiGraph,
-    api_key: str = None,
+    api_key: str | None = None,
     batch_size: int = 350,
     pause: float = 0,
-    max_locations_per_batch: int = None,
-    precision: int = None,
-    url_template: str = None,
+    max_locations_per_batch: int | None = None,
+    precision: int | None = None,
+    url_template: str | None = None,
 ) -> nx.MultiDiGraph:
     """
     Add an `elevation` (meters) attribute to each node using a web service.

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -43,7 +43,7 @@ from ._errors import InsufficientResponseError
 
 # dict of tags to determine if closed ways should be polygons, based on JSON
 # from https://wiki.openstreetmap.org/wiki/Overpass_turbo/Polygon_Features
-_POLYGON_FEATURES = {
+_POLYGON_FEATURES: dict[str, dict[str, str | list[str]]] = {
     "building": {"polygon": "all"},
     "highway": {"polygon": "passlist", "values": ["services", "rest_area", "escape", "elevator"]},
     "natural": {
@@ -700,10 +700,10 @@ def _is_closed_way_a_polygon(element: dict) -> bool:
 
                 # Determine if the key is for a blocklist or passlist in
                 # _POLYGON_FEATURES dict
-                blocklist_or_passlist = _POLYGON_FEATURES.get(key).get("polygon")
+                blocklist_or_passlist = _POLYGON_FEATURES[key].get("polygon")
 
                 # Get values for the key from the _POLYGON_FEATURES dict
-                polygon_features_values = _POLYGON_FEATURES.get(key).get("values")
+                polygon_features_values = _POLYGON_FEATURES[key].get("values")
 
                 # if all features with that key should be polygons -> Polygon
                 if blocklist_or_passlist == "all":
@@ -714,14 +714,14 @@ def _is_closed_way_a_polygon(element: dict) -> bool:
                 elif blocklist_or_passlist == "blocklist":
                     # if the value for that key in the element is not in
                     # the blocklist -> Polygon
-                    if key_value not in polygon_features_values:
+                    if key_value not in polygon_features_values:  # type: ignore[operator]
                         is_polygon = True
 
                 # if the key is for a passlist i.e. specific tags should
                 # become Polygons, and if the value for that key in the
                 # element is in the passlist -> Polygon
                 elif (blocklist_or_passlist == "passlist") and (
-                    key_value in polygon_features_values
+                    key_value in polygon_features_values  # type: ignore[operator]
                 ):
                     is_polygon = True
 

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -214,7 +214,10 @@ def features_from_address(address: str, tags: dict, dist: float = 1000) -> gpd.G
 
 
 def features_from_place(
-    query: str | dict | list, tags: dict, which_result: int = None, buffer_dist: float = None
+    query: str | dict | list,
+    tags: dict,
+    which_result: int | None = None,
+    buffer_dist: float | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Create GeoDataFrame of OSM features within boundaries of some place(s).
@@ -345,7 +348,10 @@ def features_from_polygon(polygon: Polygon | MultiPolygon, tags: dict) -> gpd.Ge
 
 
 def features_from_xml(
-    filepath: str | Path, polygon: Polygon = None, tags: dict = None, encoding: str = "utf-8"
+    filepath: str | Path,
+    polygon: Polygon | None = None,
+    tags: dict | None = None,
+    encoding: str = "utf-8",
 ) -> gpd.GeoDataFrame:
     """
     Create a GeoDataFrame of OSM features in an OSM-formatted XML file.

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -420,7 +420,7 @@ def _create_gdf(
     Parameters
     ----------
     response_jsons : iterable
-        iterable of JSON responses from from the Overpass API
+        iterable of JSON response dicts from from the Overpass API
     polygon : shapely.geometry.Polygon or shapely.geometry.MultiPolygon
         geographic boundary used for filtering the final GeoDataFrame
     tags : dict

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -405,7 +405,7 @@ def features_from_xml(
 
 
 def _create_gdf(
-    response_jsons: Iterable[dict[Any, Any] | list[Any]],
+    response_jsons: Iterable[dict[str, Any]],
     polygon: Polygon,
     tags: dict[str, bool | str | list[str]] | None,
 ) -> gpd.GeoDataFrame:
@@ -457,7 +457,7 @@ def _create_gdf(
         # Parses the JSON of OSM nodes, ways and (multipolygon) relations
         # to dictionaries of coordinates, Shapely Points, LineStrings,
         # Polygons and MultiPolygons
-        for element in response_json["elements"]:  # type: ignore[call-overload]
+        for element in response_json["elements"]:
             # id numbers are only unique within element types
             # create unique id from combination of type and id
             unique_id = f"{element['type']}/{element['id']}"

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -67,7 +67,7 @@ def plot_graph_folium(  # type: ignore[no-untyped-def]
     )
     # create gdf of all graph edges
     gdf_edges = utils_graph.graph_to_gdfs(G, nodes=False)
-    return _plot_folium(gdf_edges, graph_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)
+    return _plot_folium(gdf_edges, graph_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)  # type: ignore[no-untyped-call]
 
 
 def plot_route_folium(  # type: ignore[no-untyped-def]
@@ -123,7 +123,7 @@ def plot_route_folium(  # type: ignore[no-untyped-def]
     node_pairs = zip(route[:-1], route[1:])
     uvk = ((u, v, min(G[u][v].items(), key=lambda k: k[1]["length"])[0]) for u, v in node_pairs)
     gdf_edges = utils_graph.graph_to_gdfs(G.subgraph(route), nodes=False).loc[uvk]
-    return _plot_folium(gdf_edges, route_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)
+    return _plot_folium(gdf_edges, route_map, popup_attribute, tiles, zoom, fit_bounds, **kwargs)  # type: ignore[no-untyped-call]
 
 
 def _plot_folium(gdf, m, popup_attribute, tiles, zoom, fit_bounds, **kwargs):  # type: ignore[no-untyped-def]
@@ -170,7 +170,7 @@ def _plot_folium(gdf, m, popup_attribute, tiles, zoom, fit_bounds, **kwargs):  #
     # add each edge to the map
     for vals in gdf[attrs].to_numpy():
         params = dict(zip(["geom", "popup_val"], vals))
-        pl = _make_folium_polyline(**params, **kwargs)
+        pl = _make_folium_polyline(**params, **kwargs)  # type: ignore[no-untyped-call]
         pl.add_to(m)
 
     # if fit_bounds is True, fit the map to the bounds of the route by passing

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -45,7 +45,7 @@ def geocode(query: str) -> tuple[float, float]:
     params["limit"] = 1
     params["dedupe"] = 0  # prevent deduping to get precise number of results
     params["q"] = query
-    response_json = _nominatim._nominatim_request(params=params)
+    response_json: list[dict[str, Any]] = _nominatim._nominatim_request(params=params)
 
     # if results were returned, parse lat and lon out of the result
     if response_json and "lat" in response_json[0] and "lon" in response_json[0]:

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -45,7 +45,7 @@ def geocode(query: str) -> tuple[float, float]:
     params["limit"] = 1
     params["dedupe"] = 0  # prevent deduping to get precise number of results
     params["q"] = query
-    response_json: list[dict[str, Any]] = _nominatim._nominatim_request(params=params)
+    response_json = _nominatim._nominatim_request(params=params)
 
     # if results were returned, parse lat and lon out of the result
     if response_json and "lat" in response_json[0] and "lon" in response_json[0]:

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -62,9 +62,9 @@ def geocode(query: str) -> tuple:
 
 def geocode_to_gdf(
     query: str | dict | list[str | dict],
-    which_result: int = None,
+    which_result: int | None = None,
     by_osmid: bool = False,
-    buffer_dist: float = None,
+    buffer_dist: float | None = None,
 ) -> gpd.GeoDataFrame:
     """
     Retrieve OSM elements by place name or OSM ID with the Nominatim API.

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -189,7 +189,7 @@ def _geocode_query_to_gdf(
     results = _nominatim._download_nominatim_element(query, by_osmid=by_osmid, limit=limit)
 
     # choose the right result from the JSON response
-    if not results:
+    if len(results) == 0:
         # if no results were returned, raise error
         msg = f"Nominatim geocoder returned 0 results for query {query!r}"
         raise InsufficientResponseError(msg)

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -136,8 +136,7 @@ def geocode_to_gdf(
 
     # for each query and which_result value
     gdf = gpd.GeoDataFrame()
-    wr: int
-    for q, wr in zip(query_list, which_result_list):  # type: ignore[assignment]
+    for q, wr in zip(query_list, which_result_list):
         # ensure each query is correct type
         if not isinstance(q, (str, dict)):  # pragma: no cover
             msg = "each query must be a string or dict"

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -162,7 +162,7 @@ def geocode_to_gdf(
 
 
 def _geocode_query_to_gdf(
-    query: str | dict[str, str], which_result: int, by_osmid: bool
+    query: str | dict[str, str], which_result: int | None, by_osmid: bool
 ) -> gpd.GeoDataFrame:
     """
     Geocode a single place query to a GeoDataFrame.
@@ -242,7 +242,9 @@ def _geocode_query_to_gdf(
     return gdf
 
 
-def _get_first_polygon(results: list[dict[str, Any]], query: str) -> dict[str, Any]:
+def _get_first_polygon(
+    results: list[dict[str, Any]], query: str | dict[str, str]
+) -> dict[str, Any]:
     """
     Choose first result of geometry type (Multi)Polygon from list of results.
 

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -23,7 +23,7 @@ from . import utils
 from ._errors import InsufficientResponseError
 
 
-def geocode(query: str) -> tuple:
+def geocode(query: str) -> tuple[float, float]:
     """
     Geocode place names or addresses to (lat, lon) with the Nominatim API.
 
@@ -40,7 +40,7 @@ def geocode(query: str) -> tuple:
         the (lat, lon) coordinates returned by the geocoder
     """
     # define the parameters
-    params: OrderedDict[Any] = OrderedDict()
+    params: OrderedDict[str, Any] = OrderedDict()
     params["format"] = "json"
     params["limit"] = 1
     params["dedupe"] = 0  # prevent deduping to get precise number of results
@@ -61,7 +61,7 @@ def geocode(query: str) -> tuple:
 
 
 def geocode_to_gdf(
-    query: str | dict | list[str | dict],
+    query: str | dict[str, str] | list[str | dict[str, str]],
     which_result: int | None = None,
     by_osmid: bool = False,
     buffer_dist: float | None = None,
@@ -161,7 +161,9 @@ def geocode_to_gdf(
     return gdf
 
 
-def _geocode_query_to_gdf(query: str | dict, which_result: int, by_osmid: bool) -> gpd.GeoDataFrame:
+def _geocode_query_to_gdf(
+    query: str | dict[str, str], which_result: int, by_osmid: bool
+) -> gpd.GeoDataFrame:
     """
     Geocode a single place query to a GeoDataFrame.
 
@@ -240,7 +242,7 @@ def _geocode_query_to_gdf(query: str | dict, which_result: int, by_osmid: bool) 
     return gdf
 
 
-def _get_first_polygon(results: list, query: str) -> dict:
+def _get_first_polygon(results: list[dict[str, Any]], query: str) -> dict[str, Any]:
     """
     Choose first result of geometry type (Multi)Polygon from list of results.
 
@@ -257,7 +259,7 @@ def _get_first_polygon(results: list, query: str) -> dict:
         the chosen result
     """
     polygon_types = {"Polygon", "MultiPolygon"}
-    result: dict
+
     for result in results:
         if "geojson" in result and result["geojson"]["type"] in polygon_types:
             return result

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -40,7 +40,7 @@ def geocode(query: str) -> tuple[float, float]:
         the (lat, lon) coordinates returned by the geocoder
     """
     # define the parameters
-    params: OrderedDict[str, Any] = OrderedDict()
+    params: OrderedDict[str, int | str] = OrderedDict()
     params["format"] = "json"
     params["limit"] = 1
     params["dedupe"] = 0  # prevent deduping to get precise number of results

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -10,6 +10,7 @@ Refer to the Getting Started guide for usage limitations.
 from __future__ import annotations
 
 import itertools
+from collections.abc import Generator
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
@@ -480,9 +481,9 @@ def graph_from_polygon(
         poly_buff, _ = projection.project_geometry(poly_proj_buff, crs=crs_utm, to_latlong=True)
 
         # download the network data from OSM within buffered polygon
-        response_jsons = _overpass._download_overpass_network(
-            poly_buff, network_type, custom_filter
-        )
+        response_jsons: Generator[
+            dict[Any, Any], None, None
+        ] = _overpass._download_overpass_network(poly_buff, network_type, custom_filter)
 
         # create buffered graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types
@@ -592,7 +593,7 @@ def graph_from_xml(
 
 
 def _create_graph(
-    response_jsons: Iterable[dict[Any, Any] | list[Any]],
+    response_jsons: Iterable[dict[Any, Any]],
     retain_all: bool = False,
     bidirectional: bool = False,
 ) -> nx.MultiDiGraph:
@@ -631,7 +632,7 @@ def _create_graph(
             continue
 
         # otherwise, extract nodes and paths from the downloaded OSM data
-        nodes_temp, paths_temp = _parse_nodes_paths(response_json)  # type: ignore[arg-type]
+        nodes_temp, paths_temp = _parse_nodes_paths(response_json)
         nodes.update(nodes_temp)
         paths.update(paths_temp)
 

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -607,7 +607,7 @@ def _create_graph(
     Parameters
     ----------
     response_jsons : iterable
-        iterable of dicts of JSON responses from from the Overpass API
+        iterable of dicts of JSON responses from the Overpass API
     retain_all : bool
         if True, return the entire graph even if it is not connected.
         otherwise, retain only the largest weakly connected component.

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -44,8 +44,8 @@ def graph_from_bbox(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    clean_periphery: bool = None,
-    custom_filter: str = None,
+    clean_periphery: bool | None = None,
+    custom_filter: str | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within some bounding box.
@@ -118,8 +118,8 @@ def graph_from_point(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    clean_periphery: bool = None,
-    custom_filter: str = None,
+    clean_periphery: bool | None = None,
+    custom_filter: str | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within some distance of a (lat, lon) point.
@@ -206,9 +206,9 @@ def graph_from_address(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    return_coords: bool = None,
-    clean_periphery: bool = None,
-    custom_filter: str = None,
+    return_coords: bool | None = None,
+    clean_periphery: bool | None = None,
+    custom_filter: str | None = None,
 ) -> nx.MultiDiGraph | tuple:
     """
     Download and create a graph within some distance of an address.
@@ -298,10 +298,10 @@ def graph_from_place(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    which_result: int = None,
-    buffer_dist: float = None,
-    clean_periphery: bool = None,
-    custom_filter: str = None,
+    which_result: int | None = None,
+    buffer_dist: float | None = None,
+    clean_periphery: bool | None = None,
+    custom_filter: str | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within the boundaries of some place(s).
@@ -405,8 +405,8 @@ def graph_from_polygon(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    clean_periphery: bool = None,
-    custom_filter: str = None,
+    clean_periphery: bool | None = None,
+    custom_filter: str | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within the boundaries of a (multi)polygon.

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -10,7 +10,6 @@ Refer to the Getting Started guide for usage limitations.
 from __future__ import annotations
 
 import itertools
-from collections.abc import Generator
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
@@ -481,9 +480,9 @@ def graph_from_polygon(
         poly_buff, _ = projection.project_geometry(poly_proj_buff, crs=crs_utm, to_latlong=True)
 
         # download the network data from OSM within buffered polygon
-        response_jsons: Generator[
-            dict[str, Any], None, None
-        ] = _overpass._download_overpass_network(poly_buff, network_type, custom_filter)
+        response_jsons = _overpass._download_overpass_network(
+            poly_buff, network_type, custom_filter
+        )
 
         # create buffered graph from the downloaded data
         bidirectional = network_type in settings.bidirectional_network_types
@@ -607,7 +606,7 @@ def _create_graph(
     Parameters
     ----------
     response_jsons : iterable
-        iterable of dicts of JSON responses from the Overpass API
+        iterable of JSON responses dicts from the Overpass API
     retain_all : bool
         if True, return the entire graph even if it is not connected.
         otherwise, retain only the largest weakly connected component.

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -593,7 +593,7 @@ def graph_from_xml(
 
 
 def _create_graph(
-    response_jsons: Iterable[dict[Any, Any]],
+    response_jsons: Iterable[dict[str, Any]],
     retain_all: bool = False,
     bidirectional: bool = False,
 ) -> nx.MultiDiGraph:
@@ -720,7 +720,7 @@ def _convert_path(element: dict[str, Any]) -> dict[str, Any]:
 
 
 def _parse_nodes_paths(
-    response_json: dict[Any, Any],
+    response_json: dict[str, Any],
 ) -> tuple[dict[int, dict[str, Any]], dict[int, dict[str, Any]]]:
     """
     Construct dicts of nodes and paths from an Overpass response.

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -482,7 +482,7 @@ def graph_from_polygon(
 
         # download the network data from OSM within buffered polygon
         response_jsons: Generator[
-            dict[Any, Any], None, None
+            dict[str, Any], None, None
         ] = _overpass._download_overpass_network(poly_buff, network_type, custom_filter)
 
         # create buffered graph from the downloaded data

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 import contextlib
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 from warnings import warn
@@ -292,7 +291,7 @@ def load_graphml(
 
 
 def save_graph_xml(
-    data: nx.MultiDiGraph | Iterable[gpd.GeoDataFrame],
+    data: nx.MultiDiGraph | tuple[gpd.GeoDataFrame, gpd.GeoDataFrame],
     filepath: str | Path | None = None,
     node_tags: list[str] = settings.osm_xml_node_tags,
     node_attrs: list[str] = settings.osm_xml_node_attrs,
@@ -339,8 +338,8 @@ def save_graph_xml(
 
     Parameters
     ----------
-    data : networkx multi(di)graph OR a length 2 iterable of nodes/edges
-        geopandas GeoDataFrames
+    data : networkx.MultiDiGraph or tuple of GeoDataFrames
+        either a MultiDiGraph or (gdf_nodes, gdf_edges) tuple
     filepath : string or pathlib.Path
         path to the .osm file including extension. if None, use default data
         folder + graph.osm

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -6,6 +6,7 @@ import ast
 import contextlib
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 from warnings import warn
 
 import geopandas as gpd
@@ -186,9 +187,9 @@ def save_graphml(
 def load_graphml(
     filepath: str | Path | None = None,
     graphml_str: str | None = None,
-    node_dtypes: dict | None = None,
-    edge_dtypes: dict | None = None,
-    graph_dtypes: dict | None = None,
+    node_dtypes: dict[str, Any] | None = None,
+    edge_dtypes: dict[str, Any] | None = None,
+    graph_dtypes: dict[str, Any] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Load an OSMnx-saved GraphML file from disk or GraphML string.
@@ -291,15 +292,15 @@ def load_graphml(
 
 
 def save_graph_xml(
-    data: nx.MultiDiGraph | Iterable,
+    data: nx.MultiDiGraph | Iterable[gpd.GeoDataFrame],
     filepath: str | Path | None = None,
-    node_tags: list = settings.osm_xml_node_tags,
-    node_attrs: list = settings.osm_xml_node_attrs,
-    edge_tags: list = settings.osm_xml_way_tags,
-    edge_attrs: list = settings.osm_xml_way_attrs,
+    node_tags: list[str] = settings.osm_xml_node_tags,
+    node_attrs: list[str] = settings.osm_xml_node_attrs,
+    edge_tags: list[str] = settings.osm_xml_way_tags,
+    edge_attrs: list[str] = settings.osm_xml_way_attrs,
     oneway: bool = False,
     merge_edges: bool = True,
-    edge_tag_aggs: list | None = None,
+    edge_tag_aggs: list[tuple[str, str]] | None = None,
     api_version: float = 0.6,
     precision: int = 6,
 ) -> None:
@@ -391,7 +392,7 @@ def save_graph_xml(
     )
 
 
-def _convert_graph_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
+def _convert_graph_attr_types(G: nx.MultiDiGraph, dtypes: dict[str, Any]) -> nx.MultiDiGraph:
     """
     Convert graph-level attributes using a dict of data types.
 
@@ -416,7 +417,7 @@ def _convert_graph_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGra
     return G
 
 
-def _convert_node_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
+def _convert_node_attr_types(G: nx.MultiDiGraph, dtypes: dict[str, Any]) -> nx.MultiDiGraph:
     """
     Convert graph nodes' attributes using a dict of data types.
 
@@ -446,7 +447,7 @@ def _convert_node_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGrap
     return G
 
 
-def _convert_edge_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
+def _convert_edge_attr_types(G: nx.MultiDiGraph, dtypes: dict[str, Any]) -> nx.MultiDiGraph:
     """
     Convert graph edges' attributes using a dict of data types.
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -22,8 +22,8 @@ from . import utils_graph
 def save_graph_geopackage(
     G: nx.MultiDiGraph,
     filepath: str | Path | None = None,
-    encoding: str = "utf-8",
     directed: bool = False,
+    encoding: str = "utf-8",
 ) -> None:
     """
     Save graph nodes and edges to disk as layers in a GeoPackage file.
@@ -35,12 +35,12 @@ def save_graph_geopackage(
     filepath : string or pathlib.Path
         path to the GeoPackage file including extension. if None, use default
         data folder + graph.gpkg
-    encoding : string
-        the character encoding for the saved file
     directed : bool
         if False, save one edge for each undirected edge in the graph but
         retain original oneway and to/from information as edge attributes; if
         True, save one edge for each directed edge in the graph
+    encoding : string
+        the character encoding for the saved file
 
     Returns
     -------
@@ -300,7 +300,7 @@ def save_graph_xml(
     oneway: bool = False,
     merge_edges: bool = True,
     edge_tag_aggs: list[tuple[str, str]] | None = None,
-    api_version: float = 0.6,
+    api_version: str = "0.6",
     precision: int = 6,
 ) -> None:
     """
@@ -367,7 +367,7 @@ def save_graph_xml(
         this method to aggregate the lengths of the individual
         component edges. Otherwise, the length attribute will simply
         reflect the length of the first edge associated with the way.
-    api_version : float
+    api_version : string
         OpenStreetMap API version to write to the XML file header
     precision : int
         number of decimal places to round latitude and longitude values

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -493,7 +493,7 @@ def _convert_edge_attr_types(G: nx.MultiDiGraph, dtypes: dict[str, Any]) -> nx.M
     return G
 
 
-def _convert_bool_string(value: str) -> bool:
+def _convert_bool_string(value: bool | str) -> bool:
     """
     Convert a "True" or "False" string literal to corresponding boolean type.
 
@@ -506,18 +506,18 @@ def _convert_bool_string(value: str) -> bool:
 
     Parameters
     ----------
-    value : string {"True", "False"}
+    value : bool or string {"True", "False"}
         the value to convert
 
     Returns
     -------
     bool
     """
-    if value in {"True", "False"}:
-        return value == "True"
-
     if isinstance(value, bool):
         return value
+
+    if value in {"True", "False"}:
+        return value == "True"
 
     # otherwise the value is not a valid boolean
     msg = f"invalid literal for boolean: {value!r}"

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -1,10 +1,14 @@
 """Serialize graphs to/from files on disk."""
 
+from __future__ import annotations
+
 import ast
 import contextlib
+from collections.abc import Iterable
 from pathlib import Path
 from warnings import warn
 
+import geopandas as gpd
 import networkx as nx
 import pandas as pd
 from shapely import wkt
@@ -15,7 +19,12 @@ from . import utils
 from . import utils_graph
 
 
-def save_graph_geopackage(G, filepath=None, encoding="utf-8", directed=False):
+def save_graph_geopackage(
+    G: nx.MultiDiGraph,
+    filepath: str | Path | None = None,
+    encoding: str = "utf-8",
+    directed: bool = False,
+) -> None:
     """
     Save graph nodes and edges to disk as layers in a GeoPackage file.
 
@@ -57,7 +66,7 @@ def save_graph_geopackage(G, filepath=None, encoding="utf-8", directed=False):
     utils.log(f"Saved graph as GeoPackage at {filepath!r}")
 
 
-def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
+def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):  # type: ignore[no-untyped-def]
     """
     Do not use: deprecated. Use the save_graph_geopackage function instead.
 
@@ -115,7 +124,12 @@ def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
     utils.log(f"Saved graph as shapefiles at {filepath!r}")
 
 
-def save_graphml(G, filepath=None, gephi=False, encoding="utf-8"):
+def save_graphml(
+    G: nx.MultiDiGraph,
+    filepath: str | Path | None = None,
+    gephi: bool = False,
+    encoding: str = "utf-8",
+) -> None:
     """
     Save graph to disk as GraphML file.
 
@@ -170,8 +184,12 @@ def save_graphml(G, filepath=None, gephi=False, encoding="utf-8"):
 
 
 def load_graphml(
-    filepath=None, graphml_str=None, node_dtypes=None, edge_dtypes=None, graph_dtypes=None
-):
+    filepath: str | Path | None = None,
+    graphml_str: str = None,
+    node_dtypes: dict = None,
+    edge_dtypes: dict = None,
+    graph_dtypes: dict = None,
+) -> nx.MultiDiGraph:
     """
     Load an OSMnx-saved GraphML file from disk or GraphML string.
 
@@ -273,18 +291,18 @@ def load_graphml(
 
 
 def save_graph_xml(
-    data,
-    filepath=None,
-    node_tags=settings.osm_xml_node_tags,
-    node_attrs=settings.osm_xml_node_attrs,
-    edge_tags=settings.osm_xml_way_tags,
-    edge_attrs=settings.osm_xml_way_attrs,
-    oneway=False,
-    merge_edges=True,
-    edge_tag_aggs=None,
-    api_version=0.6,
-    precision=6,
-):
+    data: nx.MultiDiGraph | Iterable,
+    filepath: str | Path | None = None,
+    node_tags: list = settings.osm_xml_node_tags,
+    node_attrs: list = settings.osm_xml_node_attrs,
+    edge_tags: list = settings.osm_xml_way_tags,
+    edge_attrs: list = settings.osm_xml_way_attrs,
+    oneway: bool = False,
+    merge_edges: bool = True,
+    edge_tag_aggs: list = None,
+    api_version: float = 0.6,
+    precision: int = 6,
+) -> None:
     """
     Save graph to disk as an OSM-formatted XML .osm file.
 
@@ -373,7 +391,7 @@ def save_graph_xml(
     )
 
 
-def _convert_graph_attr_types(G, dtypes=None):
+def _convert_graph_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
     """
     Convert graph-level attributes using a dict of data types.
 
@@ -398,7 +416,7 @@ def _convert_graph_attr_types(G, dtypes=None):
     return G
 
 
-def _convert_node_attr_types(G, dtypes=None):
+def _convert_node_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
     """
     Convert graph nodes' attributes using a dict of data types.
 
@@ -428,7 +446,7 @@ def _convert_node_attr_types(G, dtypes=None):
     return G
 
 
-def _convert_edge_attr_types(G, dtypes=None):
+def _convert_edge_attr_types(G: nx.MultiDiGraph, dtypes: dict) -> nx.MultiDiGraph:
     """
     Convert graph edges' attributes using a dict of data types.
 
@@ -474,7 +492,7 @@ def _convert_edge_attr_types(G, dtypes=None):
     return G
 
 
-def _convert_bool_string(value):
+def _convert_bool_string(value: str) -> bool:
     """
     Convert a "True" or "False" string literal to corresponding boolean type.
 
@@ -505,7 +523,7 @@ def _convert_bool_string(value):
     raise ValueError(msg)
 
 
-def _stringify_nonnumeric_cols(gdf):
+def _stringify_nonnumeric_cols(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """
     Make every non-numeric GeoDataFrame column (besides geometry) a string.
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -185,10 +185,10 @@ def save_graphml(
 
 def load_graphml(
     filepath: str | Path | None = None,
-    graphml_str: str = None,
-    node_dtypes: dict = None,
-    edge_dtypes: dict = None,
-    graph_dtypes: dict = None,
+    graphml_str: str | None = None,
+    node_dtypes: dict | None = None,
+    edge_dtypes: dict | None = None,
+    graph_dtypes: dict | None = None,
 ) -> nx.MultiDiGraph:
     """
     Load an OSMnx-saved GraphML file from disk or GraphML string.
@@ -299,7 +299,7 @@ def save_graph_xml(
     edge_attrs: list = settings.osm_xml_way_attrs,
     oneway: bool = False,
     merge_edges: bool = True,
-    edge_tag_aggs: list = None,
+    edge_tag_aggs: list | None = None,
     api_version: float = 0.6,
     precision: int = 6,
 ) -> None:

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -68,7 +68,7 @@ class _OSMContentHandler(xml.sax.handler.ContentHandler):
             self.object["elements"].append(self._element)
 
 
-def _overpass_json_from_file(filepath: str | Path, encoding: str) -> dict[Any, Any]:
+def _overpass_json_from_file(filepath: str | Path, encoding: str) -> dict[str, Any]:
     """
     Read OSM XML from file and return Overpass-like JSON.
 

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -373,7 +373,7 @@ def _create_way_for_each_edge(
 
 def _append_merged_edge_attrs(
     xml_edge: ET.Element,
-    sample_edge: pd.Series[Any],
+    sample_edge: dict[str, Any],
     all_edges_df: pd.DataFrame,
     edge_tags: list[str],
     edge_tag_aggs: list[tuple[str, str]] | None,
@@ -385,8 +385,8 @@ def _append_merged_edge_attrs(
     ----------
     xml_edge : ElementTree.Element
         XML representation of an output graph edge
-    sample_edge: pandas.Series
-        sample row from the the dataframe of way edges
+    sample_edge: dict
+        dict of sample row from the the dataframe of way edges
     all_edges_df: pandas.DataFrame
         a dataframe with one row for each edge in an OSM way
     edge_tags : list
@@ -427,7 +427,7 @@ def _append_merged_edge_attrs(
 
 
 def _append_nodes_as_edge_attrs(
-    xml_edge: ET.Element, sample_edge: pd.Series[Any], all_edges_df: pd.DataFrame
+    xml_edge: ET.Element, sample_edge: dict[str, Any], all_edges_df: pd.DataFrame
 ) -> None:
     """
     Extract list of ordered nodes and append as attributes of XML edge.
@@ -436,7 +436,7 @@ def _append_nodes_as_edge_attrs(
     ----------
     xml_edge : ElementTree.Element
         XML representation of an output graph edge
-    sample_edge: pandas.Series
+    sample_edge: dict
         sample row from the the dataframe of way edges
     all_edges_df: pandas.DataFrame
         a dataframe with one row for each edge in an OSM way
@@ -508,11 +508,11 @@ def _append_edges_xml_tree(
             first = all_way_edges.iloc[0].dropna().astype(str)
             edge = ET.SubElement(root, "way", attrib=first[edge_attrs].dropna().to_dict())
             _append_nodes_as_edge_attrs(
-                xml_edge=edge, sample_edge=first, all_edges_df=all_way_edges
+                xml_edge=edge, sample_edge=first.to_dict(), all_edges_df=all_way_edges
             )
             _append_merged_edge_attrs(
                 xml_edge=edge,
-                sample_edge=first,
+                sample_edge=first.to_dict(),
                 edge_tags=edge_tags,
                 edge_tag_aggs=edge_tag_aggs,
                 all_edges_df=all_way_edges,
@@ -529,7 +529,7 @@ def _append_edges_xml_tree(
     return root
 
 
-def _get_unique_nodes_ordered_from_way(df_way_edges: pd.DataFrame) -> list[int]:
+def _get_unique_nodes_ordered_from_way(df_way_edges: pd.DataFrame) -> list[Any]:
     """
     Recover original node order from edges associated with a single OSM way.
 

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -6,6 +6,7 @@ import bz2
 import xml.sax
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 from typing import TextIO
 from warnings import warn
 from xml.etree import ElementTree as ET
@@ -31,8 +32,8 @@ class _OSMContentHandler(xml.sax.handler.ContentHandler):
     """
 
     def __init__(self) -> None:
-        self._element: dict | None = None
-        self.object: dict = {"elements": []}
+        self._element: dict[str, Any] | None = None
+        self.object: dict[str, Any] = {"elements": []}
 
     def startElement(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         if name == "osm":
@@ -67,7 +68,7 @@ class _OSMContentHandler(xml.sax.handler.ContentHandler):
             self.object["elements"].append(self._element)
 
 
-def _overpass_json_from_file(filepath: str | Path, encoding: str) -> dict:
+def _overpass_json_from_file(filepath: str | Path, encoding: str) -> dict[Any, Any]:
     """
     Read OSM XML from file and return Overpass-like JSON.
 
@@ -80,8 +81,8 @@ def _overpass_json_from_file(filepath: str | Path, encoding: str) -> dict:
 
     Returns
     -------
-    object : dict
-        an _OSMContentHandler.object
+    response_json : dict
+        a parsed JSON response from the Overpass API
     """
 
     # open the XML file, handling bz2 or regular XML
@@ -183,15 +184,15 @@ def save_graph_xml(  # type: ignore[no-untyped-def]
 
 
 def _save_graph_xml(
-    data: nx.MultiDiGraph | Iterable,
+    data: nx.MultiDiGraph | Iterable[gpd.GeoDataFrame],
     filepath: str | Path | None,
-    node_tags: list,
-    node_attrs: list,
-    edge_tags: list,
-    edge_attrs: list,
+    node_tags: list[str],
+    node_attrs: list[str],
+    edge_tags: list[str],
+    edge_attrs: list[str],
     oneway: bool,
     merge_edges: bool,
-    edge_tag_aggs: list | None,
+    edge_tag_aggs: list[tuple[str, str]] | None,
     api_version: float,
     precision: int,
 ) -> None:
@@ -302,7 +303,7 @@ def _save_graph_xml(
 
 
 def _append_nodes_xml_tree(
-    root: ET.Element, gdf_nodes: gpd.GeoDataFrame, node_attrs: list, node_tags: list
+    root: ET.Element, gdf_nodes: gpd.GeoDataFrame, node_attrs: list[str], node_tags: list[str]
 ) -> ET.Element:
     """
     Append nodes to an XML tree.
@@ -334,7 +335,7 @@ def _append_nodes_xml_tree(
 
 
 def _create_way_for_each_edge(
-    root: ET.Element, gdf_edges: gpd.GeoDataFrame, edge_attrs: list, edge_tags: list
+    root: ET.Element, gdf_edges: gpd.GeoDataFrame, edge_attrs: list[str], edge_tags: list[str]
 ) -> None:
     """
     Append a new way to an empty XML tree graph for each edge in way.
@@ -372,10 +373,10 @@ def _create_way_for_each_edge(
 
 def _append_merged_edge_attrs(
     xml_edge: ET.Element,
-    sample_edge: pd.Series,
+    sample_edge: pd.Series[Any],
     all_edges_df: pd.DataFrame,
-    edge_tags: list,
-    edge_tag_aggs: list | None,
+    edge_tags: list[str],
+    edge_tag_aggs: list[tuple[str, str]] | None,
 ) -> None:
     """
     Extract edge attributes and append to XML edge.
@@ -426,7 +427,7 @@ def _append_merged_edge_attrs(
 
 
 def _append_nodes_as_edge_attrs(
-    xml_edge: ET.Element, sample_edge: pd.Series, all_edges_df: pd.DataFrame
+    xml_edge: ET.Element, sample_edge: pd.Series[Any], all_edges_df: pd.DataFrame
 ) -> None:
     """
     Extract list of ordered nodes and append as attributes of XML edge.
@@ -463,9 +464,9 @@ def _append_nodes_as_edge_attrs(
 def _append_edges_xml_tree(
     root: ET.Element,
     gdf_edges: gpd.GeoDataFrame,
-    edge_attrs: list,
-    edge_tags: list,
-    edge_tag_aggs: list | None,
+    edge_attrs: list[str],
+    edge_tags: list[str],
+    edge_tag_aggs: list[tuple[str, str]] | None,
     merge_edges: bool,
 ) -> ET.Element:
     """
@@ -528,7 +529,7 @@ def _append_edges_xml_tree(
     return root
 
 
-def _get_unique_nodes_ordered_from_way(df_way_edges: pd.DataFrame) -> list:
+def _get_unique_nodes_ordered_from_way(df_way_edges: pd.DataFrame) -> list[int]:
     """
     Recover original node order from edges associated with a single OSM way.
 

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -122,7 +122,7 @@ def save_graph_xml(  # type: ignore[no-untyped-def]
     oneway=False,
     merge_edges=True,
     edge_tag_aggs=None,
-    api_version=0.6,
+    api_version="0.6",
     precision=6,
 ):
     """
@@ -152,7 +152,7 @@ def save_graph_xml(  # type: ignore[no-untyped-def]
         do not use, deprecated
     edge_tag_aggs : list of length-2 string tuples
         do not use, deprecated
-    api_version : float
+    api_version : str
         do not use, deprecated
     precision : int
         do not use, deprecated
@@ -192,7 +192,7 @@ def _save_graph_xml(
     oneway: bool,
     merge_edges: bool,
     edge_tag_aggs: list[tuple[str, str]] | None,
-    api_version: float,
+    api_version: str,
     precision: int,
 ) -> None:
     """
@@ -229,7 +229,7 @@ def _save_graph_xml(
         this method to aggregate the lengths of the individual
         component edges. Otherwise, the length attribute will simply
         reflect the length of the first edge associated with the way.
-    api_version : float
+    api_version : string
         OpenStreetMap API version to write to the XML file header
     precision : int
         number of decimal places to round latitude and longitude values
@@ -291,9 +291,7 @@ def _save_graph_xml(
         )
 
     # initialize XML tree with an OSM root element then append nodes/edges
-    root = ET.Element(
-        "osm", attrib={"version": str(api_version), "generator": f"OSMnx {__version__}"}
-    )
+    root = ET.Element("osm", attrib={"version": api_version, "generator": f"OSMnx {__version__}"})
     root = _append_nodes_xml_tree(root, gdf_nodes, node_attrs, node_tags)
     root = _append_edges_xml_tree(
         root, gdf_edges, edge_attrs, edge_tags, edge_tag_aggs, merge_edges

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -1,5 +1,7 @@
 """Read/write .osm formatted XML files."""
 
+from __future__ import annotations
+
 import bz2
 import xml.sax
 from pathlib import Path
@@ -25,11 +27,11 @@ class _OSMContentHandler(xml.sax.handler.ContentHandler):
     https://overpass-api.de
     """
 
-    def __init__(self):
-        self._element = None
-        self.object = {"elements": []}
+    def __init__(self) -> None:
+        self._element: dict | None = None
+        self.object: dict = {"elements": []}
 
-    def startElement(self, name, attrs):
+    def startElement(self, name: str, attrs: xml.sax.xmlreader.AttributesImpl) -> None:
         if name == "osm":
             self.object.update({k: v for k, v in attrs.items() if k in {"version", "generator"}})
 
@@ -47,17 +49,17 @@ class _OSMContentHandler(xml.sax.handler.ContentHandler):
             )
 
         elif name == "tag":
-            self._element["tags"].update({attrs["k"]: attrs["v"]})
+            self._element["tags"].update({attrs["k"]: attrs["v"]})  # type: ignore[index]
 
         elif name == "nd":
-            self._element["nodes"].append(int(attrs["ref"]))
+            self._element["nodes"].append(int(attrs["ref"]))  # type: ignore[index]
 
         elif name == "member":
-            self._element["members"].append(
+            self._element["members"].append(  # type: ignore[index]
                 {k: (int(v) if k == "ref" else v) for k, v in attrs.items()}
             )
 
-    def endElement(self, name):
+    def endElement(self, name: str) -> None:
         if name in {"node", "way", "relation"}:
             self.object["elements"].append(self._element)
 

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -188,9 +188,9 @@ def plot_graph(
     node_color: str | Sequence[str] = "w",
     node_size: float | Sequence[float] = 15,
     node_alpha: float | None = None,
-    node_edgecolor: str | Sequence[str] = "none",
+    node_edgecolor: str | Iterable[str] = "none",
     node_zorder: int = 1,
-    edge_color: str | Sequence[str] = "#999999",
+    edge_color: str | Iterable[str] = "#999999",
     edge_linewidth: float | Sequence[float] = 1,
     edge_alpha: float | None = None,
     show: bool = True,
@@ -220,12 +220,12 @@ def plot_graph(
     node_alpha : float
         opacity of the nodes, note: if you passed RGBA values to node_color,
         set node_alpha=None to use the alpha channel in node_color
-    node_edgecolor : string or Sequence of string
+    node_edgecolor : string or Iterable of string
         color(s) of the nodes' markers' borders
     node_zorder : int
         zorder to plot nodes: edges are always 1, so set node_zorder=0 to plot
         nodes below edges
-    edge_color : string or Sequence of string
+    edge_color : string or Iterable of string
         color(s) of the edges' lines
     edge_linewidth : float or Sequence of float
         width(s) of the edges' lines: if 0, then skip plotting the edges
@@ -253,8 +253,8 @@ def plot_graph(
         tuple of matplotlib (Figure, Axes)
     """
     _verify_mpl()
-    max_node_size = max(node_size) if hasattr(node_size, "__iter__") else node_size
-    max_edge_lw = max(edge_linewidth) if hasattr(edge_linewidth, "__iter__") else edge_linewidth
+    max_node_size = max(node_size) if isinstance(node_size, Sequence) else node_size
+    max_edge_lw = max(edge_linewidth) if isinstance(edge_linewidth, Sequence) else edge_linewidth
     if max_node_size <= 0 and max_edge_lw <= 0:  # pragma: no cover
         msg = "Either `node_size` or `edge_linewidth` must be > 0 to plot something."
         raise ValueError(msg)

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -589,7 +589,7 @@ def plot_figure_ground(
         node_sizes = 0
 
     # define the view extents of the plotting figure
-    bbox = utils_geo.bbox_from_point(point, dist, project_utm=False)  # type: ignore[arg-type]
+    bbox = utils_geo.bbox_from_point(point, dist, project_utm=False)
 
     # plot the figure
     overrides = {"bbox", "node_size", "node_color", "edge_linewidth"}

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -178,7 +178,7 @@ def plot_graph(
     show: bool = True,
     close: bool = False,
     save: bool = False,
-    filepath: str = None,
+    filepath: str | Path | None = None,
     dpi: int = 300,
     bbox: tuple = None,
 ) -> tuple:
@@ -220,7 +220,7 @@ def plot_graph(
         if True, call pyplot.close() to close the figure
     save : bool
         if True, save the figure to disk at filepath
-    filepath : string
+    filepath : string or pathlib.Path
         if save is True, the path to the file. file format determined from
         extension. if None, use settings.imgs_folder/image.png
     dpi : int
@@ -620,7 +620,7 @@ def plot_footprints(
     save: bool = False,
     show: bool = True,
     close: bool = False,
-    filepath: str = None,
+    filepath: str | Path | None = None,
     dpi: int = 600,
 ) -> tuple:
     """
@@ -653,7 +653,7 @@ def plot_footprints(
         if True, call pyplot.show() to show the figure
     close : bool
         if True, call pyplot.close() to close the figure
-    filepath : string
+    filepath : string or pathlib.Path
         if save is True, the path to the file. file format determined from
         extension. if None, use settings.imgs_folder/image.png
     dpi : int
@@ -889,7 +889,7 @@ def _save_and_show(
     save: bool = False,
     show: bool = True,
     close: bool = True,
-    filepath: str = None,
+    filepath: str | Path | None = None,
     dpi: int = 300,
 ) -> tuple:
     """

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -101,7 +101,7 @@ def get_node_colors_by_attr(
     stop: float = 1,
     na_color: str = "none",
     equal_size: bool = False,
-) -> pd.Series[str]:
+) -> pd.Series:  # type: ignore[type-arg]
     """
     Get colors based on nodes' numerical attribute values.
 
@@ -132,7 +132,7 @@ def get_node_colors_by_attr(
         labels are node IDs, values are colors as hex strings
     """
     _verify_mpl()
-    vals: pd.Series[float] = pd.Series(nx.get_node_attributes(G, attr))
+    vals = pd.Series(nx.get_node_attributes(G, attr))
     return _get_colors_by_value(vals, num_bins, cmap, start, stop, na_color, equal_size)
 
 
@@ -145,7 +145,7 @@ def get_edge_colors_by_attr(
     stop: float = 1,
     na_color: str = "none",
     equal_size: bool = False,
-) -> pd.Series[str]:
+) -> pd.Series:  # type: ignore[type-arg]
     """
     Get colors based on edges' numerical attribute values.
 
@@ -176,12 +176,12 @@ def get_edge_colors_by_attr(
         labels are (u, v, k) edge IDs, values are colors as hex strings
     """
     _verify_mpl()
-    vals: pd.Series[float] = pd.Series(nx.get_edge_attributes(G, attr))
+    vals = pd.Series(nx.get_edge_attributes(G, attr))
     return _get_colors_by_value(vals, num_bins, cmap, start, stop, na_color, equal_size)
 
 
 def plot_graph(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     ax: Axes | None = None,
     figsize: tuple[float, float] = (8, 8),
     bgcolor: str = "#111111",
@@ -205,7 +205,7 @@ def plot_graph(
 
     Parameters
     ----------
-    G : networkx.MultiDiGraph
+    G : networkx.MultiGraph or networkx.MultiDiGraph
         input graph
     ax : matplotlib axes instance
         if not None, plot on this pre-existing axes instance
@@ -839,14 +839,14 @@ def plot_orientation(
 
 
 def _get_colors_by_value(
-    vals: pd.Series[float],
+    vals: pd.Series,  # type: ignore[type-arg]
     num_bins: int | None,
     cmap: str,
     start: float,
     stop: float,
     na_color: str,
     equal_size: bool,
-) -> pd.Series[str]:
+) -> pd.Series:  # type: ignore[type-arg]
     """
     Map colors to the values in a series.
 
@@ -874,7 +874,6 @@ def _get_colors_by_value(
     color_series : pandas.Series
         labels are (u, v, k) edge IDs, values are colors as hex strings
     """
-    color_series: pd.Series[str]
     if len(vals) == 0:
         msg = "There are no attribute values."
         raise ValueError(msg)
@@ -890,7 +889,7 @@ def _get_colors_by_value(
         # linearly map a color to each attribute value
         normalizer = colors.Normalize(full_min, full_max)
         scalar_mapper = cm.ScalarMappable(normalizer, colormaps[cmap])
-        color_series = vals.map(scalar_mapper.to_rgba).map(colors.to_hex)  # type: ignore[assignment]
+        color_series = vals.map(scalar_mapper.to_rgba).map(colors.to_hex)
         color_series.loc[pd.isna(vals)] = na_color
 
     else:
@@ -899,7 +898,7 @@ def _get_colors_by_value(
             bins = pd.qcut(vals, num_bins, labels=range(num_bins))
         else:
             bins = pd.cut(vals, num_bins, labels=range(num_bins))
-        bin_colors = get_colors(num_bins, cmap, start, stop)
+        bin_colors = get_colors(num_bins, cmap, start, stop, return_hex=True)
         color_list = [bin_colors[b] if pd.notna(b) else na_color for b in bins]
         color_series = pd.Series(color_list, index=bins.index)
 

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -1028,7 +1028,7 @@ def _config_ax(ax: Axes, crs: Any, bbox: tuple[float, float, float, float], padd
 
 
 # if polar = False, return Axes
-@overload
+@overload  # pragma: no cover
 def _get_fig_ax(
     ax: Axes | None, figsize: tuple[float, float], bgcolor: str | None, polar: Literal[False]
 ) -> tuple[Figure, Axes]:
@@ -1036,7 +1036,7 @@ def _get_fig_ax(
 
 
 # if polar = True, return PolarAxes
-@overload
+@overload  # pragma: no cover
 def _get_fig_ax(
     ax: Axes | None, figsize: tuple[float, float], bgcolor: str | None, polar: Literal[True]
 ) -> tuple[Figure, PolarAxes]:

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -872,8 +872,10 @@ def _get_colors_by_value(
 
     else:
         # otherwise, bin values then assign colors to bins
-        cut_func = pd.qcut if equal_size else pd.cut
-        bins = cut_func(vals, num_bins, labels=range(num_bins))  # type: ignore[operator]
+        if equal_size:
+            bins = pd.qcut(vals, num_bins, labels=range(num_bins))
+        else:
+            bins = pd.cut(vals, num_bins, labels=range(num_bins))
         bin_colors = get_colors(num_bins, cmap, start, stop)
         color_list = [bin_colors[b] if pd.notna(b) else na_color for b in bins]
         color_series = pd.Series(color_list, index=bins.index)

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -77,7 +77,7 @@ def get_colors(
 def get_node_colors_by_attr(
     G: nx.MultiDiGraph,
     attr: str,
-    num_bins: int = None,
+    num_bins: int | None = None,
     cmap: str = "viridis",
     start: float = 0,
     stop: float = 1,
@@ -121,7 +121,7 @@ def get_node_colors_by_attr(
 def get_edge_colors_by_attr(
     G: nx.MultiDiGraph,
     attr: str,
-    num_bins: int = None,
+    num_bins: int | None = None,
     cmap: str = "viridis",
     start: float = 0,
     stop: float = 1,
@@ -164,23 +164,23 @@ def get_edge_colors_by_attr(
 
 def plot_graph(
     G: nx.MultiDiGraph,
-    ax: Axes = None,
+    ax: Axes | None = None,
     figsize: tuple = (8, 8),
     bgcolor: str = "#111111",
     node_color: str | list = "w",
     node_size: int | list = 15,
-    node_alpha: float = None,
+    node_alpha: float | None = None,
     node_edgecolor: str | list = "none",
     node_zorder: int = 1,
     edge_color: str | list = "#999999",
     edge_linewidth: int | list = 1,
-    edge_alpha: float = None,
+    edge_alpha: float | None = None,
     show: bool = True,
     close: bool = False,
     save: bool = False,
     filepath: str | Path | None = None,
     dpi: int = 300,
-    bbox: tuple = None,
+    bbox: tuple | None = None,
 ) -> tuple:
     """
     Visualize a graph.
@@ -288,7 +288,7 @@ def plot_graph_route(
     route_linewidth: int = 4,
     route_alpha: float = 0.5,
     orig_dest_size: int = 100,
-    ax: Axes = None,
+    ax: Axes | None = None,
     **pg_kwargs: Any,
 ) -> tuple:
     """
@@ -446,12 +446,12 @@ def plot_graph_routes(
 
 
 def plot_figure_ground(
-    G: nx.MultiDiGraph = None,
-    address: str = None,
-    point: tuple = None,
+    G: nx.MultiDiGraph | None = None,
+    address: str | None = None,
+    point: tuple | None = None,
     dist: float = 805,
     network_type: str = "drive_service",
-    street_widths: dict = None,
+    street_widths: dict | None = None,
     default_width: int = 4,
     figsize: tuple = (8, 8),
     edge_color: str = "w",
@@ -609,14 +609,14 @@ def plot_figure_ground(
 
 def plot_footprints(
     gdf: gpd.GeoDataFrame,
-    ax: Axes = None,
+    ax: Axes | None = None,
     figsize: tuple = (8, 8),
     color: str = "orange",
     edge_color: str = "none",
     edge_linewidth: float = 0,
-    alpha: float = None,
+    alpha: float | None = None,
     bgcolor: str = "#111111",
-    bbox: tuple = None,
+    bbox: tuple | None = None,
     save: bool = False,
     show: bool = True,
     close: bool = False,
@@ -689,18 +689,18 @@ def plot_orientation(
     Gu: nx.MultiGraph,
     num_bins: int = 36,
     min_length: float = 0,
-    weight: str = None,
-    ax: PolarAxes = None,
+    weight: str | None = None,
+    ax: PolarAxes | None = None,
     figsize: tuple = (5, 5),
     area: bool = True,
     color: str = "#003366",
     edgecolor: str = "k",
     linewidth: float = 0.5,
     alpha: float = 0.7,
-    title: str = None,
+    title: str | None = None,
     title_y: float = 1.05,
-    title_font: dict = None,
-    xtick_font: dict = None,
+    title_font: dict | None = None,
+    xtick_font: dict | None = None,
 ) -> tuple:
     """
     Plot a polar histogram of a spatial network's bidirectional edge bearings.

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -1,4 +1,5 @@
 """Project a graph, GeoDataFrame, or geometry to a different CRS."""
+from __future__ import annotations
 
 from typing import Any
 
@@ -31,7 +32,7 @@ def is_projected(crs: Any) -> bool:
 
 
 def project_geometry(
-    geometry: Geometry, crs: Any = None, to_crs: Any = None, to_latlong: bool = False
+    geometry: Geometry, crs: Any | None = None, to_crs: Any | None = None, to_latlong: bool = False
 ) -> tuple[Geometry, Any]:
     """
     Project a Shapely geometry from its current CRS to another.
@@ -69,7 +70,7 @@ def project_geometry(
 
 
 def project_gdf(
-    gdf: gpd.GeoDataFrame, to_crs: Any = None, to_latlong: bool = False
+    gdf: gpd.GeoDataFrame, to_crs: Any | None = None, to_latlong: bool = False
 ) -> gpd.GeoDataFrame:
     """
     Project a GeoDataFrame from its current CRS to another.
@@ -114,7 +115,7 @@ def project_gdf(
 
 
 def project_graph(
-    G: nx.MultiDiGraph, to_crs: Any = None, to_latlong: bool = False
+    G: nx.MultiDiGraph, to_crs: Any | None = None, to_latlong: bool = False
 ) -> nx.MultiDiGraph:
     """
     Project a graph from its current CRS to another.

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -167,9 +167,7 @@ def project_graph(
         # if not, you don't have to project these edges because the nodes
         # contain all the spatial data in the graph (unsimplified edges have
         # no geometry attributes)
-        gdf_edges_proj = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=False).drop(
-            columns=["geometry"]
-        )
+        gdf_edges_proj = utils_graph.graph_to_gdfs(G, nodes=False, fill_edge_geometry=False)
 
     # STEP 3: REBUILD GRAPH
     # turn projected node/edge gdfs into a graph and update its CRS attribute

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -157,7 +157,6 @@ def project_graph(
     gdf_nodes_proj["x"] = gdf_nodes_proj["geometry"].x
     gdf_nodes_proj["y"] = gdf_nodes_proj["geometry"].y
     to_crs = gdf_nodes_proj.crs
-    gdf_nodes_proj = gdf_nodes_proj.drop(columns=["geometry"])
 
     # STEP 2: PROJECT THE EDGES
     if "simplified" in G.graph and G.graph["simplified"]:

--- a/osmnx/routing.py
+++ b/osmnx/routing.py
@@ -6,6 +6,7 @@ import itertools
 import multiprocessing as mp
 from collections.abc import Generator
 from collections.abc import Iterable
+from typing import Any
 from warnings import warn
 
 import networkx as nx
@@ -17,11 +18,11 @@ from . import utils_graph
 
 def shortest_path(
     G: nx.MultiDiGraph,
-    orig: int | Iterable,
-    dest: int | Iterable,
+    orig: int | Iterable[int],
+    dest: int | Iterable[int],
     weight: str = "length",
     cpus: int | None = 1,
-) -> list | None:
+) -> list[Any] | None:
     """
     Solve shortest path from origin node(s) to destination node(s).
 
@@ -93,7 +94,7 @@ def shortest_path(
 
 def k_shortest_paths(
     G: nx.MultiDiGraph, orig: int, dest: int, k: int, weight: str = "length"
-) -> Generator:
+) -> Generator[list[int], None, None]:
     """
     Solve `k` shortest paths from an origin node to a destination node.
 
@@ -125,7 +126,9 @@ def k_shortest_paths(
     yield from itertools.islice(paths_gen, 0, k)
 
 
-def _single_shortest_path(G: nx.MultiDiGraph, orig: int, dest: int, weight: str) -> list | None:
+def _single_shortest_path(
+    G: nx.MultiDiGraph, orig: int, dest: int, weight: str
+) -> list[int] | None:
     """
     Solve the shortest path from an origin node to a destination node.
 

--- a/osmnx/routing.py
+++ b/osmnx/routing.py
@@ -17,7 +17,7 @@ from . import utils_graph
 
 
 # orig/dest int, weight present, cpus present
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: int,
@@ -29,7 +29,7 @@ def shortest_path(
 
 
 # orig/dest int, weight missing, cpus present
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: int,
@@ -41,7 +41,7 @@ def shortest_path(
 
 
 # orig/dest int, weight present, cpus missing
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: int,
@@ -52,7 +52,7 @@ def shortest_path(
 
 
 # orig/dest int, weight missing, cpus missing
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: int,
@@ -62,7 +62,7 @@ def shortest_path(
 
 
 # orig/dest Iterable, weight present, cpus present
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: Iterable[int],
@@ -74,7 +74,7 @@ def shortest_path(
 
 
 # orig/dest Iterable, weight missing, cpus present
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: Iterable[int],
@@ -86,7 +86,7 @@ def shortest_path(
 
 
 # orig/dest Iterable, weight present, cpus missing
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: Iterable[int],
@@ -97,7 +97,7 @@ def shortest_path(
 
 
 # orig/dest Iterable, weight missing, cpus missing
-@overload
+@overload  # pragma: no cover
 def shortest_path(
     G: nx.MultiDiGraph,
     orig: Iterable[int],

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -136,9 +136,10 @@ from __future__ import annotations
 
 import logging as lg
 from pathlib import Path
+from typing import Any
 
 all_oneway: bool = False
-bidirectional_network_types: list = ["walk"]
+bidirectional_network_types: list[str] = ["walk"]
 cache_folder: str | Path = "./cache"
 cache_only_mode: bool = False
 data_folder: str | Path = "./data"
@@ -162,18 +163,27 @@ max_query_area_size: float = 50 * 1000 * 50 * 1000
 memory: int | None = None
 nominatim_endpoint: str = "https://nominatim.openstreetmap.org/"
 nominatim_key: str | None = None
-osm_xml_node_attrs: list = ["id", "timestamp", "uid", "user", "version", "changeset", "lat", "lon"]
-osm_xml_node_tags: list = ["highway"]
-osm_xml_way_attrs: list = ["id", "timestamp", "uid", "user", "version", "changeset"]
-osm_xml_way_tags: list = ["highway", "lanes", "maxspeed", "name", "oneway"]
+osm_xml_node_attrs: list[str] = [
+    "id",
+    "timestamp",
+    "uid",
+    "user",
+    "version",
+    "changeset",
+    "lat",
+    "lon",
+]
+osm_xml_node_tags: list[str] = ["highway"]
+osm_xml_way_attrs: list[str] = ["id", "timestamp", "uid", "user", "version", "changeset"]
+osm_xml_way_tags: list[str] = ["highway", "lanes", "maxspeed", "name", "oneway"]
 overpass_endpoint: str = "https://overpass-api.de/api"
 overpass_rate_limit: bool = True
 overpass_settings: str = "[out:json][timeout:{timeout}]{maxsize}"
-requests_kwargs: dict = {}
+requests_kwargs: dict[str, Any] = {}
 timeout: float = 180
 use_cache: bool = True
-useful_tags_node: list = ["ref", "highway"]
-useful_tags_way: list = [
+useful_tags_node: list[str] = ["ref", "highway"]
+useful_tags_way: list[str] = [
     "bridge",
     "tunnel",
     "oneway",

--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -44,7 +44,7 @@ default_referer : string
 default_user_agent : string
     HTTP header user-agent. Default is
     `"OSMnx Python package (https://github.com/gboeing/osmnx)"`.
-doh_url_template : string
+doh_url_template : string or None
     Endpoint to resolve DNS-over-HTTPS if local DNS resolution fails. Set to
     None to disable DoH, but see `downloader._config_dns` documentation for
     caveats. Default is: `"https://8.8.8.8/resolve?name={hostname}"`
@@ -70,18 +70,18 @@ log_name : string
     Name of the logger. Default is `"OSMnx"`.
 logs_folder : string or pathlib.Path
     Path to folder in which to save log files. Default is `"./logs"`.
-max_query_area_size : int
+max_query_area_size : float
     Maximum area for any part of the geometry in meters: any polygon bigger
     than this will get divided up for multiple queries to the API. Default is
     `2500000000`.
-memory : int
+memory : int or None
     Overpass server memory allocation size for the query, in bytes. If
     None, server will use its default allocation size. Use with caution.
     Default is `None`.
 nominatim_endpoint : string
     The base API url to use for Nominatim queries. Default is
     `"https://nominatim.openstreetmap.org/"`.
-nominatim_key : string
+nominatim_key : string or None
     Your Nominatim API key, if you are using an API instance that requires
     one. Default is `None`.
 osm_xml_node_attrs : list
@@ -132,46 +132,48 @@ useful_tags_way : list
     "ref", "name", "highway", "maxspeed", "service", "access", "area",
     "landuse", "width", "est_width", "junction"]`.
 """
+from __future__ import annotations
 
 import logging as lg
+from pathlib import Path
 
-all_oneway = False
-bidirectional_network_types = ["walk"]
-cache_folder = "./cache"
-cache_only_mode = False
-data_folder = "./data"
-default_accept_language = "en"
-default_access = '["access"!~"private"]'
-default_crs = "epsg:4326"
-default_referer = "OSMnx Python package (https://github.com/gboeing/osmnx)"
-default_user_agent = "OSMnx Python package (https://github.com/gboeing/osmnx)"
-doh_url_template = "https://8.8.8.8/resolve?name={hostname}"
-elevation_url_template = (
+all_oneway: bool = False
+bidirectional_network_types: list = ["walk"]
+cache_folder: str | Path = "./cache"
+cache_only_mode: bool = False
+data_folder: str | Path = "./data"
+default_accept_language: str = "en"
+default_access: str = '["access"!~"private"]'
+default_crs: str = "epsg:4326"
+default_referer: str = "OSMnx Python package (https://github.com/gboeing/osmnx)"
+default_user_agent: str = "OSMnx Python package (https://github.com/gboeing/osmnx)"
+doh_url_template: str | None = "https://8.8.8.8/resolve?name={hostname}"
+elevation_url_template: str = (
     "https://maps.googleapis.com/maps/api/elevation/json?locations={locations}&key={key}"
 )
-imgs_folder = "./images"
-log_console = False
-log_file = False
-log_filename = "osmnx"
-log_level = lg.INFO
-log_name = "OSMnx"
-logs_folder = "./logs"
-max_query_area_size = 50 * 1000 * 50 * 1000
-memory = None
-nominatim_endpoint = "https://nominatim.openstreetmap.org/"
-nominatim_key = None
-osm_xml_node_attrs = ["id", "timestamp", "uid", "user", "version", "changeset", "lat", "lon"]
-osm_xml_node_tags = ["highway"]
-osm_xml_way_attrs = ["id", "timestamp", "uid", "user", "version", "changeset"]
-osm_xml_way_tags = ["highway", "lanes", "maxspeed", "name", "oneway"]
-overpass_endpoint = "https://overpass-api.de/api"
-overpass_rate_limit = True
-overpass_settings = "[out:json][timeout:{timeout}]{maxsize}"
+imgs_folder: str | Path = "./images"
+log_console: bool = False
+log_file: bool = False
+log_filename: str = "osmnx"
+log_level: int = lg.INFO
+log_name: str = "OSMnx"
+logs_folder: str | Path = "./logs"
+max_query_area_size: float = 50 * 1000 * 50 * 1000
+memory: int | None = None
+nominatim_endpoint: str = "https://nominatim.openstreetmap.org/"
+nominatim_key: str | None = None
+osm_xml_node_attrs: list = ["id", "timestamp", "uid", "user", "version", "changeset", "lat", "lon"]
+osm_xml_node_tags: list = ["highway"]
+osm_xml_way_attrs: list = ["id", "timestamp", "uid", "user", "version", "changeset"]
+osm_xml_way_tags: list = ["highway", "lanes", "maxspeed", "name", "oneway"]
+overpass_endpoint: str = "https://overpass-api.de/api"
+overpass_rate_limit: bool = True
+overpass_settings: str = "[out:json][timeout:{timeout}]{maxsize}"
 requests_kwargs: dict = {}
-timeout = 180
-use_cache = True
-useful_tags_node = ["ref", "highway"]
-useful_tags_way = [
+timeout: float = 180
+use_cache: bool = True
+useful_tags_node: list = ["ref", "highway"]
+useful_tags_way: list = [
     "bridge",
     "tunnel",
     "oneway",

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging as lg
 from collections.abc import Generator
+from typing import Any
 
 import geopandas as gpd
 import networkx as nx
@@ -84,7 +85,9 @@ def _is_endpoint(G: nx.MultiDiGraph, node: int, strict: bool = True) -> bool:
     return False
 
 
-def _build_path(G: nx.MultiDiGraph, endpoint: int, endpoint_successor: int, endpoints: set) -> list:
+def _build_path(
+    G: nx.MultiDiGraph, endpoint: int, endpoint_successor: int, endpoints: set[int]
+) -> list[int]:
     """
     Build a path of nodes from one endpoint node to next endpoint node.
 
@@ -154,7 +157,9 @@ def _build_path(G: nx.MultiDiGraph, endpoint: int, endpoint_successor: int, endp
     return path
 
 
-def _get_paths_to_simplify(G: nx.MultiDiGraph, strict: bool = True) -> Generator:
+def _get_paths_to_simplify(
+    G: nx.MultiDiGraph, strict: bool = True
+) -> Generator[list[int], None, None]:
     """
     Generate all the paths to be simplified between endpoint nodes.
 
@@ -271,7 +276,7 @@ def simplify_graph(
         # add the interstitial edges we're removing to a list so we can retain
         # their spatial geometry
         merged_edges = []
-        path_attributes: dict = {}
+        path_attributes: dict[str, Any] = {}
         for u, v in zip(path[:-1], path[1:]):
             if track_merged:
                 # keep track of the edges that were merged

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 from typing import Callable
 from warnings import warn
 
@@ -15,10 +16,10 @@ from . import utils_graph
 
 def add_edge_speeds(
     G: nx.MultiDiGraph,
-    hwy_speeds: dict | None = None,
+    hwy_speeds: dict[str, float] | None = None,
     fallback: float | None = None,
     precision: int | None = None,
-    agg: Callable = np.mean,
+    agg: Callable[[Any], Any] = np.mean,
 ) -> nx.MultiDiGraph:
     """
     Add edge speeds (km per hour) to graph as new `speed_kph` edge attributes.
@@ -190,7 +191,7 @@ def add_edge_travel_times(G: nx.MultiDiGraph, precision: int | None = None) -> n
 
 
 def _clean_maxspeed(
-    maxspeed: str, agg: Callable = np.mean, convert_mph: bool = True
+    maxspeed: str, agg: Callable[[Any], Any] = np.mean, convert_mph: bool = True
 ) -> float | None:
     """
     Clean a maxspeed string and convert mph to kph if necessary.
@@ -234,7 +235,9 @@ def _clean_maxspeed(
         return None
 
 
-def _collapse_multiple_maxspeed_values(value: str | list[str], agg: Callable) -> int | str | None:
+def _collapse_multiple_maxspeed_values(
+    value: str | list[str], agg: Callable[[Any], Any]
+) -> int | str | None:
     """
     Collapse a list of maxspeed values to a single value.
 

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -15,9 +15,9 @@ from . import utils_graph
 
 def add_edge_speeds(
     G: nx.MultiDiGraph,
-    hwy_speeds: dict = None,
-    fallback: float = None,
-    precision: int = None,
+    hwy_speeds: dict | None = None,
+    fallback: float | None = None,
+    precision: int | None = None,
     agg: Callable = np.mean,
 ) -> nx.MultiDiGraph:
     """
@@ -134,7 +134,7 @@ def add_edge_speeds(
     return G
 
 
-def add_edge_travel_times(G: nx.MultiDiGraph, precision: int = None) -> nx.MultiDiGraph:
+def add_edge_travel_times(G: nx.MultiDiGraph, precision: int | None = None) -> nx.MultiDiGraph:
     """
     Add edge travel time (seconds) to graph as new `travel_time` edge attributes.
 

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -259,7 +259,7 @@ def circuity_avg(Gu: nx.MultiGraph) -> float | None:
         return None
 
 
-def count_streets_per_node(G: nx.MultiDiGraph, nodes: list = None) -> dict:
+def count_streets_per_node(G: nx.MultiDiGraph, nodes: list | None = None) -> dict:
     """
     Count how many physical street segments connect to each node in a graph.
 
@@ -310,7 +310,9 @@ def count_streets_per_node(G: nx.MultiDiGraph, nodes: list = None) -> dict:
     return streets_per_node
 
 
-def basic_stats(G: nx.MultiDiGraph, area: float = None, clean_int_tol: float = None) -> dict:
+def basic_stats(
+    G: nx.MultiDiGraph, area: float | None = None, clean_int_tol: float | None = None
+) -> dict:
     """
     Calculate basic descriptive geometric and topological measures of a graph.
 

--- a/osmnx/stats.py
+++ b/osmnx/stats.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import itertools
 import logging as lg
 from collections import Counter
+from typing import Any
 
 import networkx as nx
 import numpy as np
@@ -28,7 +29,7 @@ from . import utils
 from . import utils_graph
 
 
-def streets_per_node(G: nx.MultiDiGraph) -> dict:
+def streets_per_node(G: nx.MultiDiGraph) -> dict[str, int]:
     """
     Count streets (undirected edges) incident on each node.
 
@@ -66,7 +67,7 @@ def streets_per_node_avg(G: nx.MultiDiGraph) -> float:
     return float(sum(spn_vals) / len(G.nodes))
 
 
-def streets_per_node_counts(G: nx.MultiDiGraph) -> dict:
+def streets_per_node_counts(G: nx.MultiDiGraph) -> dict[int, int]:
     """
     Calculate streets-per-node counts.
 
@@ -85,7 +86,7 @@ def streets_per_node_counts(G: nx.MultiDiGraph) -> dict:
     return {i: spn_vals.count(i) for i in range(int(max(spn_vals)) + 1)}
 
 
-def streets_per_node_proportions(G: nx.MultiDiGraph) -> dict:
+def streets_per_node_proportions(G: nx.MultiDiGraph) -> dict[int, float]:
     """
     Calculate streets-per-node proportions.
 
@@ -259,7 +260,7 @@ def circuity_avg(Gu: nx.MultiGraph) -> float | None:
         return None
 
 
-def count_streets_per_node(G: nx.MultiDiGraph, nodes: list | None = None) -> dict:
+def count_streets_per_node(G: nx.MultiDiGraph, nodes: list[int] | None = None) -> dict[int, int]:
     """
     Count how many physical street segments connect to each node in a graph.
 
@@ -312,7 +313,7 @@ def count_streets_per_node(G: nx.MultiDiGraph, nodes: list | None = None) -> dic
 
 def basic_stats(
     G: nx.MultiDiGraph, area: float | None = None, clean_int_tol: float | None = None
-) -> dict:
+) -> dict[str, Any]:
     """
     Calculate basic descriptive geometric and topological measures of a graph.
 
@@ -358,7 +359,7 @@ def basic_stats(
           - `streets_per_node_proportions` - see `streets_per_node_proportions` function documentation
     """
     Gu = utils_graph.get_undirected(G)
-    stats: dict = {}
+    stats: dict[str, Any] = {}
 
     stats["n"] = len(G.nodes)
     stats["m"] = len(G.edges)

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -75,8 +75,8 @@ def truncate_graph_bbox(
     west: float,
     truncate_by_edge: bool = False,
     retain_all: bool = False,
-    quadrat_width: float = None,
-    min_num: int = None,
+    quadrat_width: float | None = None,
+    min_num: int | None = None,
 ) -> nx.MultiDiGraph:
     """
     Remove every node in graph that falls outside a bounding box.
@@ -129,8 +129,8 @@ def truncate_graph_polygon(
     polygon: Polygon | MultiPolygon,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    quadrat_width: float = None,
-    min_num: int = None,
+    quadrat_width: float | None = None,
+    min_num: int | None = None,
 ) -> nx.MultiDiGraph:
     """
     Remove every node in graph that falls outside a (Multi)Polygon.

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -16,7 +16,7 @@ from . import utils_graph
 def truncate_graph_dist(
     G: nx.MultiDiGraph,
     source_node: int,
-    max_dist: int = 1000,
+    max_dist: float = 1000,
     weight: str = "length",
     retain_all: bool = False,
 ) -> nx.MultiDiGraph:

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -167,7 +167,7 @@ def truncate_graph_polygon(
     utils.log("Identifying all nodes that lie outside the polygon...")
 
     # first identify all nodes whose point geometries lie within the polygon
-    gs_nodes = utils_graph.graph_to_gdfs(G, edges=False)[["geometry"]]
+    gs_nodes = utils_graph.graph_to_gdfs(G, edges=False)["geometry"]
     to_keep = utils_geo._intersect_index_quadrats(gs_nodes, polygon)
 
     if not to_keep:

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -1,4 +1,5 @@
 """General utility functions."""
+from __future__ import annotations
 
 import datetime as dt
 import logging as lg
@@ -66,7 +67,7 @@ def citation(style: str = "bibtex") -> None:
     print(msg)  # noqa: T201
 
 
-def ts(style: str = "datetime", template: str = None) -> str:
+def ts(style: str = "datetime", template: str | None = None) -> str:
     """
     Return current local timestamp as a string.
 
@@ -252,7 +253,9 @@ def config(  # type: ignore[no-untyped-def]
     settings.requests_kwargs = requests_kwargs
 
 
-def log(message: str, level: int = None, name: str = None, filename: str = None) -> None:
+def log(
+    message: str, level: int | None = None, name: str | None = None, filename: str | None = None
+) -> None:
     """
     Write a message to the logger.
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -428,7 +428,7 @@ def bbox_from_point(
 @overload
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[True], return_crs: Literal[True]
-) -> tuple[float, float, float, float, float]:
+) -> tuple[float, float, float, float, Any]:
     ...
 
 
@@ -498,7 +498,7 @@ def bbox_from_point(
 @overload
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[True], return_crs: Literal[True]
-) -> tuple[float, float, float, float, float]:
+) -> tuple[float, float, float, float, Any]:
     ...
 
 
@@ -539,7 +539,7 @@ def bbox_from_point(
     dist: float = 1000,
     project_utm: bool = False,
     return_crs: bool = False,
-) -> tuple[float, float, float, float] | tuple[float, float, float, float, float]:
+) -> tuple[float, float, float, float] | tuple[float, float, float, float, Any]:
     """
     Create a bounding box around a (lat, lon) point.
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import Any
 from warnings import warn
 
 import geopandas as gpd
@@ -55,7 +56,7 @@ def sample_points(G: nx.MultiGraph, n: int) -> gpd.GeoSeries:
     return lines.interpolate(np.random.rand(n), normalized=True)
 
 
-def interpolate_points(geom: LineString, dist: float) -> Generator:
+def interpolate_points(geom: LineString, dist: float) -> Generator[tuple[float, float], None, None]:
     """
     Interpolate evenly spaced points along a LineString.
 
@@ -342,7 +343,9 @@ def _quadrat_cut_geometry(geometry: Polygon | MultiPolygon, quadrat_width: float
     return MultiPolygon(geometries)
 
 
-def _intersect_index_quadrats(geometries: gpd.GeoSeries, polygon: Polygon | MultiPolygon) -> set:
+def _intersect_index_quadrats(
+    geometries: gpd.GeoSeries, polygon: Polygon | MultiPolygon
+) -> set[Any]:
     """
     Identify geometries that intersect a (Multi)Polygon.
 
@@ -390,7 +393,10 @@ def _intersect_index_quadrats(geometries: gpd.GeoSeries, polygon: Polygon | Mult
 
 
 def bbox_from_point(
-    point: tuple, dist: float = 1000, project_utm: bool = False, return_crs: bool = False
+    point: tuple[float, float],
+    dist: float = 1000,
+    project_utm: bool = False,
+    return_crs: bool = False,
 ) -> tuple:
     """
     Create a bounding box around a (lat, lon) point.

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -395,13 +395,13 @@ def _intersect_index_quadrats(
 
 
 # dist missing, project_utm missing/False, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(point: tuple[float, float]) -> tuple[float, float, float, float]:
     ...
 
 
 # dist missing, project_utm missing/False, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, return_crs: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -409,7 +409,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm missing/False, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -417,7 +417,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/True, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -425,7 +425,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/True, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[True], return_crs: Literal[True]
 ) -> tuple[float, float, float, float, Any]:
@@ -433,7 +433,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/True, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[True], return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -441,7 +441,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/False, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -449,7 +449,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/False, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[False], return_crs: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -457,7 +457,7 @@ def bbox_from_point(
 
 
 # dist missing, project_utm present/False, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], *, project_utm: Literal[False], return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -465,13 +465,13 @@ def bbox_from_point(
 
 
 # dist present, project_utm missing/False, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(point: tuple[float, float], dist: float) -> tuple[float, float, float, float]:
     ...
 
 
 # dist present, project_utm missing/False, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, *, return_crs: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -479,7 +479,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm missing/False, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, *, return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -487,7 +487,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/True, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -495,7 +495,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/True, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[True], return_crs: Literal[True]
 ) -> tuple[float, float, float, float, Any]:
@@ -503,7 +503,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/True, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[True], return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -511,7 +511,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/False, return_crs missing/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[False]
 ) -> tuple[float, float, float, float]:
@@ -519,7 +519,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/False, return_crs present/True
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[False], return_crs: Literal[True]
 ) -> tuple[float, float, float, float]:
@@ -527,7 +527,7 @@ def bbox_from_point(
 
 
 # dist present, project_utm present/False, return_crs present/False
-@overload
+@overload  # pragma: no cover
 def bbox_from_point(
     point: tuple[float, float], dist: float, project_utm: Literal[False], return_crs: Literal[False]
 ) -> tuple[float, float, float, float]:

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -126,7 +126,7 @@ def _round_multipolygon_coords(mp, precision):  # type: ignore[no-untyped-def]
     -------
     shapely.geometry.MultiPolygon
     """
-    return MultiPolygon([_round_polygon_coords(p, precision) for p in mp.geoms])
+    return MultiPolygon([_round_polygon_coords(p, precision) for p in mp.geoms])  # type: ignore[no-untyped-call]
 
 
 def _round_point_coords(pt, precision):  # type: ignore[no-untyped-def]
@@ -162,7 +162,7 @@ def _round_multipoint_coords(mpt, precision):  # type: ignore[no-untyped-def]
     -------
     shapely.geometry.MultiPoint
     """
-    return MultiPoint([_round_point_coords(pt, precision) for pt in mpt.geoms])
+    return MultiPoint([_round_point_coords(pt, precision) for pt in mpt.geoms])  # type: ignore[no-untyped-call]
 
 
 def _round_linestring_coords(ls, precision):  # type: ignore[no-untyped-def]
@@ -198,7 +198,7 @@ def _round_multilinestring_coords(mls, precision):  # type: ignore[no-untyped-de
     -------
     shapely.geometry.MultiLineString
     """
-    return MultiLineString([_round_linestring_coords(ls, precision) for ls in mls.geoms])
+    return MultiLineString([_round_linestring_coords(ls, precision) for ls in mls.geoms])  # type: ignore[no-untyped-call]
 
 
 def round_geometry_coords(geom, precision):  # type: ignore[no-untyped-def]
@@ -222,22 +222,22 @@ def round_geometry_coords(geom, precision):  # type: ignore[no-untyped-def]
     )
 
     if isinstance(geom, Point):
-        return _round_point_coords(geom, precision)
+        return _round_point_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     if isinstance(geom, MultiPoint):
-        return _round_multipoint_coords(geom, precision)
+        return _round_multipoint_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     if isinstance(geom, LineString):
-        return _round_linestring_coords(geom, precision)
+        return _round_linestring_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     if isinstance(geom, MultiLineString):
-        return _round_multilinestring_coords(geom, precision)
+        return _round_multilinestring_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     if isinstance(geom, Polygon):
-        return _round_polygon_coords(geom, precision)
+        return _round_polygon_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     if isinstance(geom, MultiPolygon):
-        return _round_multipolygon_coords(geom, precision)
+        return _round_multipolygon_coords(geom, precision)  # type: ignore[no-untyped-call]
 
     # otherwise
     msg = f"cannot round coordinates of unhandled geometry type: {type(geom)}"

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from typing import Any
+from typing import Literal
+from typing import overload
 from warnings import warn
 
 import geopandas as gpd
@@ -392,12 +394,152 @@ def _intersect_index_quadrats(
     return geoms_in_poly
 
 
+# dist missing, project_utm missing/False, return_crs missing/False
+@overload
+def bbox_from_point(point: tuple[float, float]) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm missing/False, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, return_crs: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm missing/False, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/True, return_crs missing/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/True, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[True], return_crs: Literal[True]
+) -> tuple[float, float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/True, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[True], return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/False, return_crs missing/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/False, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[False], return_crs: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist missing, project_utm present/False, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], *, project_utm: Literal[False], return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm missing/False, return_crs missing/False
+@overload
+def bbox_from_point(point: tuple[float, float], dist: float) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm missing/False, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, *, return_crs: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm missing/False, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, *, return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/True, return_crs missing/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/True, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[True], return_crs: Literal[True]
+) -> tuple[float, float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/True, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[True], return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/False, return_crs missing/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/False, return_crs present/True
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[False], return_crs: Literal[True]
+) -> tuple[float, float, float, float]:
+    ...
+
+
+# dist present, project_utm present/False, return_crs present/False
+@overload
+def bbox_from_point(
+    point: tuple[float, float], dist: float, project_utm: Literal[False], return_crs: Literal[False]
+) -> tuple[float, float, float, float]:
+    ...
+
+
 def bbox_from_point(
     point: tuple[float, float],
     dist: float = 1000,
     project_utm: bool = False,
     return_crs: bool = False,
-) -> tuple:
+) -> tuple[float, float, float, float] | tuple[float, float, float, float, float]:
     """
     Create a bounding box around a (lat, lon) point.
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -18,7 +18,7 @@ from . import utils
 
 
 # nodes and edges are both missing (therefore both default true)
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     *,
@@ -29,7 +29,7 @@ def graph_to_gdfs(
 
 
 # both present/True
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
@@ -41,7 +41,7 @@ def graph_to_gdfs(
 
 
 # both present, nodes true, edges false
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
@@ -53,7 +53,7 @@ def graph_to_gdfs(
 
 
 # both present, nodes false, edges true
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[False],
@@ -65,7 +65,7 @@ def graph_to_gdfs(
 
 
 # nodes missing (therefore default true), edges present/true
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     *,
@@ -77,7 +77,7 @@ def graph_to_gdfs(
 
 
 # nodes missing (therefore default true), edges present/false
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     *,
@@ -89,7 +89,7 @@ def graph_to_gdfs(
 
 
 # nodes present/true, edges missing (therefore default true)
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
@@ -101,7 +101,7 @@ def graph_to_gdfs(
 
 
 # nodes present/false, edges missing (therefore default true)
-@overload
+@overload  # pragma: no cover
 def graph_to_gdfs(
     G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[False],

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -20,7 +20,7 @@ from . import utils
 # nodes and edges are both missing (therefore both default true)
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     *,
     node_geometry: bool = True,
     fill_edge_geometry: bool = True,
@@ -31,7 +31,7 @@ def graph_to_gdfs(
 # both present/True
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
     edges: Literal[True],
     node_geometry: bool = True,
@@ -43,7 +43,7 @@ def graph_to_gdfs(
 # both present, nodes true, edges false
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
     edges: Literal[False],
     node_geometry: bool = True,
@@ -55,7 +55,7 @@ def graph_to_gdfs(
 # both present, nodes false, edges true
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[False],
     edges: Literal[True],
     node_geometry: bool = True,
@@ -67,7 +67,7 @@ def graph_to_gdfs(
 # nodes missing (therefore default true), edges present/true
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     *,
     edges: Literal[True],
     node_geometry: bool = True,
@@ -79,7 +79,7 @@ def graph_to_gdfs(
 # nodes missing (therefore default true), edges present/false
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     *,
     edges: Literal[False],
     node_geometry: bool = True,
@@ -91,7 +91,7 @@ def graph_to_gdfs(
 # nodes present/true, edges missing (therefore default true)
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[True],
     edges: bool = True,
     node_geometry: bool = True,
@@ -103,7 +103,7 @@ def graph_to_gdfs(
 # nodes present/false, edges missing (therefore default true)
 @overload
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: Literal[False],
     edges: bool = True,
     node_geometry: bool = True,
@@ -113,20 +113,20 @@ def graph_to_gdfs(
 
 
 def graph_to_gdfs(
-    G: nx.MultiDiGraph,
+    G: nx.MultiGraph | nx.MultiDiGraph,
     nodes: bool = True,
     edges: bool = True,
     node_geometry: bool = True,
     fill_edge_geometry: bool = True,
 ) -> gpd.GeoDataFrame | tuple[gpd.GeoDataFrame, gpd.GeoDataFrame]:
     """
-    Convert a MultiDiGraph to node and/or edge GeoDataFrames.
+    Convert a MultiGraph or MultiDiGraph to node and/or edge GeoDataFrames.
 
     This function is the inverse of `graph_from_gdfs`.
 
     Parameters
     ----------
-    G : networkx.MultiDiGraph
+    G : networkx.MultiGraph or networkx.MultiDiGraph
         input graph
     nodes : bool
         if True, convert graph nodes to a GeoDataFrame and return it
@@ -142,7 +142,7 @@ def graph_to_gdfs(
     geopandas.GeoDataFrame or tuple
         gdf_nodes or gdf_edges or tuple of (gdf_nodes, gdf_edges). gdf_nodes
         is indexed by osmid and gdf_edges is multi-indexed by u, v, key
-        following normal MultiDiGraph structure.
+        following normal MultiGraph/MultiDiGraph structure.
     """
     crs = G.graph["crs"]
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -217,7 +217,7 @@ def graph_to_gdfs(
 
 
 def graph_from_gdfs(
-    gdf_nodes: gpd.GeoDataFrame, gdf_edges: gpd.GeoDataFrame, graph_attrs: dict = None
+    gdf_nodes: gpd.GeoDataFrame, gdf_edges: gpd.GeoDataFrame, graph_attrs: dict | None = None
 ) -> nx.MultiDiGraph:
     """
     Convert node and edge GeoDataFrames to a MultiDiGraph.

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+from typing import Any
 from typing import Literal
 from typing import overload
 from warnings import warn
@@ -176,7 +177,11 @@ def graph_to_gdfs(
             y_lookup = nx.get_node_attributes(G, "y")
 
             def _make_edge_geometry(
-                u: int, v: int, data: dict, x: dict = x_lookup, y: dict = y_lookup
+                u: int,
+                v: int,
+                data: dict[str, Any],
+                x: dict[int, float] = x_lookup,
+                y: dict[int, float] = y_lookup,
             ) -> LineString:
                 if "geometry" in data:
                     return data["geometry"]
@@ -217,7 +222,9 @@ def graph_to_gdfs(
 
 
 def graph_from_gdfs(
-    gdf_nodes: gpd.GeoDataFrame, gdf_edges: gpd.GeoDataFrame, graph_attrs: dict | None = None
+    gdf_nodes: gpd.GeoDataFrame,
+    gdf_edges: gpd.GeoDataFrame,
+    graph_attrs: dict[str, Any] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Convert node and edge GeoDataFrames to a MultiDiGraph.
@@ -295,7 +302,7 @@ def graph_from_gdfs(
     return G
 
 
-def route_to_gdf(G: nx.MultiDiGraph, route: list, weight: str = "length") -> gpd.GeoDataFrame:
+def route_to_gdf(G: nx.MultiDiGraph, route: list[int], weight: str = "length") -> gpd.GeoDataFrame:
     """
     Return a GeoDataFrame of the edges in a path, in order.
 
@@ -446,7 +453,7 @@ def get_digraph(G: nx.MultiDiGraph, weight: str = "length") -> nx.DiGraph:
     """
     # make a copy to not mutate original graph object caller passed in
     G = G.copy()
-    to_remove: list = []
+    to_remove: list[tuple[int, int, int]] = []
 
     # identify all the parallel edges in the MultiDiGraph
     parallels = ((u, v) for u, v in G.edges(keys=False) if len(G.get_edge_data(u, v)) > 1)
@@ -526,7 +533,7 @@ def get_undirected(G: nx.MultiDiGraph) -> nx.MultiGraph:
     return H
 
 
-def _is_duplicate_edge(data1: dict, data2: dict) -> bool:
+def _is_duplicate_edge(data1: dict[str, Any], data2: dict[str, Any]) -> bool:
     """
     Check if two graph edge data dicts have the same osmid and geometry.
 

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -343,7 +343,7 @@ def get_route_edge_attributes(  # type: ignore[no-untyped-def]
         deprecated
     minimize_key : string
         deprecated
-    retrieve_default : Callable[Tuple[Any, Any], Any]
+    retrieve_default : function
         deprecated
 
     Returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ path = "osmnx/_version.py"
 cache_dir = "~/.cache/mypy"
 disable_error_code = ["type-arg"]
 ignore_missing_imports = true
-implicit_optional = true
 implicit_reexport = true
 python_version = "3.9"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,16 +58,14 @@ packages = ["osmnx"]
 path = "osmnx/_version.py"
 
 [tool.mypy]
-disable_error_code = ["attr-defined", "type-arg"]
-disallow_untyped_defs = true
+cache_dir = "~/.cache/mypy"
+disable_error_code = ["type-arg"]
 ignore_missing_imports = true
 implicit_optional = true
+implicit_reexport = true
 python_version = "3.9"
 strict = true
 warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unused_configs = true
 
 [tool.ruff]
 cache-dir = "~/.cache/ruff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ path = "osmnx/_version.py"
 
 [tool.mypy]
 cache_dir = "~/.cache/mypy"
-disable_error_code = ["type-arg"]
 ignore_missing_imports = true
 implicit_reexport = true
 python_version = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,10 +59,11 @@ path = "osmnx/_version.py"
 
 [tool.mypy]
 disable_error_code = ["attr-defined", "type-arg"]
-disallow_untyped_defs = false
+disallow_untyped_defs = true
 ignore_missing_imports = true
 implicit_optional = true
 python_version = "3.9"
+strict = true
 warn_no_return = true
 warn_redundant_casts = true
 warn_return_any = true

--- a/tests/environments/env-ci.yml
+++ b/tests/environments/env-ci.yml
@@ -26,6 +26,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
+  - typeguard
   - twine
 
   # docs

--- a/tests/environments/env-test-minimal.yml
+++ b/tests/environments/env-test-minimal.yml
@@ -29,6 +29,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
+  - typeguard
   - twine
 
   # docs

--- a/tests/lint_test.sh
+++ b/tests/lint_test.sh
@@ -17,7 +17,7 @@ twine check --strict ./dist/*
 
 # build the docs
 make -C ./docs html
-python -m sphinx -b linkcheck ./docs/source ./docs/build/linkcheck
+#python -m sphinx -b linkcheck ./docs/source ./docs/build/linkcheck
 
 # run the tests and report the test coverage
 pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=term-missing --verbose

--- a/tests/lint_test.sh
+++ b/tests/lint_test.sh
@@ -20,7 +20,7 @@ make -C ./docs html
 python -m sphinx -b linkcheck ./docs/source ./docs/build/linkcheck
 
 # run the tests and report the test coverage
-pytest --cov=./osmnx --cov-report=term-missing --verbose
+pytest --maxfail=1 --typeguard-packages=osmnx --cov=./osmnx --cov-report=term-missing --verbose
 
 # delete temp files and folders
 rm -r -f .pytest_cache .temp ./dist/ ./docs/build osmnx/__pycache__ tests/__pycache__

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -15,7 +15,6 @@ import os
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
 from xml.etree import ElementTree as etree
 
 import folium
@@ -441,7 +440,7 @@ def test_api_endpoints() -> None:
     ox.settings.overpass_rate_limit = default_overpass_rate_limit
     ox.settings.timeout = default_timeout
 
-    params: OrderedDict[Any] = OrderedDict()
+    params: OrderedDict[str, int | str] = OrderedDict()
     params["format"] = "json"
     params["address_details"] = 0
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -463,7 +463,18 @@ def test_api_endpoints() -> None:
     params["address_details"] = 0
     params["osm_ids"] = "W68876073"
 
+    # good call
     response_json = ox._nominatim._nominatim_request(params=params, request_type="lookup")
+
+    # bad call
+    with pytest.raises(
+        ox._errors.InsufficientResponseError, match="Nominatim API did not return a list of results"
+    ):
+        response_json = ox._nominatim._nominatim_request(params=params, request_type="search")
+
+    # query must be a str if by_osmid=True
+    with pytest.raises(TypeError, match="`query` must be a string if `by_osmid` is True"):
+        ox.geocode_to_gdf(query={"City": "Boston"}, by_osmid=True)
 
     # Invalid nominatim query type
     with pytest.raises(ValueError, match="Nominatim request_type must be"):

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -300,14 +300,19 @@ def test_routing() -> None:
     orig_node = ox.distance.nearest_nodes(G, orig_x, orig_y)[0]
     dest_node = ox.distance.nearest_nodes(G, dest_x, dest_y)[0]
 
-    # test non-numeric weight (should raise ValueError)
+    # test non-numeric weight, should raise ValueError
     with pytest.raises(ValueError, match="contains non-numeric values"):
         route1 = ox.shortest_path(G, orig_node, dest_node, weight="highway")
 
-    # mismatch iterable and non-iterable orig/dest should raise ValueError
+    # mismatch iterable and non-iterable orig/dest, should raise TypeError
     msg = "orig and dest must either both be iterable or neither must be iterable"
-    with pytest.raises(ValueError, match=msg):
+    with pytest.raises(TypeError, match=msg):
         route2 = ox.shortest_path(G, orig_node, [dest_node])
+
+    # mismatch lengths of orig/dest, should raise ValueError
+    msg = "orig and dest must be of equal length"
+    with pytest.raises(ValueError, match=msg):
+        route2 = ox.shortest_path(G, [orig_node] * 2, [dest_node] * 3)
 
     # test missing weight (should raise warning)
     route3 = ox.shortest_path(G, orig_node, dest_node, weight="time")

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -141,7 +141,7 @@ def test_stats() -> None:
     """Test generating graph stats."""
     # create graph, add a new node, add bearings, project it
     G = ox.graph_from_place(place1, network_type="all")
-    G.add_node(0, x=location_point[1], y=location_point[0])
+    G.add_node(0, x=location_point[1], y=location_point[0], street_count=0)
     _ = ox.bearing.calculate_bearing(0, 0, 1, 1)
     G = ox.add_edge_bearings(G)
     G = ox.add_edge_bearings(G, precision=2)
@@ -226,7 +226,7 @@ def test_osm_xml() -> None:
     first = gdf_way.iloc[0].dropna().astype(str)
     root = etree.Element("osm", attrib={"version": "0.6", "generator": "OSMnx"})
     edge = etree.SubElement(root, "way")
-    ox.osm_xml._append_nodes_as_edge_attrs(edge, first, gdf_way)
+    ox.osm_xml._append_nodes_as_edge_attrs(edge, first.to_dict(), gdf_way)
 
     # restore settings
     ox.settings.overpass_settings = default_overpass_settings

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -288,7 +288,7 @@ def test_routing() -> None:
     assert ox.speed._clean_maxspeed("100;70") is None
 
     # test collapsing multiple mph values to single kph value
-    assert ox.speed._collapse_multiple_maxspeed_values(["25 mph", "30 mph"], np.mean) == 44
+    assert ox.speed._collapse_multiple_maxspeed_values(["25 mph", "30 mph"], np.mean) == 44.25685
 
     # test collapsing invalid values: should return None
     assert ox.speed._collapse_multiple_maxspeed_values(["mph", "kph"], np.mean) is None
@@ -297,8 +297,8 @@ def test_routing() -> None:
     dest_x = np.array([-122.401429])
     orig_y = np.array([37.794302])
     dest_y = np.array([37.794987])
-    orig_node = ox.distance.nearest_nodes(G, orig_x, orig_y)[0]
-    dest_node = ox.distance.nearest_nodes(G, dest_x, dest_y)[0]
+    orig_node = int(ox.distance.nearest_nodes(G, orig_x, orig_y)[0])
+    dest_node = int(ox.distance.nearest_nodes(G, dest_x, dest_y)[0])
 
     # test non-numeric weight, should raise ValueError
     with pytest.raises(ValueError, match="contains non-numeric values"):
@@ -307,7 +307,7 @@ def test_routing() -> None:
     # mismatch iterable and non-iterable orig/dest, should raise TypeError
     msg = "orig and dest must either both be iterable or neither must be iterable"
     with pytest.raises(TypeError, match=msg):
-        route2 = ox.shortest_path(G, orig_node, [dest_node])
+        route2 = ox.shortest_path(G, orig_node, [dest_node])  # type: ignore[call-overload]
 
     # mismatch lengths of orig/dest, should raise ValueError
     msg = "orig and dest must be of equal length"
@@ -330,8 +330,8 @@ def test_routing() -> None:
     # test multiple origins-destinations
     n = 5
     nodes = np.array(G.nodes)
-    origs = np.random.choice(nodes, size=n, replace=True)
-    dests = np.random.choice(nodes, size=n, replace=True)
+    origs = [int(x) for x in np.random.choice(nodes, size=n, replace=True)]
+    dests = [int(x) for x in np.random.choice(nodes, size=n, replace=True)]
     paths1 = ox.shortest_path(G, origs, dests, weight="length", cpus=1)
     paths2 = ox.shortest_path(G, origs, dests, weight="length", cpus=2)
     paths3 = ox.shortest_path(G, origs, dests, weight="length", cpus=None)
@@ -471,7 +471,7 @@ def test_api_endpoints() -> None:
 
     # Searching on public nominatim should work even if a (bad) key was provided
     ox.settings.nominatim_key = "NOT_A_KEY"
-    response_json = ox._nominatim._nominatim_request(params=params, request_type="search")
+    response_json = ox._nominatim._nominatim_request(params=params, request_type="lookup")
 
     ox.settings.nominatim_key = default_key
     ox.settings.nominatim_endpoint = default_nominatim_endpoint

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -209,7 +209,7 @@ def test_osm_xml() -> None:
 
     # test osm xml output from gdfs
     nodes, edges = ox.graph_to_gdfs(G)
-    ox.osm_xml.save_graph_xml([nodes, edges])  # type: ignore[no-untyped-call]
+    ox.osm_xml.save_graph_xml((nodes, edges))  # type: ignore[no-untyped-call]
 
     # test ordered nodes from way
     df_uv = pd.DataFrame({"u": [54, 2, 5, 3, 10, 19, 20], "v": [76, 3, 8, 10, 5, 20, 15]})

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -475,8 +475,6 @@ def test_api_endpoints() -> None:
 
 def test_graph_save_load() -> None:
     """Test saving/loading graphs to/from disk."""
-    fp: str | Path = Path(ox.settings.data_folder) / "graph.graphml"
-
     # save graph as shapefile and geopackage
     G = ox.graph_from_point(location_point, dist=500, network_type="drive")
     ox.save_graph_shapefile(G, directed=True)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -1,6 +1,8 @@
 # ruff: noqa: E402 F841 PLR2004
 """Test suite for the package."""
 
+from __future__ import annotations
+
 # use agg backend so you don't need a display on CI
 # do this first before pyplot is imported by anything
 import matplotlib as mpl
@@ -13,6 +15,7 @@ import os
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
+from typing import Any
 from xml.etree import ElementTree as etree
 
 import folium
@@ -54,7 +57,7 @@ p = (
 polygon = wkt.loads(p)
 
 
-def test_logging():
+def test_logging() -> None:
     """Test the logger."""
     ox.log("test a fake default message")
     ox.log("test a fake debug", level=lg.DEBUG)
@@ -69,7 +72,7 @@ def test_logging():
     ox.ts(style="time")
 
 
-def test_exceptions():
+def test_exceptions() -> None:
     """Test the custom errors."""
     message = "testing exception"
 
@@ -86,18 +89,18 @@ def test_exceptions():
         raise ox._errors.GraphSimplificationError(message)
 
 
-def test_coords_rounding():
+def test_coords_rounding() -> None:
     """Test the rounding of geometry coordinates."""
     precision = 3
 
     shape1 = Point(1.123456, 2.123456)
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     shape1 = MultiPoint([(1.123456, 2.123456), (3.123456, 4.123456)])
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     shape1 = LineString([(1.123456, 2.123456), (3.123456, 4.123456)])
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     shape1 = MultiLineString(
         [
@@ -106,10 +109,10 @@ def test_coords_rounding():
         ]
     )
 
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     shape1 = Polygon([(1.123456, 2.123456), (3.123456, 4.123456), (6.123456, 5.123456)])
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     shape1 = MultiPolygon(
         [
@@ -117,13 +120,13 @@ def test_coords_rounding():
             Polygon([(16.123456, 15.123456), (13.123456, 14.123456), (12.123456, 11.123456)]),
         ]
     )
-    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)
+    shape2 = ox.utils_geo.round_geometry_coords(shape1, precision)  # type: ignore[no-untyped-call]
 
     with pytest.raises(TypeError, match="cannot round coordinates of unhandled geometry type"):
-        ox.utils_geo.round_geometry_coords(GeometryCollection(), precision)
+        ox.utils_geo.round_geometry_coords(GeometryCollection(), precision)  # type: ignore[no-untyped-call]
 
 
-def test_geocoder():
+def test_geocoder() -> None:
     """Test retrieving elements by place name and OSM ID."""
     city = ox.geocode_to_gdf("R2999176", by_osmid=True)
     city = ox.geocode_to_gdf(place1, which_result=1, buffer_dist=100)
@@ -135,7 +138,7 @@ def test_geocoder():
         _ = ox.geocode("!@#$%^&*")
 
 
-def test_stats():
+def test_stats() -> None:
     """Test generating graph stats."""
     # create graph, add a new node, add bearings, project it
     G = ox.graph_from_place(place1, network_type="all")
@@ -156,7 +159,7 @@ def test_stats():
     # calculate entropy
     Gu = ox.get_undirected(G)
     entropy = ox.bearing.orientation_entropy(Gu, weight="length")
-    fig, ax = ox.bearing.plot_orientation(Gu, area=True, title="Title")
+    fig, ax = ox.bearing.plot_orientation(Gu, area=True, title="Title")  # type: ignore[no-untyped-call]
     fig, ax = ox.plot_orientation(Gu, area=True, title="Title")
     fig, ax = ox.plot_orientation(Gu, ax=ax, area=False, title="Title")
 
@@ -173,7 +176,7 @@ def test_stats():
     G_clean = ox.consolidate_intersections(G, rebuild_graph=False)
 
 
-def test_osm_xml():
+def test_osm_xml() -> None:
     """Test working with .osm XML data."""
     # test loading a graph from a local .osm xml file
     node_id = 53098262
@@ -207,7 +210,7 @@ def test_osm_xml():
 
     # test osm xml output from gdfs
     nodes, edges = ox.graph_to_gdfs(G)
-    ox.osm_xml.save_graph_xml([nodes, edges])
+    ox.osm_xml.save_graph_xml([nodes, edges])  # type: ignore[no-untyped-call]
 
     # test ordered nodes from way
     df_uv = pd.DataFrame({"u": [54, 2, 5, 3, 10, 19, 20], "v": [76, 3, 8, 10, 5, 20, 15]})
@@ -231,7 +234,7 @@ def test_osm_xml():
     ox.settings.all_oneway = default_all_oneway
 
 
-def test_elevation():
+def test_elevation() -> None:
     """Test working with elevation data."""
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 
@@ -265,7 +268,7 @@ def test_elevation():
     G = ox.add_edge_grades(G, add_absolute=True, precision=2)
 
 
-def test_routing():
+def test_routing() -> None:
     """Test working with speed, travel time, and routing."""
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
 
@@ -311,11 +314,11 @@ def test_routing():
     route = ox.shortest_path(G, orig_node, dest_node, weight="time")
     # test good weight
     route = ox.shortest_path(G, orig_node, dest_node, weight="travel_time")
-    route = ox.distance.shortest_path(G, orig_node, dest_node, weight="travel_time")
+    route = ox.distance.shortest_path(G, orig_node, dest_node, weight="travel_time")  # type: ignore[no-untyped-call]
 
     route_edges = ox.utils_graph.route_to_gdf(G, route, "travel_time")
-    attributes = ox.utils_graph.get_route_edge_attributes(G, route)
-    attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")
+    attributes = ox.utils_graph.get_route_edge_attributes(G, route)  # type: ignore[no-untyped-call]
+    attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")  # type: ignore[no-untyped-call]
 
     fig, ax = ox.plot_graph_route(G, route, save=True)
 
@@ -331,12 +334,12 @@ def test_routing():
 
     # test k shortest paths
     routes = ox.k_shortest_paths(G, orig_node, dest_node, k=2, weight="travel_time")
-    routes = ox.distance.k_shortest_paths(G, orig_node, dest_node, k=2, weight="travel_time")
+    routes = ox.distance.k_shortest_paths(G, orig_node, dest_node, k=2, weight="travel_time")  # type: ignore[no-untyped-call]
     fig, ax = ox.plot_graph_routes(G, list(routes))
 
     # test great circle and euclidean distance calculators
-    assert ox.distance.great_circle_vec(0, 0, 1, 1) == pytest.approx(157249.6034105)
-    assert ox.distance.euclidean_dist_vec(0, 0, 1, 1) == pytest.approx(1.4142135)
+    assert ox.distance.great_circle_vec(0, 0, 1, 1) == pytest.approx(157249.6034105)  # type: ignore[no-untyped-call]
+    assert ox.distance.euclidean_dist_vec(0, 0, 1, 1) == pytest.approx(1.4142135)  # type: ignore[no-untyped-call]
 
     # test folium with keyword arguments to pass to folium.PolyLine
     gm = ox.plot_graph_folium(G, popup_attribute="name", color="#333333", weight=5, opacity=0.7)
@@ -351,7 +354,7 @@ def test_routing():
     assert isinstance(rm, folium.FeatureGroup)
 
 
-def test_plots():
+def test_plots() -> None:
     """Test visualization methods."""
     G = ox.graph_from_point(location_point, dist=500, network_type="drive")
     Gp = ox.project_graph(G)
@@ -389,7 +392,7 @@ def test_plots():
     fig, ax = ox.plot_figure_ground(address=address, dist=500, network_type="bike")
 
 
-def test_find_nearest():
+def test_find_nearest() -> None:
     """Test nearest node/edge searching."""
     # get graph and x/y coords to search
     G = ox.graph_from_point(location_point, dist=500, network_type="drive", simplify=False)
@@ -403,12 +406,12 @@ def test_find_nearest():
     nn1, dist1 = ox.distance.nearest_nodes(Gp, X[0], Y[0], return_dist=True)
 
     # get nearest edge
-    ne0 = ox.distance.nearest_edges(Gp, X[0], Y[0], interpolate=None)
-    ne1 = ox.distance.nearest_edges(Gp, X[0], Y[0], interpolate=50)
-    ne2 = ox.distance.nearest_edges(G, X[0], Y[0], interpolate=50, return_dist=True)
+    ne0 = ox.distance.nearest_edges(Gp, X[0], Y[0], interpolate=None)  # type: ignore[call-overload]
+    ne1 = ox.distance.nearest_edges(Gp, X[0], Y[0], interpolate=50)  # type: ignore[call-overload]
+    ne2 = ox.distance.nearest_edges(G, X[0], Y[0], interpolate=50, return_dist=True)  # type: ignore[call-overload]
 
 
-def test_api_endpoints():
+def test_api_endpoints() -> None:
     """Test different API endpoints."""
     default_timeout = ox.settings.timeout
     default_key = ox.settings.nominatim_key
@@ -437,7 +440,7 @@ def test_api_endpoints():
     ox.settings.overpass_rate_limit = default_overpass_rate_limit
     ox.settings.timeout = default_timeout
 
-    params = OrderedDict()
+    params: OrderedDict[Any] = OrderedDict()
     params["format"] = "json"
     params["address_details"] = 0
 
@@ -470,9 +473,9 @@ def test_api_endpoints():
     ox.settings.overpass_endpoint = default_overpass_endpoint
 
 
-def test_graph_save_load():
+def test_graph_save_load() -> None:
     """Test saving/loading graphs to/from disk."""
-    fp = Path(ox.settings.data_folder) / "graph.graphml"
+    fp: str | Path = Path(ox.settings.data_folder) / "graph.graphml"
 
     # save graph as shapefile and geopackage
     G = ox.graph_from_point(location_point, dist=500, network_type="drive")
@@ -561,7 +564,7 @@ def test_graph_save_load():
     G = ox.load_graphml(graphml_str=data, node_dtypes=nd, edge_dtypes=ed)
 
 
-def test_graph_from_functions():
+def test_graph_from_functions() -> None:
     """Test downloading graphs from Overpass."""
     # test subdividing a large geometry (raises a UserWarning)
     bbox = ox.utils_geo.bbox_from_point((0, 0), dist=1e5, project_utm=True)
@@ -604,7 +607,7 @@ def test_graph_from_functions():
         location_point, dist=500, custom_filter=cf, dist_type="bbox", network_type="all"
     )
 
-    ox.settings.memory = "1073741824"
+    ox.settings.memory = 1073741824
     G = ox.graph_from_point(
         location_point,
         dist=500,
@@ -613,7 +616,7 @@ def test_graph_from_functions():
     )
 
 
-def test_features():
+def test_features() -> None:
     """Test downloading features from Overpass."""
     # geometries_from_bbox - bounding box query to return no data
     with pytest.raises(ox._errors.InsufficientResponseError):
@@ -621,8 +624,8 @@ def test_features():
 
     # geometries_from_bbox - successful
     north, south, east, west = ox.utils_geo.bbox_from_point(location_point, dist=500)
-    tags = {"landuse": True, "building": True, "highway": True}
-    gdf = ox.geometries_from_bbox(north, south, east, west, tags=tags)
+    tags1 = {"landuse": True, "building": True, "highway": True}
+    gdf = ox.geometries_from_bbox(north, south, east, west, tags=tags1)
     fig, ax = ox.plot_footprints(gdf)
     fig, ax = ox.plot_footprints(gdf, ax=ax, bbox=(10, 0, 10, 0))
 
@@ -630,17 +633,17 @@ def test_features():
     gdf = ox.geometries_from_point((48.15, 10.02), tags={"landuse": True}, dist=2000)
 
     # geometries_from_place - includes test of list of places
-    tags = {"amenity": True, "landuse": ["retail", "commercial"], "highway": "bus_stop"}
-    gdf = ox.geometries_from_place(place1, tags=tags, buffer_dist=0)
-    gdf = ox.geometries_from_place([place1], tags=tags)
+    tags2 = {"amenity": True, "landuse": ["retail", "commercial"], "highway": "bus_stop"}
+    gdf = ox.geometries_from_place(place1, tags=tags2, buffer_dist=0)
+    gdf = ox.geometries_from_place([place1], tags=tags2)
 
     # geometries_from_polygon
     polygon = ox.geocode_to_gdf(place1).geometry.iloc[0]
-    ox.geometries_from_polygon(polygon, tags)
+    ox.geometries_from_polygon(polygon, tags2)
 
     # geometries_from_address - includes testing overpass settings and snapshot from 2019
     ox.settings.overpass_settings = '[out:json][timeout:200][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.geometries_from_address(address, tags=tags)
+    gdf = ox.geometries_from_address(address, tags=tags2)
 
     # geometries_from_xml - tests error handling of clipped XMLs with incomplete geometry
     gdf = ox.geometries_from_xml("tests/input_data/planet_10.068,48.135_10.071,48.137.osm")

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -36,7 +36,7 @@ from shapely.geometry import Polygon
 
 import osmnx as ox
 
-ox.config(log_console=True)
+ox.config(log_console=True)  # type: ignore[no-untyped-call]
 ox.settings.log_console = True
 ox.settings.log_file = True
 ox.settings.use_cache = True
@@ -303,24 +303,25 @@ def test_routing() -> None:
 
     # test non-numeric weight (should raise ValueError)
     with pytest.raises(ValueError, match="contains non-numeric values"):
-        route = ox.shortest_path(G, orig_node, dest_node, weight="highway")
+        route1 = ox.shortest_path(G, orig_node, dest_node, weight="highway")
 
     # mismatch iterable and non-iterable orig/dest should raise ValueError
     msg = "orig and dest must either both be iterable or neither must be iterable"
     with pytest.raises(ValueError, match=msg):
-        route = ox.shortest_path(G, orig_node, [dest_node])
+        route2 = ox.shortest_path(G, orig_node, [dest_node])
 
     # test missing weight (should raise warning)
-    route = ox.shortest_path(G, orig_node, dest_node, weight="time")
+    route3 = ox.shortest_path(G, orig_node, dest_node, weight="time")
     # test good weight
-    route = ox.shortest_path(G, orig_node, dest_node, weight="travel_time")
-    route = ox.distance.shortest_path(G, orig_node, dest_node, weight="travel_time")  # type: ignore[no-untyped-call]
+    route4 = ox.distance.shortest_path(G, orig_node, dest_node, weight="travel_time")  # type: ignore[no-untyped-call]
+    route5 = ox.shortest_path(G, orig_node, dest_node, weight="travel_time")
+    assert route5 is not None
 
-    route_edges = ox.utils_graph.route_to_gdf(G, route, "travel_time")
-    attributes = ox.utils_graph.get_route_edge_attributes(G, route)  # type: ignore[no-untyped-call]
-    attributes = ox.utils_graph.get_route_edge_attributes(G, route, "travel_time")  # type: ignore[no-untyped-call]
+    route_edges = ox.utils_graph.route_to_gdf(G, route5, "travel_time")
+    attributes = ox.utils_graph.get_route_edge_attributes(G, route5)  # type: ignore[no-untyped-call]
+    attributes = ox.utils_graph.get_route_edge_attributes(G, route5, "travel_time")  # type: ignore[no-untyped-call]
 
-    fig, ax = ox.plot_graph_route(G, route, save=True)
+    fig, ax = ox.plot_graph_route(G, route5, save=True)
 
     # test multiple origins-destinations
     n = 5
@@ -342,15 +343,15 @@ def test_routing() -> None:
     assert ox.distance.euclidean_dist_vec(0, 0, 1, 1) == pytest.approx(1.4142135)  # type: ignore[no-untyped-call]
 
     # test folium with keyword arguments to pass to folium.PolyLine
-    gm = ox.plot_graph_folium(G, popup_attribute="name", color="#333333", weight=5, opacity=0.7)
-    rm = ox.plot_route_folium(G, route, color="#cc0000", weight=5, opacity=0.7)
+    gm = ox.plot_graph_folium(G, popup_attribute="name", color="#333333", weight=5, opacity=0.7)  # type: ignore[no-untyped-call]
+    rm = ox.plot_route_folium(G, route5, color="#cc0000", weight=5, opacity=0.7)  # type: ignore[no-untyped-call]
 
     # test calling folium plotters with FeatureGroup instead of Map, and extra kwargs
     fg = folium.FeatureGroup(name="legend name", show=True)
-    gm = ox.plot_graph_folium(G, graph_map=fg)
+    gm = ox.plot_graph_folium(G, graph_map=fg)  # type: ignore[no-untyped-call]
     assert isinstance(gm, folium.FeatureGroup)
 
-    rm = ox.plot_route_folium(G, route, route_map=fg, tooltip="x")
+    rm = ox.plot_route_folium(G, route5, route_map=fg, tooltip="x")  # type: ignore[no-untyped-call]
     assert isinstance(rm, folium.FeatureGroup)
 
 
@@ -477,8 +478,8 @@ def test_graph_save_load() -> None:
     """Test saving/loading graphs to/from disk."""
     # save graph as shapefile and geopackage
     G = ox.graph_from_point(location_point, dist=500, network_type="drive")
-    ox.save_graph_shapefile(G, directed=True)
-    ox.save_graph_shapefile(G, filepath=Path(ox.settings.data_folder) / "graph_shapefile")
+    ox.save_graph_shapefile(G, directed=True)  # type: ignore[no-untyped-call]
+    ox.save_graph_shapefile(G, filepath=Path(ox.settings.data_folder) / "graph_shapefile")  # type: ignore[no-untyped-call]
     ox.save_graph_geopackage(G, directed=False)
 
     # save/load geopackage and convert graph to/from node/edge GeoDataFrames
@@ -618,33 +619,33 @@ def test_features() -> None:
     """Test downloading features from Overpass."""
     # geometries_from_bbox - bounding box query to return no data
     with pytest.raises(ox._errors.InsufficientResponseError):
-        gdf = ox.geometries_from_bbox(0.009, -0.009, 0.009, -0.009, tags={"building": True})
+        gdf = ox.geometries_from_bbox(0.009, -0.009, 0.009, -0.009, tags={"building": True})  # type: ignore[no-untyped-call]
 
     # geometries_from_bbox - successful
     north, south, east, west = ox.utils_geo.bbox_from_point(location_point, dist=500)
     tags1 = {"landuse": True, "building": True, "highway": True}
-    gdf = ox.geometries_from_bbox(north, south, east, west, tags=tags1)
+    gdf = ox.geometries_from_bbox(north, south, east, west, tags=tags1)  # type: ignore[no-untyped-call]
     fig, ax = ox.plot_footprints(gdf)
     fig, ax = ox.plot_footprints(gdf, ax=ax, bbox=(10, 0, 10, 0))
 
     # geometries_from_point - tests multipolygon creation
-    gdf = ox.geometries_from_point((48.15, 10.02), tags={"landuse": True}, dist=2000)
+    gdf = ox.geometries_from_point((48.15, 10.02), tags={"landuse": True}, dist=2000)  # type: ignore[no-untyped-call]
 
     # geometries_from_place - includes test of list of places
     tags2 = {"amenity": True, "landuse": ["retail", "commercial"], "highway": "bus_stop"}
-    gdf = ox.geometries_from_place(place1, tags=tags2, buffer_dist=0)
-    gdf = ox.geometries_from_place([place1], tags=tags2)
+    gdf = ox.geometries_from_place(place1, tags=tags2, buffer_dist=0)  # type: ignore[no-untyped-call]
+    gdf = ox.geometries_from_place([place1], tags=tags2)  # type: ignore[no-untyped-call]
 
     # geometries_from_polygon
     polygon = ox.geocode_to_gdf(place1).geometry.iloc[0]
-    ox.geometries_from_polygon(polygon, tags2)
+    ox.geometries_from_polygon(polygon, tags2)  # type: ignore[no-untyped-call]
 
     # geometries_from_address - includes testing overpass settings and snapshot from 2019
     ox.settings.overpass_settings = '[out:json][timeout:200][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.geometries_from_address(address, tags=tags2)
+    gdf = ox.geometries_from_address(address, tags=tags2)  # type: ignore[no-untyped-call]
 
     # geometries_from_xml - tests error handling of clipped XMLs with incomplete geometry
-    gdf = ox.geometries_from_xml("tests/input_data/planet_10.068,48.135_10.071,48.137.osm")
+    gdf = ox.geometries_from_xml("tests/input_data/planet_10.068,48.135_10.071,48.137.osm")  # type: ignore[no-untyped-call]
 
     # test loading a geodataframe from a local .osm xml file
     with bz2.BZ2File("tests/input_data/West-Oakland.osm.bz2") as f:
@@ -652,6 +653,6 @@ def test_features() -> None:
         os.write(handle, f.read())
         os.close(handle)
     for filename in ("tests/input_data/West-Oakland.osm.bz2", temp_filename):
-        gdf = ox.geometries_from_xml(filename)
+        gdf = ox.geometries_from_xml(filename)  # type: ignore[no-untyped-call]
         assert "Willow Street" in gdf["name"].to_numpy()
     Path.unlink(Path(temp_filename))


### PR DESCRIPTION
*Comments, feedback, and improvements welcome.*

This PR adds complete type annotations throughout the package (validated via `mypy . --strict` and `typeguard` in CI) for user type hinting and type checking. It also fixes minor bugs and inconsistencies revealed by the subsequent type check validation. Resolves #1062.

This PR includes the following enhancements:
  - [x] adds type annotations to all public and private functions
  - [x] adds mypy strict validation to CI
  - [x] adds typeguard runtime validation to CI
  - [x] maintains test coverage
  - [x] fix bug where `_downloader._save_to_cache` function expected `requests.response.ok` bool values as an argument, but was being passed `requests.response.status_code` int values instead
  - [x] minor fixes throughout to address inconsistencies revealed by mypy static checking and typeguard runtime checking