### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.9.0 (Unreleased)
+## 1.9.0 (2023-01-31)
 
 - add endpoint_attrs argument to simplification.simplify_graph function to flexibly relax strictness (#1117)
 - fix a bug in the features module's polygon handling (#1104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - add endpoint_attrs argument to simplification.simplify_graph function to flexibly relax strictness (#1117)
 - fix a bug in the features module's polygon handling (#1104)
 - update obsolete numpy random number generation (#1108)
-- update warning messages to note that deprecated code will be removed in v2.0.0 (#1111)
+- update FutureWarning messages to note that deprecated code will be removed in v2.0.0 (#1111)
 - deprecate strict argument in simplification.simplify_graph function in favor of new endpoint_attrs argument (#1117)
 - deprecate north, south, east, west arguments throughout package in favor of bbox tuple argument (#1112)
 - deprecate return_coords argument in graph.graph_from_address function (#1105)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **OSMnx** is a Python package to easily download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap. You can download and model walking, driving, or biking networks with a single line of code then analyze and visualize them. You can just as easily work with urban amenities/points of interest, building footprints, transit stops, elevation data, street orientations, speed/travel time, and routing.
 
+OSMnx 2.0 is coming soon: read the [migration guide](https://github.com/gboeing/osmnx/issues/1123).
+
 ## Citation
 
 If you use OSMnx in your work, please cite the journal article:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,10 @@ OSMnx |version|
 
 **OSMnx** is a Python package to easily download, model, analyze, and visualize street networks and other geospatial features from OpenStreetMap. You can download and model walking, driving, or biking networks with a single line of code then analyze and visualize them. You can just as easily work with urban amenities/points of interest, building footprints, transit stops, elevation data, street orientations, speed/travel time, and routing.
 
+OSMnx 2.0 is coming soon: read the `migration guide`_.
+
+.. _migration guide: https://github.com/gboeing/osmnx/issues/1123
+
 Citation
 --------
 

--- a/docs/source/user-reference.rst
+++ b/docs/source/user-reference.rst
@@ -1,9 +1,11 @@
 User Reference
 ==============
 
-This is the User Reference for the OSMnx package. If you are looking for an introduction to OSMnx, read the :doc:`getting-started` guide.
+This is the User Reference for the OSMnx package. If you are looking for an introduction to OSMnx, read the :doc:`getting-started` guide. This guide describes the usage of OSMnx's public API.
 
-This guide describes the usage of OSMnx's public API. Every function can be accessed via ``ox.module_name.function_name()`` and many can also be accessed directly via ``ox.function_name()`` as a shortcut.
+OSMnx 2.0 is coming soon: read the `migration guide`_.
+
+.. _migration guide: https://github.com/gboeing/osmnx/issues/1123
 
 osmnx.bearing module
 --------------------

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -82,6 +82,7 @@ def add_edge_bearings(G, precision=None):
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -300,6 +301,7 @@ def plot_orientation(
     warn(
         "The `plot_orientation` function moved to the `plot` module. Calling it "
         "via the `bearing` module will raise an exception starting with the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
     return plot.plot_orientation(

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -131,6 +131,7 @@ def great_circle_vec(lat1, lng1, lat2, lng2, earth_radius=EARTH_RADIUS_M):
     warn(
         "The `great_circle_vec` function has been renamed `great_circle`. Calling "
         "`great_circle_vec` will raise an error starting in the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
     return great_circle(lat1, lng1, lat2, lng2, earth_radius)
@@ -162,6 +163,7 @@ def euclidean_dist_vec(y1, x1, y2, x2):
     warn(
         "The `euclidean_dist_vec` function has been renamed `euclidean`. Calling "
         "`euclidean_dist_vec` will raise an error starting in the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
     return euclidean(y1, x1, y2, x2)
@@ -207,6 +209,7 @@ def add_edge_lengths(G, precision=None, edges=None):
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -374,6 +377,7 @@ def nearest_edges(G, X, Y, interpolate=None, return_dist=False):
         warn(
             "The `interpolate` parameter has been deprecated and will be "
             "removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -447,6 +451,7 @@ def shortest_path(G, orig, dest, weight="length", cpus=1):
     warn(
         "The `shortest_path` function has moved to the `routing` module. Calling it "
         "via the `distance` module will raise an error starting in the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
     return routing.shortest_path(G, orig, dest, weight, cpus)
@@ -482,6 +487,7 @@ def k_shortest_paths(G, orig, dest, k, weight="length"):
     warn(
         "The `k_shortest_paths` function has moved to the `routing` module. "
         "Calling it via the `distance` module will raise an error in the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
     return routing.k_shortest_paths(G, orig, dest, k, weight)

--- a/osmnx/elevation.py
+++ b/osmnx/elevation.py
@@ -55,6 +55,7 @@ def add_edge_grades(G, add_absolute=True, precision=None):
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -211,6 +212,7 @@ def add_node_elevations_google(
         warn(
             "The `max_locations_per_batch` parameter is deprecated and will be "
             "removed the v2.0.0 release, use the `batch_size` parameter instead",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -219,6 +221,7 @@ def add_node_elevations_google(
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -229,6 +232,7 @@ def add_node_elevations_google(
             "The `url_template` parameter is deprecated and will be removed "
             "in the v2.0.0 release. Configure the `settings` module's "
             "`elevation_url_template` instead",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -123,7 +123,7 @@ def features_from_bbox(north=None, south=None, east=None, west=None, bbox=None, 
             "The `north`, `south`, `east`, and `west` parameters are deprecated and "
             "will be removed in the v2.0.0 release. Use the `bbox` parameter instead."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
         bbox = (north, south, east, west)
 
     # convert bounding box to a polygon
@@ -270,6 +270,7 @@ def features_from_place(query, tags, which_result=None, buffer_dist=None):
         warn(
             "The buffer_dist argument has been deprecated and will be removed "
             "in the v2.0.0 release. Buffer your query area directly, if desired.",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/folium.py
+++ b/osmnx/folium.py
@@ -63,6 +63,7 @@ def plot_graph_folium(
         "and/or routes automatically using GeoPandas.GeoDataFrame.explore instead, "
         "for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the "
         "OSMnx examples gallery for complete details and demonstrations.",
+        FutureWarning,
         stacklevel=2,
     )
     # create gdf of all graph edges
@@ -117,6 +118,7 @@ def plot_route_folium(
         "and/or routes automatically using GeoPandas.GeoDataFrame.explore instead, "
         "for example like: `ox.graph_to_gdfs(G, nodes=False).explore()`. See the "
         "OSMnx examples gallery for complete details and demonstrations.",
+        FutureWarning,
         stacklevel=2,
     )
     # create gdf of the route edges in order

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -102,6 +102,7 @@ def geocode_to_gdf(query, which_result=None, by_osmid=False, buffer_dist=None):
         warn(
             "The buffer_dist argument has been deprecated and will be removed "
             "in the v2.0.0 release. Buffer your results directly, if desired.",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/geometries.py
+++ b/osmnx/geometries.py
@@ -43,7 +43,7 @@ def geometries_from_bbox(north, south, east, west, tags):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_bbox(north, south, east, west, tags=tags)
 
 
@@ -69,7 +69,7 @@ def geometries_from_point(center_point, tags, dist=1000):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_point(center_point, tags, dist)
 
 
@@ -95,7 +95,7 @@ def geometries_from_address(address, tags, dist=1000):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_address(address, tags, dist)
 
 
@@ -123,7 +123,7 @@ def geometries_from_place(query, tags, which_result=None, buffer_dist=None):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_place(query, tags, which_result, buffer_dist)
 
 
@@ -147,7 +147,7 @@ def geometries_from_polygon(polygon, tags):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_polygon(polygon, tags)
 
 
@@ -173,5 +173,5 @@ def geometries_from_xml(filepath, polygon=None, tags=None):
     -------
     gdf : geopandas.GeoDataFrame
     """
-    warn(DEP_MSG, stacklevel=2)
+    warn(DEP_MSG, FutureWarning, stacklevel=2)
     return features.features_from_xml(filepath, polygon, tags)

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -96,7 +96,7 @@ def graph_from_bbox(
             "The `north`, `south`, `east`, and `west` parameters are deprecated and "
             "will be removed in the v2.0.0 release. Use the `bbox` parameter instead."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
         bbox = (north, south, east, west)
 
     # convert bounding box to a polygon
@@ -270,6 +270,7 @@ def graph_from_address(
             "The `return_coords` argument has been deprecated and will be removed in "
             "the v2.0.0 release. Future behavior will be as though `return_coords=False`. "
             "If you want the address's geocoded coordinates, use the `geocode` function.",
+            FutureWarning,
             stacklevel=2,
         )
     # geocode the address string to a (lat, lon) point
@@ -367,6 +368,7 @@ def graph_from_place(
         warn(
             "The buffer_dist argument has been deprecated and will be removed "
             "in the v2.0.0 release. Buffer your query area directly, if desired.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -458,6 +460,7 @@ def graph_from_polygon(
         warn(
             "The clean_periphery argument has been deprecated and will be removed in "
             "the v2.0.0 release. Future behavior will be as though clean_periphery=True.",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -87,6 +87,7 @@ def save_graph_shapefile(G, filepath=None, encoding="utf-8", directed=False):
         "The `save_graph_shapefile` function is deprecated and will be removed "
         "in the v2.0.0 release. Instead, use the `save_graph_geopackage` function "
         "to save graphs as GeoPackage files for subsequent GIS analysis.",
+        FutureWarning,
         stacklevel=2,
     )
 

--- a/osmnx/osm_xml.py
+++ b/osmnx/osm_xml.py
@@ -159,6 +159,7 @@ def save_graph_xml(
         "The save_graph_xml function has moved from the osm_xml module to the io module. "
         "osm_xml.save_graph_xml has been deprecated and will be removed in the v2.0.0 "
         "release. Access the function via the io module instead.",
+        FutureWarning,
         stacklevel=2,
     )
     _save_graph_xml(

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -56,6 +56,7 @@ def get_colors(n, cmap="viridis", start=0.0, stop=1.0, alpha=1.0, return_hex=Fal
         warn(
             "The `return_hex` parameter has been deprecated and will be removed "
             "in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -483,7 +484,7 @@ def plot_figure_ground(
             "The `edge_color` parameter is deprecated and will be removed in the "
             "v2.0.0 release. Use `color` instead."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
 
     if smooth_joints is None:
         smooth_joints = True
@@ -492,7 +493,7 @@ def plot_figure_ground(
             "The `smooth_joints` parameter is deprecated and will be removed in the "
             "v2.0.0 release. In the future this function will behave as though True."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
 
     # if user did not pass in custom street widths, create a dict of defaults
     if street_widths is None:
@@ -522,7 +523,7 @@ def plot_figure_ground(
     # dist multiplier to ensure we get more than enough network. simplify in
     # non-strict mode to not combine multiple street types into single edge
     elif address is not None:
-        warn(dep_msg, stacklevel=2)
+        warn(dep_msg, FutureWarning, stacklevel=2)
         G, point = graph.graph_from_address(
             address,
             dist=dist * multiplier,
@@ -534,7 +535,7 @@ def plot_figure_ground(
         )
         G = simplification.simplify_graph(G, strict=False)
     elif point is not None:
-        warn(dep_msg, stacklevel=2)
+        warn(dep_msg, FutureWarning, stacklevel=2)
         G = graph.graph_from_point(
             point,
             dist=dist * multiplier,

--- a/osmnx/speed.py
+++ b/osmnx/speed.py
@@ -63,6 +63,7 @@ def add_edge_speeds(G, hwy_speeds=None, fallback=None, precision=None, agg=np.me
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 
@@ -151,6 +152,7 @@ def add_edge_travel_times(G, precision=None):
     else:
         warn(
             "The `precision` parameter is deprecated and will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/truncate.py
+++ b/osmnx/truncate.py
@@ -107,7 +107,7 @@ def truncate_graph_bbox(
             "The `north`, `south`, `east`, and `west` parameters are deprecated and "
             "will be removed in the v2.0.0 release. Use the `bbox` parameter instead."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
         bbox = (north, south, east, west)
 
     # convert bounding box to a polygon, then truncate
@@ -157,6 +157,7 @@ def truncate_graph_polygon(
         warn(
             "The `quadrat_width` and `min_num` parameters are deprecated and "
             "will be removed in the v2.0.0 release.",
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/osmnx/utils.py
+++ b/osmnx/utils.py
@@ -213,6 +213,7 @@ def config(
         "the v2.0.0 release. Instead, use the `settings` module directly to "
         "configure a global setting's value. For example, "
         "`ox.settings.log_console=True`.",
+        FutureWarning,
         stacklevel=2,
     )
 

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -215,6 +215,7 @@ def round_geometry_coords(geom, precision):
     warn(
         "The `round_geometry_coords` function is deprecated and will be "
         "removed in the v2.0.0 release.",
+        FutureWarning,
         stacklevel=2,
     )
 
@@ -459,7 +460,7 @@ def bbox_to_poly(north=None, south=None, east=None, west=None, bbox=None):
             "The `north`, `south`, `east`, and `west` parameters are deprecated and "
             "will be removed in the v2.0.0 release. Use the `bbox` parameter instead."
         )
-        warn(msg, stacklevel=2)
+        warn(msg, FutureWarning, stacklevel=2)
     else:
         north, south, east, west = bbox
     return Polygon([(west, south), (east, south), (east, north), (west, north)])

--- a/osmnx/utils_graph.py
+++ b/osmnx/utils_graph.py
@@ -238,6 +238,7 @@ def get_route_edge_attributes(
     warn(
         "The `get_route_edge_attributes` function has been deprecated and will "
         "be removed in the v2.0.0 release. Use the `route_to_gdf` function instead.",
+        FutureWarning,
         stacklevel=2,
     )
     attribute_values = []

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -17,7 +17,7 @@ mamba update conda-smithy --yes --no-banner
 
 # test the docs build and validate that all their links are live
 rm -rf ./docs/build
-make -C ./docs html
+make -C ./docs html SPHINXOPTS="-W --keep-going"
 python -m sphinx -b linkcheck ./docs/source ./docs/build/linkcheck
 rm -rf ./docs/build
 


### PR DESCRIPTION
See changelog for details.

This PR updates the readme and the docs to point to the 2.0 migration guide at #1123.