### PR TITLE
_bearings_distribution: bin_centers terminology

### DIFF
--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -268,8 +268,9 @@ def _bearings_distribution(
 
     Returns
     -------
-    bin_counts, bin_edges
-        Counts of bearings per bin and the bins edges.
+    bin_counts, bin_centers
+        Counts of bearings per bin and the bins' centers in degrees.
+        Both arrays are of length `num_bins`.
     """
     n = num_bins * 2
     bins = np.arange(n + 1) * 360 / n
@@ -282,6 +283,6 @@ def _bearings_distribution(
     count = np.roll(count, 1)
     bin_counts = count[::2] + count[1::2]
 
-    # because we merged the bins, their edges are now only every other one
-    bin_edges = bin_edges[range(0, len(bin_edges), 2)]
-    return bin_counts, bin_edges
+    # because we merged the bins, their centers are now only every other one
+    bin_centers = bin_edges[range(0, len(bin_edges) - 1, 2)]
+    return bin_counts, bin_centers

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -748,7 +748,7 @@ def plot_orientation(  # noqa: PLR0913
             "zorder": 3,
         }
 
-    # get the bearings' distribution's bin counts and edges
+    # get the bearing distribution's bin counts and center values in degrees
     bin_counts, bin_centers = bearing._bearings_distribution(
         G,
         num_bins,
@@ -756,8 +756,7 @@ def plot_orientation(  # noqa: PLR0913
         weight=weight,
     )
 
-    # positions: where to center each bar. ignore the last bin edge, because
-    # it's the same as the first (i.e., 0 degrees = 360 degrees)
+    # positions: where to center each bar
     positions = np.radians(bin_centers)
 
     # width: make bars fill the circumference without gaps or overlaps

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -749,7 +749,7 @@ def plot_orientation(  # noqa: PLR0913
         }
 
     # get the bearings' distribution's bin counts and edges
-    bin_counts, bin_edges = bearing._bearings_distribution(
+    bin_counts, bin_centers = bearing._bearings_distribution(
         G,
         num_bins,
         min_length=min_length,
@@ -758,7 +758,7 @@ def plot_orientation(  # noqa: PLR0913
 
     # positions: where to center each bar. ignore the last bin edge, because
     # it's the same as the first (i.e., 0 degrees = 360 degrees)
-    positions = np.radians(bin_edges[:-1])
+    positions = np.radians(bin_centers)
 
     # width: make bars fill the circumference without gaps or overlaps
     width = 2 * np.pi / num_bins

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -165,6 +165,24 @@ def test_bearings() -> None:
     assert list(bearings) == [0.0, 180.0]  # north and south
     assert list(weights) == [2.0, 2.0]
 
+    # test _bearings_distribution split bin implementation
+    bin_counts, bin_centers = ox.bearing._bearings_distribution(
+        G,
+        num_bins=1,
+        min_length=0,
+        weight=None,
+    )
+    assert list(bin_counts) == [1.0]
+    assert list(bin_centers) == [0.0]
+    bin_counts, bin_centers = ox.bearing._bearings_distribution(
+        G,
+        num_bins=2,
+        min_length=0,
+        weight=None,
+    )
+    assert list(bin_counts) == [1.0, 0.0]
+    assert list(bin_centers) == [0.0, 180.0]
+
 
 def test_osm_xml() -> None:
     """Test working with .osm XML data."""


### PR DESCRIPTION
This PR addresses terminology in internal-use functions for greater clarity:

- bin centers were referred to as "edges"
- `bin_counts` and `bin_centers` now have the same length, which is best for most use cases