### PR TITLE
Similar functionality is available for the function graph_from_point(). But it is not available for def graph_from_polygon(). Here user can get buffer with fixed 500 meters. However the value of buffer is not flexible. My proposal is that we can also add one new parameter buffer_dist(float value) so that user can give any buffer value to create a graph with the buffer. Because I faced this problem while working on a government project. I am sending push request for this update. Please review my proposal.

### DIFF
--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -102,6 +102,7 @@ def graph_from_bbox(
         retain_all=retain_all,
         truncate_by_edge=truncate_by_edge,
         custom_filter=custom_filter,
+        buffer_dist=None,
     )
 
     msg = f"graph_from_bbox returned graph with {len(G):,} nodes and {len(G.edges):,} edges"
@@ -163,6 +164,8 @@ def graph_from_point(
         e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
         in a `network_type` that is in `settings.bidirectional_network_types`
         if you want the graph to be fully bidirectional.
+    buffer_dist : float
+        distance to buffer around the place geometry, in meters
 
     Returns
     -------
@@ -370,6 +373,7 @@ def graph_from_place(
         retain_all=retain_all,
         truncate_by_edge=truncate_by_edge,
         custom_filter=custom_filter,
+        buffer_dist=None,
     )
 
     msg = f"graph_from_place returned graph with {len(G):,} nodes and {len(G.edges):,} edges"
@@ -385,6 +389,7 @@ def graph_from_polygon(
     retain_all: bool = False,
     truncate_by_edge: bool = False,
     custom_filter: str | None = None,
+    buffer_dist=None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within the boundaries of a (Multi)Polygon.
@@ -420,6 +425,8 @@ def graph_from_polygon(
         e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
         in a `network_type` that is in `settings.bidirectional_network_types`
         if you want the graph to be fully bidirectional.
+     buffer_dist : float
+        distance to buffer around the place geometry, in meters
 
     Returns
     -------


### PR DESCRIPTION
Similar functionality is available for the function graph_from_point(). But it is not available for def graph_from_polygon(). Here user can get buffer with fixed 500 meters. However the value of buffer is not flexible. My proposal is that we can also add one new parameter buffer_dist(float value) so that user can give any buffer value to create a graph with the buffer.

# Read these instructions carefully

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests. Please edit the changelog to reflect your changes.

In this pull request, please include:

- a reference to related issue(s)
- a description of the changes proposed in the pull request
- an example code snippet illustrating usage of the new functionality
