### PR TITLE
Replace deprecated GeoPandas unary_union with union_all(), require geopandas>=1.0.1

### DIFF
--- a/osmnx/_osm_xml.py
+++ b/osmnx/_osm_xml.py
@@ -213,7 +213,7 @@ def _save_graph_xml(
 
     # convert graph to node/edge gdfs and create dict of spatial bounds
     gdf_nodes, gdf_edges = convert.graph_to_gdfs(G, fill_edge_geometry=False)
-    coords = [str(round(c, PRECISION)) for c in gdf_nodes.unary_union.bounds]
+    coords = [str(round(c, PRECISION)) for c in gdf_nodes.union_all().bounds]
     bounds = dict(zip(["minlon", "minlat", "maxlon", "maxlat"], coords))
 
     # add default values (if missing) for standard attrs

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -267,7 +267,7 @@ def features_from_place(
     """
     # extract the geometry from the GeoDataFrame to use in query
     gdf_place = geocoder.geocode_to_gdf(query, which_result=which_result)
-    polygon = gdf_place["geometry"].unary_union
+    polygon = gdf_place["geometry"].union_all()
     msg = "Constructed place geometry polygon(s) to query Overpass"
     utils.log(msg, level=lg.INFO)
 

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -357,7 +357,7 @@ def graph_from_place(
     """
     # extract the geometry from the GeoDataFrame to use in query
     gdf_place = geocoder.geocode_to_gdf(query, which_result=which_result)
-    polygon = gdf_place["geometry"].unary_union
+    polygon = gdf_place["geometry"].union_all()
 
     msg = "Constructed place geometry polygon(s) to query Overpass"
     utils.log(msg, level=lg.INFO)

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -553,7 +553,7 @@ def plot_figure_ground(
     node_sizes: list[float] | float = [node_widths[node] for node in Gu.nodes]
 
     # define the view extents of the plotting figure
-    node_geoms = convert.graph_to_gdfs(Gu, edges=False, node_geometry=True).unary_union
+    node_geoms = convert.graph_to_gdfs(Gu, edges=False, node_geometry=True).union_all()
     lonlat_point = node_geoms.centroid.coords[0]
     latlon_point = tuple(reversed(lonlat_point))
     bbox = utils_geo.bbox_from_point(latlon_point, dist=dist, project_utm=False)

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -580,10 +580,10 @@ def _merge_nodes_geometric(
         # fill nulls (resulting from missing tolerances) with original points,
         # then merge overlapping geometries
         tols = pd.Series(tolerance).reindex(gdf_nodes.index)
-        merged = gdf_nodes.buffer(tols).fillna(gdf_nodes["geometry"]).unary_union
+        merged = gdf_nodes.buffer(tols).fillna(gdf_nodes["geometry"]).union_all()
     else:
         # buffer nodes then merge overlapping geometries
-        merged = gdf_nodes.buffer(tolerance).unary_union
+        merged = gdf_nodes.buffer(tolerance).union_all()
 
     # extract the member geometries if it's a multi-geometry
     merged = merged.geoms if hasattr(merged, "geoms") else merged
@@ -665,7 +665,7 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
                 for suffix, wcc in enumerate(wccs):
                     # set subcluster xy to the centroid of just these nodes
                     idx = list(wcc)
-                    subcluster_centroid = node_points.loc[idx].unary_union.centroid
+                    subcluster_centroid = node_points.loc[idx].union_all().centroid
                     gdf.loc[idx, "x"] = subcluster_centroid.x
                     gdf.loc[idx, "y"] = subcluster_centroid.y
                     # move to subcluster by appending suffix to cluster label

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Visualization",
 ]
 dependencies = [
-  "geopandas>=0.12",
+  "geopandas>=1.0.1",
   "networkx>=2.5",
   "numpy>=1.21",
   "pandas>=1.1",


### PR DESCRIPTION
Replace the deprecated GeoPandas `.unary_union` attribute with the `.union_all()` method, as recommended in https://github.com/geopandas/geopandas/pull/3007.

Closes #1178 and should help make OSMnx be compatible with GeoPandas 1.0.0.

Furthermore, note that `unary_union` is also imported from `shapely.ops` somewhere:

https://github.com/gboeing/osmnx/blob/a99fc4d7dd9ee13b256347af7cdcb58d214e8915/osmnx/features.py#L32

This PR doesn't adres that, but maybe we should?