### PR TITLE
added open-elevation public api in addition to google's

### DIFF
--- a/osmnx/settings.py
+++ b/osmnx/settings.py
@@ -40,12 +40,16 @@ doh_url_template : str | None
     Endpoint to resolve DNS-over-HTTPS if local DNS resolution fails. Set to
     None to disable DoH, but see `downloader._config_dns` documentation for
     caveats. Default is: `"https://8.8.8.8/resolve?name={hostname}"`
-elevation_url_template : str
+elevation_url_template_google : str
     Endpoint of the Google Maps Elevation API (or equivalent), containing
     exactly two parameters: `locations` and `key`. Default is:
     `"https://maps.googleapis.com/maps/api/elevation/json?locations={locations}&key={key}"`
     One example of an alternative equivalent would be Open Topo Data:
     `"https://api.opentopodata.org/v1/aster30m?locations={locations}&key={key}"`
+elevation_url_template_open : str
+    Endpoint of the Open Elevation API (or equivalent), containing
+    exactly one parameter: `locations`. Default is:
+    `"https://api.open-elevation.com/api/v1/lookup?locations={locations}"`
 http_accept_language : str
     HTTP header accept-language. Default is `"en"`. Note that Nominatim's
     default language is "en" and it may sort its results' importance scores
@@ -139,8 +143,11 @@ data_folder: str | Path = "./data"
 default_access: str = '["access"!~"private"]'
 default_crs: str = "epsg:4326"
 doh_url_template: str | None = "https://8.8.8.8/resolve?name={hostname}"
-elevation_url_template: str = (
+elevation_url_template_google: str = (
     "https://maps.googleapis.com/maps/api/elevation/json?locations={locations}&key={key}"
+)
+elevation_url_template_open: str = (
+    "https://api.open-elevation.com/api/v1/lookup?locations={locations}"
 )
 http_accept_language: str = "en"
 http_referer: str = "OSMnx Python package (https://github.com/gboeing/osmnx)"


### PR DESCRIPTION
- a reference to related issue(s): https://github.com/gboeing/osmnx/issues/341#issuecomment-548892510
- a description of the changes proposed in the pull request: Adds another function called `add_node_elevations_open` which only requires the locations and nothing else.
- an example code snippet illustrating usage of the new functionality: 
```
import osmnx as ox
# get the street network for san francisco
place = "San Francisco"
place_query = {"city": "San Francisco", "state": "California", "country": "USA"}
G = ox.graph_from_place(place_query, network_type="drive")
# add elevation to each of the nodes, using the open elevation API
G = ox.elevation.add_node_elevations_open(G)
```

In case we want to fully replace google's elevation api, please let me know, the swap is fairly simple and i will create a new PR. 

Although I should mention the free [public api](https://github.com/Jorl17/open-elevation/blob/master/docs/api.md) may not be very performant. Hence the reduction of batch size from 512 to 128, and a default wait of 0.5 seconds to not overload the server.
