### PR TITLE
Error from XML String results from reverse geocode _nominatim_request

### DIFF
--- a/osmnx/_nominatim.py
+++ b/osmnx/_nominatim.py
@@ -152,7 +152,7 @@ def _nominatim_request(
 
     response_json = _http._parse_response(response)
     if not isinstance(response_json, list):
-        msg = "Nominatim API did not return a list of results."
+        msg = f"Nominatim API did not return a list of results. Reponse Json is of type {type(response_json)}"
         raise InsufficientResponseError(msg)
     _http._save_to_cache(prepared_url, response_json, response.ok)
     return response_json


### PR DESCRIPTION
While developing a script that uses osmnx capabilities, I encountered an issue when I wanted to use the _nominatim_request feature to reverse geocode. For example, when running the code...
`import osmnx as ox`
`params = {'lat':43.70776104984752,'lon':-72.29470591308431}`
`reverse_dict = ox._nominatim._nominatim_request(params, request_type='reverse')`

...an InsufficientResponseError is returned, with the results of the reverse geocode populating the error message:

`InsufficientResponseError: 'nominatim.openstreetmap.org' responded: 200 OK <?xml version="1.0" encoding="UTF-8" ?>
<reversegeocode timestamp="Wed, 03 Jul 2024 16:42:24 +00:00" attribution="Data © OpenStreetMap contributors, ODbL 1.0. http://osm.org/copyright" querystring="lat=43.70776104984752&amp;lon=-72.29470591308431&amp;format=xml"><result place_id="10173084" osm_type="way" osm_id="245204742" ref="The Goat Path" lat="43.7079428" lon="-72.2948434" boundingbox="43.7065509,43.7153819,-72.2964453,-72.2859228" place_rank="27" address_rank="27">The Goat Path, Hanover, Grafton County, New Hampshire, 03755, United States</result><addressparts><road>The Goat Path</road><town>Hanover</town><county>Grafton County</county><state>New Hampshire</state><ISO3166-2-lvl4>US-NH</ISO3166-2-lvl4><postcode>03755</postcode><country>United States</country><country_code>us</country_code></addressparts></reversegeocode>`

Looking into the _nominatim.py and _http.py scripts, I discovered this was due to the expectation in the _parse_response function that the response from the API request would be either a dictionary or list of dictionaries (_http.py line 320): `response_json: dict[str, Any] | list[dict[str, Any]] = response.json()`

Since it appears the reverse geocode results are a xml formatted string, this trips the InsufficientResponseError. My proposed code suggests that the error only be raised should the string not be able to be parsed as an XML (I have included functions developed out of the python standard library 'xml' module to parse a string XML into a JSON / Dict). This solution then returns the result as a list of dicts when prompted with the same request shown earlier:
`[{'reversegeocode': {'result': 'The Goat Path, Hanover, Grafton County, New Hampshire, 03755, United States',
   'addressparts': {'road': 'The Goat Path',
    'town': 'Hanover',
    'county': 'Grafton County',
    'state': 'New Hampshire',
    'ISO3166-2-lvl4': 'US-NH',
    'postcode': '03755',
    'country': 'United States',
    'country_code': 'us'}}}]`

Only the _http.py and _nominatim.py scripts are altered, and all in order to account for these String-XML type responses seen in the reverse geocoding request.