### PR TITLE
Union filters

### DIFF
--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -391,7 +391,9 @@ def _download_overpass_network(
     # the '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
         for way_filter_str in way_filter:
-            query_str = f"{overpass_settings};(way{way_filter_str}(poly:{polygon_coord_str!r});>;);out;"
+            query_str = (
+                f"{overpass_settings};(way{way_filter_str}(poly:{polygon_coord_str!r});>;);out;"
+            )
             yield _overpass_request(OrderedDict(data=query_str))
 
 

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -350,7 +350,7 @@ def _create_overpass_features_query(  # noqa: PLR0912
 def _download_overpass_network(
     polygon: Polygon | MultiPolygon,
     network_type: str,
-    custom_filter: str | None,
+    custom_filter: str | list[str] | None,
 ) -> Iterator[dict[str, Any]]:
     """
     Retrieve networked ways and nodes within boundary from the Overpass API.
@@ -371,7 +371,13 @@ def _download_overpass_network(
     """
     # create a filter to exclude certain kinds of ways based on the requested
     # network_type, if provided, otherwise use custom_filter
-    way_filter = custom_filter if custom_filter is not None else _get_network_filter(network_type)
+    way_filter = []
+    if isinstance(custom_filter, list):
+        way_filter = custom_filter
+    elif isinstance(custom_filter, str):
+        way_filter = [custom_filter]
+    else:
+        way_filter = [_get_network_filter(network_type)]
 
     # create overpass settings string
     overpass_settings = _make_overpass_settings()
@@ -384,8 +390,9 @@ def _download_overpass_network(
     # pass exterior coordinates of each polygon in list to API, one at a time
     # the '>' makes it recurse so we get ways and the ways' nodes.
     for polygon_coord_str in polygon_coord_strs:
-        query_str = f"{overpass_settings};(way{way_filter}(poly:{polygon_coord_str!r});>;);out;"
-        yield _overpass_request(OrderedDict(data=query_str))
+        for way_filter_str in way_filter:
+            query_str = f"{overpass_settings};(way{way_filter_str}(poly:{polygon_coord_str!r});>;);out;"
+            yield _overpass_request(OrderedDict(data=query_str))
 
 
 def _download_overpass_features(

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -77,9 +77,14 @@ def graph_from_bbox(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
-        in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional.
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
+        If single `str` is provded, intersection will be used to combine results, 
+        e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
+        of 50 and having two lanes.
+        If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
+        will query all ways with maximum speed of 50 or having two lanes.
+        Also pass in a `network_type` that is in `settings.bidirectional_network_types`
+        if you want the graph to be fully bidirectional. 
 
     Returns
     -------
@@ -160,9 +165,14 @@ def graph_from_point(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
-        in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional.
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
+        If single `str` is provded, intersection will be used to combine results, 
+        e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
+        of 50 and having two lanes.
+        If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
+        will query all ways with maximum speed of 50 or having two lanes.
+        Also pass in a `network_type` that is in `settings.bidirectional_network_types`
+        if you want the graph to be fully bidirectional. 
 
     Returns
     -------
@@ -251,9 +261,14 @@ def graph_from_address(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
-        in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional.
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
+        If single `str` is provded, intersection will be used to combine results, 
+        e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
+        of 50 and having two lanes.
+        If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
+        will query all ways with maximum speed of 50 or having two lanes.
+        Also pass in a `network_type` that is in `settings.bidirectional_network_types`
+        if you want the graph to be fully bidirectional. 
 
     Returns
     -------
@@ -341,9 +356,14 @@ def graph_from_place(
         (Multi)Polygon or raise an error if OSM doesn't return one.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
-        in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional.
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
+        If single `str` is provded, intersection will be used to combine results, 
+        e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
+        of 50 and having two lanes.
+        If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
+        will query all ways with maximum speed of 50 or having two lanes.
+        Also pass in a `network_type` that is in `settings.bidirectional_network_types`
+        if you want the graph to be fully bidirectional. 
 
     Returns
     -------
@@ -415,9 +435,14 @@ def graph_from_polygon(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. Also pass
-        in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional.
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
+        If single `str` is provded, intersection will be used to combine results, 
+        e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
+        of 50 and having two lanes.
+        If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
+        will query all ways with maximum speed of 50 or having two lanes.
+        Also pass in a `network_type` that is in `settings.bidirectional_network_types`
+        if you want the graph to be fully bidirectional. 
 
     Returns
     -------

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -44,7 +44,7 @@ def graph_from_bbox(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    custom_filter: str | None = None,
+    custom_filter: str | list[str] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within a lat-lon bounding box.
@@ -118,7 +118,7 @@ def graph_from_point(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    custom_filter: str | None = None,
+    custom_filter: str | list[str] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within some distance of a lat-lon point.
@@ -210,7 +210,7 @@ def graph_from_address(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    custom_filter: str | None = None,
+    custom_filter: str | list[str] | None = None,
 ) -> nx.MultiDiGraph | tuple[nx.MultiDiGraph, tuple[float, float]]:
     """
     Download and create a graph within some distance of an address.
@@ -293,7 +293,7 @@ def graph_from_place(
     retain_all: bool = False,
     truncate_by_edge: bool = False,
     which_result: int | None | list[int | None] = None,
-    custom_filter: str | None = None,
+    custom_filter: str | list[str] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within the boundaries of some place(s).
@@ -382,7 +382,7 @@ def graph_from_polygon(
     simplify: bool = True,
     retain_all: bool = False,
     truncate_by_edge: bool = False,
-    custom_filter: str | None = None,
+    custom_filter: str | list[str] | None = None,
 ) -> nx.MultiDiGraph:
     """
     Download and create a graph within the boundaries of a (Multi)Polygon.

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -77,14 +77,14 @@ def graph_from_bbox(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
-        If single `str` is provded, intersection will be used to combine results, 
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`.
+        If single `str` is provded, intersection will be used to combine results,
         e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
         of 50 and having two lanes.
         If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
         will query all ways with maximum speed of 50 or having two lanes.
         Also pass in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional. 
+        if you want the graph to be fully bidirectional.
 
     Returns
     -------
@@ -165,14 +165,14 @@ def graph_from_point(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
-        If single `str` is provded, intersection will be used to combine results, 
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`.
+        If single `str` is provded, intersection will be used to combine results,
         e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
         of 50 and having two lanes.
         If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
         will query all ways with maximum speed of 50 or having two lanes.
         Also pass in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional. 
+        if you want the graph to be fully bidirectional.
 
     Returns
     -------
@@ -261,14 +261,14 @@ def graph_from_address(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
-        If single `str` is provded, intersection will be used to combine results, 
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`.
+        If single `str` is provded, intersection will be used to combine results,
         e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
         of 50 and having two lanes.
         If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
         will query all ways with maximum speed of 50 or having two lanes.
         Also pass in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional. 
+        if you want the graph to be fully bidirectional.
 
     Returns
     -------
@@ -356,14 +356,14 @@ def graph_from_place(
         (Multi)Polygon or raise an error if OSM doesn't return one.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
-        If single `str` is provded, intersection will be used to combine results, 
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`.
+        If single `str` is provded, intersection will be used to combine results,
         e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
         of 50 and having two lanes.
         If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
         will query all ways with maximum speed of 50 or having two lanes.
         Also pass in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional. 
+        if you want the graph to be fully bidirectional.
 
     Returns
     -------
@@ -435,14 +435,14 @@ def graph_from_polygon(
         neighbors is within the bounding box.
     custom_filter
         A custom ways filter to be used instead of the `network_type` presets,
-        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`. 
-        If single `str` is provded, intersection will be used to combine results, 
+        e.g. `'["power"~"line"]' or '["highway"~"motorway|trunk"]'`.
+        If single `str` is provded, intersection will be used to combine results,
         e.g `'[maxspeed=50][lanes=2]'` will query all ways with maximum speed
         of 50 and having two lanes.
         If `list[str]`, union will be used, e.g. `['[maxspeed=50]', '[lanes=2]']`
         will query all ways with maximum speed of 50 or having two lanes.
         Also pass in a `network_type` that is in `settings.bidirectional_network_types`
-        if you want the graph to be fully bidirectional. 
+        if you want the graph to be fully bidirectional.
 
     Returns
     -------


### PR DESCRIPTION
# Union filters

Discussion: https://github.com/gboeing/osmnx/issues/1199

## Problem
When developing city graph models, the size of the resulting graph might be important. Thanks to OSMnx, it's possible to use a pre-defined filters to request  a network, based on desired types of OSM ways. But sometimes, it's needed to add an additional ways from OSM into network or union them based on multiple filters.

## Technical details
When using `custom_filter`, it's not possible to request additional roads by Overpass union condition.

## Example
We need to request additional road by name (The Road), ignoring all other conditions.

In Overpass this request will look like this:
```
(way[...](poly:'***'); way[name="The Road"](poly:'***'););
```

OSMnx constructs Overpass request like this, where `$filter` is pre-defined filter or provided by user.
```
[out:json][timeout:180];
(way[$filter](poly:'***');>;);
out;
```

## Proposal
Make `custom_filter` accepts not only string, but a list of filters and then combine the result into single graph. 
Because OSMnx already supports sub-divided requests, it's easy to implement this without changing logic on actual graph creation (simplification, connectivity, etc). 

## Usage example
On example of city Petrozavodsk we will use `graph_from_place ` with `network_type = "drive"`. This will give us a graph on a perfect level of details. But for some reason, two additional roads are required to be in model.

The request below correctly adds these roads.

```
ptz_graph = ox.graph_from_place(
    'Petrozavodsk, Russia',
    custom_filter=[
        op._get_network_filter("drive"),
        f'[name="улица Достоевского"]',
        f'[name="улица Калевалы"]'
    ]
)
```