### PR TITLE
Fix tests on Windows

### DIFF
--- a/osmnx/_osm_xml.py
+++ b/osmnx/_osm_xml.py
@@ -174,7 +174,8 @@ def _overpass_json_from_xml(filepath: Path, encoding: str) -> dict[str, Any]:
         file.seek(0)
         handler = _OSMContentHandler()
         sax_parse(file, handler)  # noqa: S317
-        return handler.object
+
+    return handler.object
 
 
 def _save_graph_xml(

--- a/osmnx/graph.py
+++ b/osmnx/graph.py
@@ -603,19 +603,16 @@ def _create_graph(
     nodes: dict[int, dict[str, Any]] = {}
     paths: dict[int, dict[str, Any]] = {}
 
-    # consume response_jsons generator to download data from server
+    # consume response_jsons generator to download data from server. if
+    # cache_only_mode, just consume response_jsons then continue next loop.
+    # otherwise, extract nodes and paths from the downloaded OSM data.
     response_count = 0
     for response_json in response_jsons:
         response_count += 1
-
-        # if cache_only_mode, consume response_jsons then continue next loop
-        if settings.cache_only_mode:  # pragma: no cover
-            continue
-
-        # otherwise, extract nodes and paths from the downloaded OSM data
-        nodes_temp, paths_temp = _parse_nodes_paths(response_json)
-        nodes.update(nodes_temp)
-        paths.update(paths_temp)
+        if not settings.cache_only_mode:
+            nodes_temp, paths_temp = _parse_nodes_paths(response_json)
+            nodes.update(nodes_temp)
+            paths.update(paths_temp)
 
     msg = f"Retrieved all data from API in {response_count} request(s)"
     utils.log(msg, level=lg.INFO)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -220,8 +220,7 @@ def test_osm_xml() -> None:
         f.write(file_contents)
 
     # load and test graph_from_xml across the .osm, bzip2, and gzip files
-    for filepath_str in (path_bz2, path_gz, path_osm):
-        filepath = Path(filepath_str)
+    for filepath in (path_bz2, path_gz, path_osm):
         G = ox.graph_from_xml(filepath)
         assert node_id in G.nodes
 
@@ -231,9 +230,9 @@ def test_osm_xml() -> None:
             assert edge_key in G.edges
             assert G.edges[edge_key]["name"] in {"8th Street", "Willow Street"}
 
-        # delete temporary files
-        if filepath.suffix != ".bz2":
-            Path.unlink(filepath)
+    # delete temporary files
+    Path.unlink(Path(path_osm))
+    Path.unlink(Path(path_gz))
 
     # test OSM xml saving
     G = ox.graph_from_point(location_point, dist=500, network_type="drive", simplify=False)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -210,17 +210,17 @@ def test_osm_xml() -> None:
         file_contents = f.read()
 
     # write the contents to a .osm file
-    _, path_osm = tempfile.mkstemp(suffix=".osm")
-    with Path(path_osm).open("wb") as f:
+    path_osm_temp = path_bz2.strip(".bz2")
+    with Path(path_osm_temp).open("wb") as f:
         f.write(file_contents)
 
     # write the contents to a gzip file
-    path_gz = path_osm + ".gz"
-    with gzip.open(path_gz, mode="wb") as f:
+    path_gz_temp = path_osm_temp + ".gz"
+    with gzip.open(path_gz_temp, mode="wb") as f:
         f.write(file_contents)
 
-    # load and test graph_from_xml across the .osm, bzip2, and gzip files
-    for filepath in (path_bz2, path_gz, path_osm):
+    # load and test graph_from_xml across the .osm, .bz2, and .gz files
+    for filepath in (path_bz2, path_gz_temp, path_osm_temp):
         G = ox.graph_from_xml(filepath)
         assert node_id in G.nodes
 
@@ -229,6 +229,10 @@ def test_osm_xml() -> None:
             assert neighbor_id in G.nodes
             assert edge_key in G.edges
             assert G.edges[edge_key]["name"] in {"8th Street", "Willow Street"}
+
+    # delete the temporary .osm and .gz files
+    Path.unlink(Path(path_osm_temp))
+    Path.unlink(Path(path_gz_temp))
 
     # test OSM xml saving
     G = ox.graph_from_point(location_point, dist=500, network_type="drive", simplify=False)
@@ -264,10 +268,6 @@ def test_osm_xml() -> None:
     # restore settings
     ox.settings.overpass_settings = default_overpass_settings
     ox.settings.all_oneway = default_all_oneway
-
-    # delete temporary files
-    Path.unlink(Path(path_osm))
-    Path.unlink(Path(path_gz))
 
 
 def test_elevation() -> None:

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -230,10 +230,6 @@ def test_osm_xml() -> None:
             assert edge_key in G.edges
             assert G.edges[edge_key]["name"] in {"8th Street", "Willow Street"}
 
-    # delete temporary files
-    Path.unlink(Path(path_osm))
-    Path.unlink(Path(path_gz))
-
     # test OSM xml saving
     G = ox.graph_from_point(location_point, dist=500, network_type="drive", simplify=False)
     fp = Path(ox.settings.data_folder) / "graph.osm"
@@ -268,6 +264,10 @@ def test_osm_xml() -> None:
     # restore settings
     ox.settings.overpass_settings = default_overpass_settings
     ox.settings.all_oneway = default_all_oneway
+
+    # delete temporary files
+    Path.unlink(Path(path_osm))
+    Path.unlink(Path(path_gz))
 
 
 def test_elevation() -> None:


### PR DESCRIPTION
Change where temp OSM XML files are stored for CI tests, because CI on Windows wasn't able to delete files saved in the default system temp folder (I think?). It was [broken](https://github.com/gboeing/osmnx/actions/runs/11549040322/job/32141415945) following #1227, but now it's [fixed](https://github.com/gboeing/osmnx/actions/runs/11642052615/job/32421211375).