### PR TITLE
only allow topological node consolidation to be run once on a graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.2 (TBD)
 
 - improve docstrings (#1272)
+- fix bug where consolidate_intersections function would mutate the passed-in graph (#1273)
+- provide user-friendly error message if consolidate_intersections is run more than once (#1273)
 
 ## 2.0.1 (2025-01-01)
 

--- a/osmnx/_osm_xml.py
+++ b/osmnx/_osm_xml.py
@@ -228,9 +228,9 @@ def _save_graph_xml(
         )
         warn(msg, category=UserWarning, stacklevel=2)
 
-    # raise error if graph has been simplified
-    if G.graph.get("simplified", False):
-        msg = "Graph must be unsimplified to save as OSM XML."
+    # raise error if graph has been simplified or nodes consolidated
+    if G.graph.get("simplified", False) or G.graph.get("consolidated", False):
+        msg = "Graph must be unsimplified and unconsolidated to save as OSM XML."
         raise GraphSimplificationError(msg)
 
     # set default filepath if None was provided

--- a/osmnx/_osm_xml.py
+++ b/osmnx/_osm_xml.py
@@ -228,9 +228,9 @@ def _save_graph_xml(
         )
         warn(msg, category=UserWarning, stacklevel=2)
 
-    # raise error if graph has been simplified or nodes consolidated
-    if G.graph.get("simplified", False) or G.graph.get("consolidated", False):
-        msg = "Graph must be unsimplified and unconsolidated to save as OSM XML."
+    # raise error if graph has been simplified
+    if G.graph.get("simplified", False):
+        msg = "Graph must be unsimplified to save as OSM XML."
         raise GraphSimplificationError(msg)
 
     # set default filepath if None was provided

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -188,7 +188,10 @@ def load_graphml(
         raise ValueError(msg)
 
     # specify default graph/node/edge attribute values' data types
-    default_graph_dtypes = {"simplified": _convert_bool_string}
+    default_graph_dtypes = {
+        "consolidated": _convert_bool_string,
+        "simplified": _convert_bool_string,
+    }
     default_node_dtypes = {
         "elevation": float,
         "elevation_res": float,

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -335,7 +335,7 @@ def simplify_graph(  # noqa: C901, PLR0912
 
     Returns
     -------
-    G
+    Gs
         Topologically simplified graph, with a new `geometry` attribute on
         each simplified edge.
     """
@@ -513,19 +513,19 @@ def consolidate_intersections(
 
     Returns
     -------
-    G or gs
+    Gc or gs
         If `rebuild_graph=True`, returns MultiDiGraph with consolidated
         intersections and (optionally) reconnected edge geometries. If
         `rebuild_graph=False`, returns GeoSeries of Points representing the
         centroids of street intersections.
     """
+    # make a copy to not mutate original graph object caller passed in
+    G = G.copy()
+
     # if dead_ends is False, discard dead-ends to retain only intersections
     if not dead_ends:
         spn = stats.streets_per_node(G)
         dead_end_nodes = [node for node, count in spn.items() if count <= 1]
-
-        # make a copy to not mutate original graph object caller passed in
-        G = G.copy()
         G.remove_nodes_from(dead_end_nodes)
 
     if rebuild_graph:

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -630,6 +630,10 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
         A rebuilt graph with consolidated intersections and (optionally)
         reconnected edge geometries.
     """
+    if G.graph.get("consolidated"):  # pragma: no cover
+        msg = "This graph has already been consolidated, cannot consolidate it again."
+        raise GraphSimplificationError(msg)
+
     # default node attributes to aggregate upon consolidation
     if node_attr_aggs is None:
         node_attr_aggs = {"elevation": "mean"}
@@ -714,6 +718,9 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
                     # if there are multiple unique values, keep one of each
                     node_attrs[col] = unique_vals
             Gc.add_node(cluster_label, **node_attrs)
+
+    # mark the graph as having been consolidated
+    G.graph["consolidated"] = True
 
     if len(G.edges) == 0 or not reconnect_edges:
         # if reconnect_edges is False or there are no edges in original graph


### PR DESCRIPTION
This PR fixes inscrutable error messages from occurring when trying to run topological node consolidation via the `consolidate_intersections` more than once on the same graph.

For example, consider the snippet:

```python
import osmnx as ox
G = ox.graph.graph_from_place("Piedmont, California, USA", network_type="drive")
G = ox.projection.project_graph(G)
G = ox.simplification.consolidate_intersections(G, tolerance=10)
G = ox.simplification.consolidate_intersections(G, tolerance=10)
```

Would give you:
```
ValueError: Grouper for 'cluster' not 1-dimensional
```

And if you instead set `tolerance=1` you'd get:
```
TypeError: networkx.classes.digraph.DiGraph.add_node() got multiple values for keyword argument 'osmid_original'
```

These errors are impossible for a user to understand what's wrong. The nature of the problem is that the node consolidation algorithm can only be run once (because it's lossy) and should only be run once (because its parameterization allows near infinite customization to get a precise outcome in only one run). The `simplify_graph` function handles this gracefully by marked a graph as "simplified" and then raising an interpretable error if it's run again.

This PR makes the `consolidate_intersections` consistent with the behavior of the `simplify_graph` function so its behavior is clearer for users:
  - A graph is marked as "consolidated" with a graph-level attribute if the `consolidate_intersections` function is run in topological mode (i.e., you rebuilt the graph)
  - If a graph marked as "consolidated" has the`consolidate_intersections` function run in topological mode again, it raises an error with a clearer message: "GraphSimplificationError: This graph has already been consolidated, cannot consolidate it again."
  - The `io` module gracefully handles the "consolidated" graph-level attribute when loading to/from file.
  - Fixes a bug where the `consolidate_intersections` would mutate the passed-in graph itself.