### PR TITLE
Consolidate deg/rad conversions and bins creation in code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - fix bug where consolidate_intersections function would mutate the passed-in graph (#1273)
 - fix bug in parsing time when calculating pause duration between requests (#1277)
-- refactor interals of caching and pausing between requests (#1279)
+- refactor internals of caching and pausing between requests (#1279)
+- streamline internal handling of radians throughout package (#1281)
 - provide user-friendly error message if consolidate_intersections is run more than once (#1273)
 - improve docstrings (#1272 #1274)
 

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -69,14 +69,14 @@ def calculate_bearing(
         The bearing(s) in decimal degrees.
     """
     # get the latitudes and the difference in longitudes, all in radians
-    lat1 = np.radians(lat1)
-    lat2 = np.radians(lat2)
-    delta_lon = np.radians(lon2 - lon1)
+    lat1 = np.deg2rad(lat1)
+    lat2 = np.deg2rad(lat2)
+    delta_lon = np.deg2rad(lon2 - lon1)
 
     # calculate initial bearing from -180 degrees to +180 degrees
     y = np.sin(delta_lon) * np.cos(lat2)
     x = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(delta_lon)
-    initial_bearing = np.degrees(np.arctan2(y, x))
+    initial_bearing = np.rad2deg(np.arctan2(y, x))
 
     # normalize to 0-360 degrees to get compass bearing
     bearing: float | npt.NDArray[np.float64] = initial_bearing % 360

--- a/osmnx/bearing.py
+++ b/osmnx/bearing.py
@@ -277,7 +277,7 @@ def _bearings_distribution(
     # Bins will be merged in pairs after the histogram is computed. The last
     # bin edge is the same as the first (i.e., 0 degrees = 360 degrees).
     num_split_bins = num_bins * 2
-    split_bin_edges = np.arange(num_split_bins + 1) * 360 / num_split_bins
+    split_bin_edges = np.linspace(0, 360, num_split_bins + 1)
 
     bearings, weights = _extract_edge_bearings(G, min_length, weight)
     split_bin_counts, split_bin_edges = np.histogram(

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -761,7 +761,7 @@ def plot_orientation(  # noqa: PLR0913
     )
 
     # positions: where to center each bar
-    positions = np.radians(bin_centers)
+    positions = np.deg2rad(bin_centers)
 
     # width: make bars fill the circumference without gaps or overlaps
     width = 2 * np.pi / num_bins
@@ -995,7 +995,7 @@ def _config_ax(ax: Axes, crs: Any, bbox: tuple[float, float, float, float], padd
         ax.set_aspect("equal")
     else:
         # if not projected, conform aspect ratio to not stretch plot
-        cos_lat = np.cos((bottom + top) / 2 / 180 * np.pi)
+        cos_lat = np.cos(np.deg2rad((bottom + top) / 2))
         ax.set_aspect(1 / cos_lat)
 
     return ax

--- a/osmnx/utils_geo.py
+++ b/osmnx/utils_geo.py
@@ -396,8 +396,8 @@ def bbox_from_point(
     EARTH_RADIUS_M = 6_371_009  # meters
     lat, lon = point
 
-    delta_lat = (dist / EARTH_RADIUS_M) * (180 / np.pi)
-    delta_lon = (dist / EARTH_RADIUS_M) * (180 / np.pi) / np.cos(lat * np.pi / 180)
+    delta_lat = np.rad2deg(dist / EARTH_RADIUS_M)
+    delta_lon = np.rad2deg(dist / EARTH_RADIUS_M) / np.cos(np.deg2rad(lat))
     top = lat + delta_lat
     bottom = lat - delta_lat
     right = lon + delta_lon


### PR DESCRIPTION
This is just a refactoring PR (no bug and no feature) and hopefully improved the consistency and readability of the code.

Some numpy functions need radians and these were calculated in different ways. This PR consolidates them to the usage of `deg2rad` and `rad2deg`. The second commit suggests a more descriptive creation of bins.
