### PR TITLE
Add function to animate graph routes

### DIFF
--- a/osmnx/__init__.py
+++ b/osmnx/__init__.py
@@ -34,6 +34,7 @@ from .io import load_graphml as load_graphml
 from .io import save_graph_geopackage as save_graph_geopackage
 from .io import save_graph_xml as save_graph_xml
 from .io import save_graphml as save_graphml
+from .plot import animate_graph_route as animate_graph_route
 from .plot import plot_figure_ground as plot_figure_ground
 from .plot import plot_footprints as plot_footprints
 from .plot import plot_graph as plot_graph

--- a/osmnx/__init__.py
+++ b/osmnx/__init__.py
@@ -34,7 +34,6 @@ from .io import load_graphml as load_graphml
 from .io import save_graph_geopackage as save_graph_geopackage
 from .io import save_graph_xml as save_graph_xml
 from .io import save_graphml as save_graphml
-from .plot import animate_graph_route as animate_graph_route
 from .plot import plot_figure_ground as plot_figure_ground
 from .plot import plot_footprints as plot_footprints
 from .plot import plot_graph as plot_graph

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -347,11 +347,6 @@ def plot_graph_route(
         **pg_kwargs,
     )
 
-    # scatterplot origin and destination points (first/last nodes in route)
-    od_x = (G.nodes[route[0]]["x"], G.nodes[route[-1]]["x"])
-    od_y = (G.nodes[route[0]]["y"], G.nodes[route[-1]]["y"])
-    ax.scatter(od_x, od_y, s=orig_dest_size, c=route_color, alpha=route_alpha, edgecolor="none")
-
     # assemble the route edge geometries' x and y coords then plot the line
     x = []
     y = []

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -337,15 +337,15 @@ def plot_graph_route(
     fig, ax
         The resulting matplotlib figure and axes objects.
     """
-    _verify_mpl()
-    if ax is None:
-        # plot the graph but not the route, and override any user show/close
-        # args for now: we'll do that later
-        overrides = {"show", "save", "close"}
-        kwargs = {k: v for k, v in pg_kwargs.items() if k not in overrides}
-        fig, ax = plot_graph(G, show=False, save=False, close=False, **kwargs)
-    else:
-        fig = ax.figure  # type: ignore[assignment]
+    fig, ax = _prepare_graph_route_plot(
+        G,
+        route,
+        orig_dest_color=route_color,
+        orig_dest_alpha=route_alpha,
+        orig_dest_size=orig_dest_size,
+        ax=ax,
+        **pg_kwargs,
+    )
 
     # scatterplot origin and destination points (first/last nodes in route)
     od_x = (G.nodes[route[0]]["x"], G.nodes[route[-1]]["x"])
@@ -414,20 +414,15 @@ def animate_graph_route(
     fig, ax
         The resulting matplotlib figure and axes objects.
     """
-    _verify_mpl()
-    if ax is None:
-        # plot the graph but not the route, and override any user show/close
-        # args for now: we'll do that later
-        overrides = {"show", "save", "close"}
-        kwargs = {k: v for k, v in pg_kwargs.items() if k not in overrides}
-        fig, ax = plot_graph(G, show=False, save=False, close=False, **kwargs)
-    else:
-        fig = ax.figure  # type: ignore[assignment]
-
-    # scatterplot origin and destination points (first/last nodes in route)
-    od_x = (G.nodes[route[0]]["x"], G.nodes[route[-1]]["x"])
-    od_y = (G.nodes[route[0]]["y"], G.nodes[route[-1]]["y"])
-    ax.scatter(od_x, od_y, s=orig_dest_size, c=route_color, alpha=route_alpha, edgecolor="none")
+    fig, ax = _prepare_graph_route_plot(
+        G,
+        route,
+        orig_dest_color=route_color,
+        orig_dest_alpha=route_alpha,
+        orig_dest_size=orig_dest_size,
+        ax=ax,
+        **pg_kwargs,
+    )
 
     # assemble list of lists of x and y coords for each edge
     x = []
@@ -1119,6 +1114,66 @@ def _config_ax(ax: Axes, crs: Any, bbox: tuple[float, float, float, float], padd
         ax.set_aspect(1 / cos_lat)
 
     return ax
+
+
+def _prepare_graph_route_plot(
+    G: nx.MultiDiGraph,
+    route: list[int],
+    *,
+    orig_dest_color: str = "r",
+    orig_dest_alpha: float = 0.5,
+    orig_dest_size: float = 100,
+    ax: Axes | None = None,
+    **pg_kwargs: Any,  # noqa: ANN401
+) -> tuple[Figure, Axes]:
+    """
+    Plot graph and origin/destination nodes of a route, helper for plot_graph_route and animate_graph_route.
+
+    Parameters
+    ----------
+    G
+        Input graph.
+    route
+        A path of node IDs.
+    orig_dest_color
+        The color of the origin and destination nodes.
+    orig_dest_alpha
+        Opacity of the origin and destination nodes.
+    orig_dest_size
+        Size of the origin and destination nodes.
+    ax
+        If not None, plot on this pre-existing axes instance.
+    **pg_kwargs
+        Keyword arguments to pass to `plot_graph`.
+
+    Returns
+    -------
+    fig, ax
+        The resulting matplotlib figure and axes objects.
+    """
+    _verify_mpl()
+    if ax is None:
+        # plot the graph but not the route, and override any user show/close
+        # args for now: we'll do that later
+        overrides = {"show", "save", "close"}
+        kwargs = {k: v for k, v in pg_kwargs.items() if k not in overrides}
+        fig, ax = plot_graph(G, show=False, save=False, close=False, **kwargs)
+    else:
+        fig = ax.figure  # type: ignore[assignment]
+
+    # scatterplot origin and destination points (first/last nodes in route)
+    od_x = (G.nodes[route[0]]["x"], G.nodes[route[-1]]["x"])
+    od_y = (G.nodes[route[0]]["y"], G.nodes[route[-1]]["y"])
+    ax.scatter(
+        od_x,
+        od_y,
+        s=orig_dest_size,
+        c=orig_dest_color,
+        alpha=orig_dest_alpha,
+        edgecolor="none",
+    )
+
+    return fig, ax
 
 
 # if polar = False, return Axes

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -366,6 +366,7 @@ def test_routing() -> None:
     route_edges = ox.routing.route_to_gdf(G, route5, weight="travel_time")
 
     fig, ax = ox.plot_graph_route(G, route5, save=True)
+    fig, ax = ox.animate_graph_route(G, route5, save=True)
 
     # test multiple origins-destinations
     n = 5

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -366,7 +366,7 @@ def test_routing() -> None:
     route_edges = ox.routing.route_to_gdf(G, route5, weight="travel_time")
 
     fig, ax = ox.plot_graph_route(G, route5, save=True)
-    fig, ax = ox.animate_graph_route(G, route5, save=True)
+    fig, ax = ox.plot.animate_graph_route(G, route5, save=True)
 
     # test multiple origins-destinations
     n = 5


### PR DESCRIPTION
Opening a PR to implement feature proposed in #1187. Adds a new function `animate_graph_route` that is analogous to `plot_graph_route`, but shows a edge-by-edge animation instead of a static image. 

In 59fd139ac3f5c2046009065ef7e7650c9097042e I simply copied the existing `plot_graph_route` function and modified it to create an animation. Since this created duplication of code shared by the two funcs (i.e. plotting the graph itself and origin/destination nodes) I then added a 52ffb46372d220e21290d173f1a088b5398a4ff6 to refactor this out. Wanted to keep that as a separate commit commit so it's easy to drop per your advice (thinking perhaps you may want to avoid touching existing functionality?). 

For testing just added a single call to the new function in `test_routing`, following from what I saw done for `plot_graph_route`. Can add more tests if desired. 

Haven't updated the changelog yet, not sure if I should put this under the `2.0.2` section or a new section.

Example usage (adapted from [this example](https://github.com/gboeing/osmnx-examples/blob/main/notebooks/15-advanced-plotting.ipynb)):
```python
import osmnx as ox

place = "Piedmont, California, USA"
G = ox.graph.graph_from_place(place, network_type="drive")

# impute missing edge speeds and calculate free-flow travel times
G = ox.routing.add_edge_speeds(G)
G = ox.routing.add_edge_travel_times(G)

# calculate 3 shortest paths, minimizing travel time
w = "travel_time"
orig, dest = list(G)[10], list(G)[-10]
route1 = ox.routing.shortest_path(G, orig, dest, weight=w)
orig, dest = list(G)[0], list(G)[-1]
route2 = ox.routing.shortest_path(G, orig, dest, weight=w)
orig, dest = list(G)[-100], list(G)[100]
route3 = ox.routing.shortest_path(G, orig, dest, weight=w)

# animate routes
fig, ax = ox.plot.animate_graph_route(G, route1, orig_dest_size=0, node_size=0, save=True, show=True, filepath='images/animation.mp4')
fig, ax = ox.plot.animate_graph_route(G, route2, orig_dest_size=0, node_size=0, save=True, show=True, filepath='images/animation.gif')
fig, ax = ox.plot.animate_graph_route(G, route3, orig_dest_size=0, node_size=0, save=True, show=True, filepath='images/animation.mov')
```