### PR TITLE
fix geocoding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: numpydoc-validation
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3 (TBD)
+
+- ensure geocoder results are sorted by importance (#1290)
+
 ## 2.0.2 (2025-03-25)
 
 - fix bug in parsing time when calculating pause duration between requests (#1277)

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -94,8 +94,8 @@ def geocode_to_gdf(
     which_result
         Which search result to return. If None, auto-select the first
         (Multi)Polygon or raise an error if OSM doesn't return one. To get
-        the top match regardless of geometry type, set `which_result=1`.
-        Ignored if `by_osmid=True`.
+        the top match (sorted by importance) regardless of geometry type, set
+        `which_result=1`. Ignored if `by_osmid=True`.
     by_osmid
         If True, treat query as an OSM ID lookup rather than text search.
 

--- a/osmnx/geocoder.py
+++ b/osmnx/geocoder.py
@@ -157,6 +157,9 @@ def _geocode_query_to_gdf(
     limit = 50 if which_result is None else which_result
     results = _nominatim._download_nominatim_element(query, by_osmid=by_osmid, limit=limit)
 
+    # ensure geocoder results are sorted from most to least important
+    results = sorted(results, key=lambda x: x["importance"], reverse=True)
+
     # choose the right result from the JSON response
     if len(results) == 0:
         # if no results were returned, raise error

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -41,7 +41,7 @@ ox.settings.cache_folder = ".temp/cache"
 
 # define queries to use throughout tests
 location_point = (37.791427, -122.410018)
-address = "600 Montgomery St, San Francisco, California, USA"
+address = "Transamerica Pyramid, 600 Montgomery Street, San Francisco, California, USA"
 place1 = {"city": "Piedmont", "state": "California", "country": "USA"}
 polygon_wkt = (
     "POLYGON ((-122.262 37.869, -122.255 37.869, -122.255 37.874, "

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -101,7 +101,7 @@ def test_geocoder() -> None:
 
     # fails to geocode to a (Multi)Polygon
     with pytest.raises(TypeError):
-        _ = ox.geocode_to_gdf("Bunker Hill, Los Angeles, CA, USA")
+        _ = ox.geocode_to_gdf("Civic Center, San Francisco, California, USA")
 
 
 @pytest.mark.xdist_group(name="group1")


### PR DESCRIPTION
I noticed this morning that Nominatim has been returning geocoder results not sorted by importance. Historically they have been, which allows OSMnx to go down the list and pick the first, or second, or third, or pick the first polygon result, etc. This change has [broken](https://github.com/gboeing/osmnx/actions/runs/14408974307/attempts/1) our CI tests, and more importantly makes simple queries behave unintuitively.

For example, `G = ox.graph.graph_from_place("Piedmont, California, USA", network_type="drive")` now raises `ValueError: Found no graph nodes within the requested polygon` because "Piedmont, California, USA" resolves to Piedmont High School's boundary polygon, rather than the city of Piedmont. Although the city has a higher importance value than the high school, Nominatim is returning the high school to us sorted ahead of the city.

This PR [fixes](https://github.com/gboeing/osmnx/pull/1290/commits/81b08408e50f5daddeda14cc09b94fcc4d8f0ca8) this problem by manually ensuring that geocoder results are sorted by importance before processing them.

This PR also fixes the [failing](https://github.com/gboeing/osmnx/actions/runs/14408905900) geocoding of an SF address.