### PR TITLE
fix gephi compatibility mode erasing node attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.4 (TBD)
 
 - fix bug in features module when elements have pre-existing geometry tags (#1298)
+- fix bug in save_graphml function where gephi compatibility mode erases node attributes (#1300)
 
 ## 2.0.3 (2025-05-06)
 

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -98,14 +98,14 @@ def save_graphml(
     # if save folder does not already exist, create it
     filepath.parent.mkdir(parents=True, exist_ok=True)
 
+    # make a copy to not mutate original graph object caller passed in
+    G = G.copy()
+
     if gephi:
         # for gephi compatibility, each edge's key must be unique as an id
-        uvkd = ((u, v, k, d) for k, (u, v, d) in enumerate(G.edges(keys=False, data=True)))
-        G = nx.MultiDiGraph(uvkd)
-
-    else:
-        # make a copy to not mutate original graph object caller passed in
-        G = G.copy()
+        uvkd = [(u, v, k, d) for k, (u, v, d) in enumerate(G.edges(keys=False, data=True))]
+        G.clear_edges()
+        G.add_edges_from(uvkd)
 
     # stringify all the graph attribute values
     for attr, value in G.graph.items():


### PR DESCRIPTION
Resolves an issue raised on [StackOverflow](https://stackoverflow.com/q/79630985/7321942).