### PR TITLE
Potential fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -3,6 +3,9 @@
 # run, it just builds the image as a test, but does not push it.
 name: Build and publish Docker image
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:

--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -5,6 +5,9 @@
 # this workflow file's name.
 name: Build and publish to PyPI
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 # This workflow runs the repo's CI tests.
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, v1]

--- a/.github/workflows/test-docs-linkcheck.yml
+++ b/.github/workflows/test-docs-linkcheck.yml
@@ -1,5 +1,6 @@
 # This workflow tests building the package docs and verifying links are live.
 name: Build docs and check links
+
 permissions:
   contents: read
 

--- a/.github/workflows/test-docs-linkcheck.yml
+++ b/.github/workflows/test-docs-linkcheck.yml
@@ -1,5 +1,7 @@
 # This workflow tests building the package docs and verifying links are live.
 name: Build docs and check links
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/test-latest-deps.yml
+++ b/.github/workflows/test-latest-deps.yml
@@ -2,6 +2,9 @@
 # versions.
 name: Test latest/pre-release dependencies
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: 15 4 * * 1  # every monday at 04:15 UTC

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -2,6 +2,9 @@
 # versions.
 name: Test minimum dependencies
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: 25 4 * * 1  # every monday at 04:25 UTC


### PR DESCRIPTION
Potential fix for [https://github.com/gboeing/osmnx/security/code-scanning/7](https://github.com/gboeing/osmnx/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only requires read access to the repository contents (e.g., for checking out the code), we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` has only the necessary privileges to complete the tasks in the workflow.
