### PR TITLE
Added a function to get the nearest nodes of the largest connected component for routing.

### DIFF
--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -597,8 +597,8 @@ def nearest_connected_nodes(
             island_x = G.nodes[node]["x"]
             island_y = G.nodes[node]["y"]
 
-            main_x: NDArray[np.float64] = np.array([G_main_strong.nodes[n]["x"] for n in main_node_ids])
-            main_y: NDArray[np.float64] = np.array([G_main_strong.nodes[n]["y"] for n in main_node_ids])
+            main_x = np.array([G_main_strong.nodes[n]["x"] for n in main_node_ids])
+            main_y = np.array([G_main_strong.nodes[n]["y"] for n in main_node_ids])
 
             distances = np.sqrt((main_x - island_x) ** 2 + (main_y - island_y) ** 2)
             nearest_index = int(distances.argmin())


### PR DESCRIPTION
Some of the nodes in osm are island nodes, that is nodes that are not connected to the largest connected component in an area. So when we try to route from a point like this, it raises an error. This function aims to solve this problem by replacing the island node with a node in the largest connected component that is closest to it. If the node is not an island node, it returns the same node.