### PR TITLE
Expose _errors module in __init__

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,14 +35,14 @@ repos:
       - id: numpydoc-validation
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.12
+    rev: v0.12.0
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.16.1
     hooks:
       - id: mypy
         additional_dependencies:

--- a/osmnx/__init__.py
+++ b/osmnx/__init__.py
@@ -14,6 +14,7 @@ from importlib.metadata import version as metadata_version
 __version__ = metadata_version("osmnx")
 
 # expose the package's public modules
+from . import _errors as _errors
 from . import bearing as bearing
 from . import convert as convert
 from . import distance as distance

--- a/osmnx/io.py
+++ b/osmnx/io.py
@@ -1,4 +1,3 @@
-# ruff: noqa: A005
 """File I/O functions to save/load graphs to/from files on disk."""
 
 from __future__ import annotations
@@ -392,7 +391,7 @@ def _convert_edge_attr_types(G: nx.MultiDiGraph, dtypes: dict[str, Any]) -> nx.M
     return G
 
 
-def _convert_bool_string(value: bool | str) -> bool:
+def _convert_bool_string(value: bool | str) -> bool:  # noqa: FBT001
     """
     Convert a "True" or "False" string literal to corresponding boolean type.
 

--- a/osmnx/plot.py
+++ b/osmnx/plot.py
@@ -260,7 +260,7 @@ def plot_graph(  # noqa: PLR0913
     if max_node_size > 0:
         # scatter plot the nodes' x/y coordinates
         gdf_nodes = convert.graph_to_gdfs(G, edges=False, node_geometry=False)[["x", "y"]]
-        ax.scatter(  # type: ignore[union-attr]
+        ax.scatter(
             x=gdf_nodes["x"],
             y=gdf_nodes["y"],
             s=node_size,
@@ -282,7 +282,7 @@ def plot_graph(  # noqa: PLR0913
         padding = 0.02  # pad 2% to not cut off peripheral nodes' circles
 
     # configure axes appearance, save/show figure as specified, and return
-    ax = _config_ax(ax, G.graph["crs"], bbox, padding)  # type: ignore[arg-type]
+    ax = _config_ax(ax, G.graph["crs"], bbox, padding)
     fig, ax = _save_and_show(
         fig=fig,
         ax=ax,
@@ -653,7 +653,7 @@ def plot_footprints(  # noqa: PLR0913
         bbox = tuple(gdf.total_bounds)
 
     # configure axes appearance, save/show figure as specified, and return
-    ax = _config_ax(ax, gdf.crs, bbox, 0)  # type: ignore[arg-type]
+    ax = _config_ax(ax, gdf.crs, bbox, 0)
     fig, ax = _save_and_show(
         fig=fig,
         ax=ax,
@@ -860,7 +860,7 @@ def _get_colors_by_value(
         # linearly map a color to each attribute value
         normalizer = colors.Normalize(full_min, full_max)
         scalar_mapper = cm.ScalarMappable(normalizer, colormaps[cmap])
-        color_series = vals.map(scalar_mapper.to_rgba).map(colors.to_hex)  # type: ignore[arg-type,unused-ignore]  # needed for python<3.10
+        color_series = vals.map(scalar_mapper.to_rgba).map(colors.to_hex)  # type: ignore[arg-type,unused-ignore]  # needed for python<=3.9
         color_series.loc[pd.isna(vals)] = na_color
 
     else:

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# ruff: noqa: E402,F841,PLR2004,S101
+# ruff: noqa: F841, PLR2004, S101
 """Test suite for the package."""
 
 from __future__ import annotations


### PR DESCRIPTION
Expose `_errors` module in `__init__.py` for easier code introspection, e.g., with VSCode.