### PR TITLE
fix bug when computing area using UTM for polar regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - improve module exposure for better code introspection (#1308)
 - add "all" optional dependency extra (#1313)
 - bump minimum required patch versions of optional extras to earliest versions with macosx/arm64 wheels (#1313)
+- fix bug when computing area using UTM for polar regions (#1323)
 
 ## 2.0.4 (2025-06-11)
 

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -261,9 +261,18 @@ def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list[s
     coord_strs
         Exterior coordinates of polygon(s).
     """
-    # first subdivide the polygon if its area exceeds max size
+    # use UPS if the polygon is in the southern or northern extremes
+    # of the world, otherwise use UTM.
+    UTM_SOUTH_LIMIT = -80
+    UTM_NORTH_LIMIT = 84
+    to_crs = None
+    if polygon.bounds[1] < UTM_SOUTH_LIMIT:
+        to_crs = "epsg:32761"
+    elif polygon.bounds[3] > UTM_NORTH_LIMIT:
+        to_crs = "epsg:32661"
+    # subdivide the polygon if its area exceeds max size
     # this results in a multipolygon of 1+ constituent polygons
-    poly_proj, crs_proj = projection.project_geometry(polygon)
+    poly_proj, crs_proj = projection.project_geometry(polygon, to_crs=to_crs)
     multi_poly_proj = utils_geo._consolidate_subdivide_geometry(poly_proj)
     multi_poly, _ = projection.project_geometry(multi_poly_proj, crs=crs_proj, to_latlong=True)
 

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -261,8 +261,8 @@ def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list[s
     coord_strs
         Exterior coordinates of polygon(s).
     """
-    # use UPS if the polygon is in the southern or northern extremes
-    # of the world, otherwise use UTM.
+    # if polygon is outside UTM limits (80 deg south, 84 deg north), then we
+    # must use universal polar stereographic coordinate system instead
     UTM_SOUTH_LIMIT = -80
     UTM_NORTH_LIMIT = 84
     to_crs = None
@@ -270,6 +270,7 @@ def _make_overpass_polygon_coord_strs(polygon: Polygon | MultiPolygon) -> list[s
         to_crs = "epsg:32761"
     elif polygon.bounds[3] > UTM_NORTH_LIMIT:
         to_crs = "epsg:32661"
+
     # subdivide the polygon if its area exceeds max size
     # this results in a multipolygon of 1+ constituent polygons
     poly_proj, crs_proj = projection.project_geometry(polygon, to_crs=to_crs)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -42,6 +42,9 @@ ox.settings.cache_folder = ".temp/cache"
 
 # define queries to use throughout tests
 location_point = (37.791427, -122.410018)
+polar_point_south = (-84.5501149, -64.1500283)
+polar_point_north = (85.0511092, -30.4142117)
+
 address = "Transamerica Pyramid, 600 Montgomery Street, San Francisco, California, USA"
 place1 = {"city": "Piedmont", "state": "California", "country": "USA"}
 polygon_wkt = (
@@ -701,25 +704,34 @@ def test_features() -> None:
     fig, ax = ox.plot_footprints(gdf)
     fig, ax = ox.plot_footprints(gdf, ax=ax, bbox=(0, 0, 10, 10))
 
+    # features_from_bbox - test < -80 deg latitude
+    tags2: dict[str, bool | str | list[str]] = {"natural": True, "amenity": True}
+    bbox = ox.utils_geo.bbox_from_point(polar_point_south, dist=500)
+    gdf = ox.features_from_bbox(bbox, tags=tags2)
+
+    # features_from_bbox - test > 84 deg latitude
+    bbox = ox.utils_geo.bbox_from_point(polar_point_north, dist=500)
+    gdf = ox.features_from_bbox(bbox, tags=tags2)
+
     # features_from_point - tests multipolygon creation
     gdf = ox.utils_geo.bbox_from_point(location_point, dist=500)
 
     # features_from_place - includes test of list of places
-    tags2: dict[str, bool | str | list[str]] = {
+    tags3: dict[str, bool | str | list[str]] = {
         "amenity": True,
         "landuse": ["retail", "commercial"],
         "highway": "bus_stop",
     }
-    gdf = ox.features_from_place(place1, tags=tags2)
-    gdf = ox.features_from_place([place1], which_result=[None], tags=tags2)
+    gdf = ox.features_from_place(place1, tags=tags3)
+    gdf = ox.features_from_place([place1], which_result=[None], tags=tags3)
 
     # features_from_polygon
     polygon = ox.geocode_to_gdf(place1).geometry.iloc[0]
-    ox.features_from_polygon(polygon, tags2)
+    ox.features_from_polygon(polygon, tags3)
 
     # features_from_address - includes testing overpass settings and snapshot from 2019
     ox.settings.overpass_settings = '[out:json][timeout:200][date:"2019-10-28T19:20:00Z"]'
-    gdf = ox.features_from_address(address, tags=tags2, dist=1000)
+    gdf = ox.features_from_address(address, tags=tags3, dist=1000)
 
     # features_from_xml - tests error handling of clipped XMLs with incomplete geometry
     gdf = ox.features_from_xml("tests/input_data/planet_10.068,48.135_10.071,48.137.osm")


### PR DESCRIPTION
# Read these instructions carefully

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests. Then fill out the template below.

## Checklist
- [x] I have read the contributing guidelines and have run the pre-commit hooks and tests locally.
- [x] I have edited the changelog to reflect my changes.
- [ ] If this is an enhancement, I have opened a feature proposal issue to discuss first.

## Related issues

This PR resolves #1323 when when getting features from polar regions 

## Proposed changes

Cconverting polar lat lon polygons to Universal Polar Stereographic North and Universal Polar Stereographic South CRS before computing the area

## Usage example

```python
import osmnx
from shapely import Polygon

tags = {'landuse': True}
coords = ((-57.01507272, -83.86728198,), (-57.01507272, -83.69376112), (-55.67423087, -83.69376112))
polygon = Polygon(coords)
features = osmnx.features_from_polygon(polygon=polygon, tags=tags)
```
This should return `osmnx._errors.InsufficientResponseError: No matching features. Check query location, tags, and log.` instead of `RuntimeError: Unable to determine UTM CRS`
