### PR TITLE
features module: handle relations with missing member geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## TBD
 
+- handle relations with missing member geometries when loading features from XML (#1334)
 - exclude ways tagged "rest_area" or "services" when downloading network data (#1328)
 
 ## 2.0.5 (2025-07-05)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,9 +8,9 @@ The foolproof way to install OSMnx is with `conda`_ or `mamba`_:
 
 .. code-block:: shell
 
-    conda create -n ox conda-forge::osmnx
+    conda create --strict-channel-priority -c conda-forge -n ox osmnx
 
-This creates a new conda environment and installs OSMnx into it, via the conda-forge channel. If you want other packages, such as :code:`jupyterlab`, installed in this environment as well, just add their names after :code:`osmnx` above. To upgrade OSMnx to a newer release, remove the conda environment you created and then create a new one again, as above. See the `conda`_ and `conda-forge`_ documentation for more details.
+This creates a new conda environment and installs OSMnx into it, via the conda-forge channel. If you want other packages, such as :code:`jupyterlab`, installed in this environment as well, just add their names after :code:`osmnx` above. To upgrade OSMnx to a newer release, remove the conda environment you created and then create a new one again, as above. See the `conda-forge`_ documentation for details.
 
 Docker
 ------

--- a/osmnx/features.py
+++ b/osmnx/features.py
@@ -598,7 +598,14 @@ def _build_relation_geometry(
     # sort member geometries by member role and geometry type
     for member in members:
         if member["type"] == "way":
-            geom = way_geoms[member["ref"]]
+            geom = way_geoms.get(member["ref"])
+            if geom is None:
+                # a member's geometry may be missing when loaded from XML, if
+                # so, we cannot build this relation's complete geometry, so
+                # just return a null geometry to be removed at final filtering
+                msg = f"Cannot build relation geometry, missing member way {member['ref']}"
+                utils.log(msg, level=lg.WARNING)
+                return Polygon()
             role = member["role"]
             if role == "outer" and geom.geom_type == "LineString":
                 outer_linestrings.append(geom)

--- a/tests/input_data/osm_schema.xsd
+++ b/tests/input_data/osm_schema.xsd
@@ -87,6 +87,7 @@
       <xs:attribute name="copyright" type="xs:string" use="optional" />
       <xs:attribute name="generator" type="xs:string" use="required" />
       <xs:attribute name="license" type="xs:string" use="optional" />
+      <xs:attribute name="timestamp" type="xs:dateTime" use="optional" />
       <xs:attribute name="version" type="xs:float" use="required" fixed="0.6" />
     </xs:complexType>
   </xs:element>

--- a/tests/input_data/planet_10.068,48.135_10.071,48.137.osm
+++ b/tests/input_data/planet_10.068,48.135_10.071,48.137.osm
@@ -967,4 +967,26 @@
 		<tag k="type" v="multipolygon"/>
 		<tag k="landuse" v="residential"/>
 	</relation>
+	<relation id="318560" visible="true" version="8" changeset="136724339" timestamp="2023-05-30T04:42:59Z" user="Aleks-Berlin" uid="85218">
+		<member type="way" ref="43326015" role="outer"/>
+		<member type="way" ref="44098878" role="inner"/>
+		<member type="way" ref="44098877" role="inner"/>
+		<member type="way" ref="44098876" role="inner"/>
+		<tag k="addr:housenumber" v="75"/>
+		<tag k="addr:postcode" v="10117"/>
+		<tag k="addr:street" v="Mauerstraße"/>
+		<tag k="architect" v="Ernst Hake;Heinrich Techo;Franz Ahrens"/>
+		<tag k="building" v="government"/>
+		<tag k="building:architecture" v="neo-baroque"/>
+		<tag k="building:levels" v="4"/>
+		<tag k="fixme" v="Gebäude baulich richtig aufteilen und dann building=office für das Ministerium und building=civic für das Museum verwendet werden."/>
+		<tag k="heritage" v="4"/>
+		<tag k="loc_name" v="Post-Kolosseum"/>
+		<tag k="museum" v="technology"/>
+		<tag k="old_name" v="Reichspostministerium"/>
+		<tag k="start_date" v="1872"/>
+		<tag k="tourism" v="museum"/>
+		<tag k="type" v="multipolygon"/>
+		<tag k="wikipedia" v="de:Museum für Kommunikation Berlin"/>
+	</relation>
 </osm>


### PR DESCRIPTION
Resolves #1333. When loading features from XML, it's possible that a relation's member geometry element could be missing from the file. Currently this causes an exception. This PR instead logs a warning and returns a null geometry for that relation, which is subsequently removed in the final filtering step.