### PR TITLE
FIX: Prevent TypeError in _getaddrinfo when host is a kwarg

### DIFF
--- a/osmnx/_http.py
+++ b/osmnx/_http.py
@@ -261,6 +261,8 @@ def _config_dns(url: str) -> None:
         if hostname == next(iter(args), kwargs.get("host")):
             msg = f"Resolved {hostname!r} to {ip!r}"
             utils.log(msg, level=lg.INFO)
+            # Remove 'host' from kwargs to avoid TypeError when 'host' is passed both positionally and as a keyword.
+            kwargs.pop("host", None)
             return _original_getaddrinfo(ip, *args[1:], **kwargs)
 
         # otherwise


### PR DESCRIPTION
This PR fixes a latent `TypeError` in the `_getaddrinfo` wrapper that occurs when the function is called with `host` as a keyword argument.

Existing implementation resolved an `IndexError` but did not account for the case where `host` was supplied via `kwargs`. In that scenario, the wrapper would prepend the resolved IP as a new positional argument while leaving the original `host` keyword in `**kwargs`, leading to a `TypeError: getaddrinfo() got multiple values for argument 'host'`.

This change resolves the issue by safely popping the `host` key from `kwargs` before calling the original function, ensuring no duplicate arguments are passed. The fix is robust and handles both positional and keyword-based calls correctly.

Fixes #1339 