### PR TITLE
Restore geometries_from_place as alias to features_from_place for bac…

### DIFF
--- a/osmnx/__init__.py
+++ b/osmnx/__init__.py
@@ -35,3 +35,7 @@ from . import utils_geo as utils_geo
 
 # expose the old v1 API for backwards compatibility
 from ._api_v1 import *  # noqa: F403
+
+# backward compatibility alias for removed v1 function
+from .features import features_from_place as geometries_from_place
+


### PR DESCRIPTION
In OSMnx 2.x the function `geometries_from_place` was removed and replaced by `features_from_place`. Many tutorials, examples, and existing scripts still use the old name, which currently results in:

AttributeError: module 'osmnx' has no attribute 'geometries_from_place'

This change restores backward compatibility by adding a simple alias in `osmnx/__init__.py`:

from .features import features_from_place as geometries_from_place

Both calls

- ox.geometries_from_place("Weimar, Germany", tags={"building": True})
- ox.features_from_place("Weimar, Germany", tags={"building": True})

now return identical GeoDataFrames (`gdf_old.equals(gdf_new` is True).

This makes OSMnx 2.x compatible with older code and existing documentation again, with a minimal and safe change.
