### PR TITLE
Add sphinx linkcode extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ typehints_fully_qualified = False
 # general configuration and options for HTML output
 # see https://www.sphinx-doc.org/en/master/usage/configuration.html
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx_autodoc_typehints"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx_autodoc_typehints", "sphinx.ext.linkcode"]
 html_static_path: list[str] = []
 html_theme = "furo"
 language = "en"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,9 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+import os
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from tomllib import load as toml_load
 
@@ -54,7 +56,12 @@ typehints_fully_qualified = False
 # general configuration and options for HTML output
 # see https://www.sphinx-doc.org/en/master/usage/configuration.html
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.napoleon", "sphinx_autodoc_typehints", "sphinx.ext.linkcode"]
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.linkcode",
+    "sphinx.ext.napoleon",
+    "sphinx_autodoc_typehints",
+]
 html_static_path: list[str] = []
 html_theme = "furo"
 language = "en"
@@ -62,3 +69,28 @@ needs_sphinx = "9"  # match version from pyproject.toml and requirements-docs.tx
 root_doc = "index"
 source_suffix = ".rst"
 templates_path: list[str] = []
+
+
+def linkcode_resolve(domain: str, info: Mapping[str, str]) -> str | None:
+    """
+    Resolve Python objects to GitHub source URLs.
+
+    Parameters
+    ----------
+    domain
+        The object domain.
+    info
+        Information about the documented object.
+
+    Returns
+    -------
+    str or None
+        URL of the source file on GitHub, or None if unavailable.
+    """
+    if domain != "py":
+        return None
+    if not info.get("module"):
+        return None
+    module = info["module"].replace(".", "/")
+    ref = "main" if os.environ.get("READTHEDOCS_VERSION") == "latest" else f"v{release}"
+    return f"https://github.com/gboeing/osmnx/blob/{ref}/{module}.py"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,5 +92,5 @@ def linkcode_resolve(domain: str, info: Mapping[str, str]) -> str | None:
     if not info.get("module"):
         return None
     module = info["module"].replace(".", "/")
-    ref = "main" if os.environ.get("READTHEDOCS_VERSION") == "latest" else f"v{release}"
+    ref = f"v{release}" if os.environ.get("READTHEDOCS_VERSION") == "stable" else "main"
     return f"https://github.com/gboeing/osmnx/blob/{ref}/{module}.py"


### PR DESCRIPTION
Automatically adds a link to the source code in the docs

# Read these instructions carefully

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests. Then fill out the template below.

## Checklist
- [X] I have read the contributing guidelines and have run the pre-commit hooks and tests locally.
- [ ] I have edited the changelog to reflect my changes.
- [X] If this is an enhancement, I have opened a feature proposal issue to discuss first.

Note:
- I did not edit the changelog for this insignificant addition.
- I did not manage to test, as setting up the dev env with pixi failed due to an issue with pyproj. If testing should be done here, let me know.

## Related issues

#1386

## Proposed changes

See #1386, though the correct extension is [linkcode](https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html), not viewcode.

## Usage example

n/a

## Benchmarks

No impacts on performance.
