### PR TITLE
fix projecting ignores consolidated flag (#1388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.1 (TBD)
 
 - fix re-projection bug (#1373 #1374)
+- fix projection after consolidating intersections bug (#1388)
 
 ## 2.1.0 (2026-02-16)
 

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -186,7 +186,7 @@ def project_graph(
     to_crs = gdf_nodes_proj.crs
 
     # STEP 2: PROJECT THE EDGES
-    if G.graph.get("simplified"):
+    if G.graph.get("simplified") or G.graph.get("consolidated"):
         # if graph has previously been simplified, project the edge geometries
         gdf_edges = convert.graph_to_gdfs(G, nodes=False, fill_edge_geometry=False)
         gdf_edges_proj = project_gdf(gdf_edges, to_crs=to_crs)


### PR DESCRIPTION
# Read these instructions carefully

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests. Then fill out the template below.

## Checklist
- [x] I have read the contributing guidelines and have run the pre-commit hooks and tests locally.
- [x] I have edited the changelog to reflect my changes.
- [] If this is an enhancement, I have opened a feature proposal issue to discuss first.

## Related issues

Related to #1388 

## Proposed changes

Checks for "consolidated" flag as well as "simplified" flag before projecting, so edge geometries that are added after using `consolidate_intersections` are correctly projected.