### PR TITLE
add live APIs test

### DIFF
--- a/.github/workflows/live-apis.yml
+++ b/.github/workflows/live-apis.yml
@@ -1,0 +1,49 @@
+---
+# This workflow runs the repo's tests against live web APIs without hitting
+# the OSMnx cache that's otherwise persisted across the other tests.
+name: Live API tests
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: 30 4 * * 1  # every monday at 04:30 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  live_api_tests:
+    name: Python ${{ matrix.python-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.14']
+    defaults:
+      run:
+        shell: bash -elo pipefail {0}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          cache-dependency-glob: pyproject.toml
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install OSMnx
+        run: |
+          uv python pin ${{ matrix.python-version }}
+          uv sync --all-extras --group test
+
+      - name: Test code and coverage
+        run: uv run pytest


### PR DESCRIPTION
Lower code coverage is due to persisting the OSMnx cache across tests (in #1391), which means we don't make live API calls anymore in CI, so we don't hit the lines of code that make live HTTP requests. 

However, those lines are hit in the new workflow added here (`list-apis.yml`) which doesn't use that persisted cache so it does make live HTTP requests to the web APIs. It's scheduled to run once a week, just to ensure that the code and tests align with current Overpass and Nominatim responses, which could possibly change over time.