### PR TITLE
code clean up

### DIFF
--- a/osmnx/_validate.py
+++ b/osmnx/_validate.py
@@ -216,14 +216,6 @@ def _validate_nodes(G: nx.MultiDiGraph, strict: bool) -> tuple[bool, str, str]: 
             if strict:
                 is_valid = False
 
-        # WARN: nodes' "x" and "y" data attributes should be type Real
-        valid_xs = all(isinstance(x, Real) for x in nx.get_node_attributes(G, name="x").values())
-        valid_ys = all(isinstance(y, Real) for y in nx.get_node_attributes(G, name="y").values())
-        if not (valid_xs and valid_ys):
-            warn_msg += "Node 'x' and 'y' data attributes should be numeric. "
-            if strict:
-                is_valid = False
-
         # WARN: node IDs should be type int
         if not all(isinstance(n, int) for n in G.nodes):
             warn_msg += "Node IDs should be type int. "

--- a/osmnx/distance.py
+++ b/osmnx/distance.py
@@ -212,7 +212,7 @@ def add_edge_lengths(
     G
         Graph with `length` attributes on the edges.
     """
-    uvk = G.edges if edges is None else edges
+    uvk = G.edges if edges is None else tuple(edges)
 
     # extract edge IDs and corresponding coordinates from their nodes
     x = G.nodes(data="x")

--- a/osmnx/projection.py
+++ b/osmnx/projection.py
@@ -7,13 +7,13 @@ from typing import TYPE_CHECKING
 from typing import Any
 
 import geopandas as gpd
+import networkx as nx
 
 from . import convert
 from . import settings
 from . import utils
 
 if TYPE_CHECKING:
-    import networkx as nx
     from shapely import Geometry
 
 
@@ -186,8 +186,12 @@ def project_graph(
     to_crs = gdf_nodes_proj.crs
 
     # STEP 2: PROJECT THE EDGES
-    if G.graph.get("simplified") or G.graph.get("consolidated"):
-        # if graph has previously been simplified, project the edge geometries
+    if (
+        G.graph.get("simplified")
+        or G.graph.get("consolidated")
+        or nx.get_edge_attributes(G, "geometry")
+    ):
+        # if graph was simplified/consolidated or otherwise has edge geometries, project them
         gdf_edges = convert.graph_to_gdfs(G, nodes=False, fill_edge_geometry=False)
         gdf_edges_proj = project_gdf(gdf_edges, to_crs=to_crs)
     else:

--- a/osmnx/routing.py
+++ b/osmnx/routing.py
@@ -651,7 +651,7 @@ def _clean_maxspeed(
         return None
 
     # regex adapted from OSM wiki
-    pattern = "^([0-9][\\.,0-9]+?)(?:[ ]?(?:km/h|kmh|kph|mph|knots))?$"
+    pattern = "^([0-9][\\.,0-9]*?)(?:[ ]?(?:km/h|kmh|kph|mph|knots))?$"
     values = re.split(r"\|", maxspeed)  # creates a list even if it's a single value
     try:
         clean_values = []

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -202,7 +202,11 @@ def test_stats() -> None:
     # create graph, add a new node, add bearings, project it
     G = ox.graph_from_place(place1, network_type="all")
     G.add_node(0, x=location_point[1], y=location_point[0], street_count=0)
+    G.graph.pop("simplified")  # test projecting edge geometries without flag
     G_proj = ox.project_graph(G)
+    assert next(iter(nx.get_edge_attributes(G, "geometry").values())) != next(
+        iter(nx.get_edge_attributes(G_proj, "geometry").values()),
+    )
     G_proj = ox.project_graph(G_proj)  # test double-projection
     G_proj = ox.distance.add_edge_lengths(G_proj, edges=tuple(G_proj.edges)[0:3])
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -419,6 +419,8 @@ def test_routing() -> None:
     G = ox.add_edge_travel_times(G)
 
     # test value cleaning
+    assert ox.routing._clean_maxspeed("5") == 5.0
+    assert ox.routing._clean_maxspeed("5 mph") == pytest.approx(8.0467)
     assert ox.routing._clean_maxspeed("100,2") == 100.2
     assert ox.routing._clean_maxspeed("100.2") == 100.2
     assert ox.routing._clean_maxspeed("100 km/h") == 100.0

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -208,7 +208,7 @@ def test_stats() -> None:
         iter(nx.get_edge_attributes(G_proj, "geometry").values()),
     )
     G_proj = ox.project_graph(G_proj)  # test double-projection
-    G_proj = ox.distance.add_edge_lengths(G_proj, edges=tuple(G_proj.edges)[0:3])
+    G_proj = ox.distance.add_edge_lengths(G_proj, edges=(e for e in tuple(G_proj.edges)[0:3]))
 
     # calculate stats
     cspn = ox.stats.count_streets_per_node(G)


### PR DESCRIPTION
Fixes a few minor bugs:
- removes duplicated code in _validate module
- ensures all graphs with edge geometries get their geometries projected when projecting (even if they're not simplified or consolidated -- this could happen if a user loads a custom graph)
- fix the speed parsing regex when single digit speed limits occur
- realize iterable in distance module in case it's a generator, to prevent double-consumption of that possible generator