### PR TITLE
fix node consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix projection bug when re-projecting an already projected graph (#1373 #1374)
 - fix projection bug after consolidating intersections (#1388)
+- fix cloverleaf intersection consolidation bug (#1396)
 - minor bug fixes (#1395)
 
 ## 2.1.0 (2026-02-16)

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -452,8 +452,8 @@ def consolidate_intersections(
     G: nx.MultiDiGraph,
     *,
     tolerance: float | dict[int, float] = 10,
-    max_length: float | None = None,
     rebuild_graph: bool = True,
+    max_length: float | None = None,
     dead_ends: bool = False,
     reconnect_edges: bool = True,
     node_attr_aggs: dict[str, Any] | None = None,
@@ -503,18 +503,17 @@ def consolidate_intersections(
         that single value will be used for all nodes. If dict (mapping node
         IDs to individual values), then those values will be used per node and
         any missing node IDs will not be buffered.
-    max_length
-        If not None, when rebuilding the graph, ignore edges whose `length`
-        attributes exceed this value when determining whether nearby nodes are
-        topologically connected. This prevents long edges that loop outside
-        an intersection, such as cloverleaf ramps, from merging their nearby
-        endpoint nodes. The edges remain in the rebuilt graph.
     rebuild_graph
         If True, consolidate the nodes topologically, rebuild the graph, and
         return as MultiDiGraph. Otherwise, consolidate the nodes geometrically
         and return the consolidated node points as GeoSeries.
+    max_length
+        Ignore edges longer than this when determining whether nearby nodes
+        are topologically connected. If None, consider all edges. This
+        prevents long edges that loop outside an intersection, such as
+        cloverleaf ramps, from merging their nearby endpoint nodes.
     dead_ends
-        If False, discard dead-end nodes to return only street-intersection
+        If False, discard dead-end nodes to return only street intersection
         points.
     reconnect_edges
         If True, reconnect edges (and their geometries) to the consolidated

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -452,6 +452,7 @@ def consolidate_intersections(
     G: nx.MultiDiGraph,
     *,
     tolerance: float | dict[int, float] = 10,
+    edge_length_tolerance: float | None = None,
     rebuild_graph: bool = True,
     dead_ends: bool = False,
     reconnect_edges: bool = True,
@@ -502,6 +503,13 @@ def consolidate_intersections(
         that single value will be used for all nodes. If dict (mapping node
         IDs to individual values), then those values will be used per node and
         any missing node IDs will not be buffered.
+    edge_length_tolerance
+        When rebuilding the graph, ignore edges longer than this when
+        determining whether nearby nodes are topologically connected. This
+        prevents long edges that loop outside an intersection, such as
+        cloverleaf ramps, from merging their nearby endpoint nodes. If None,
+        consider all edges, preserving the existing behavior. Uses the same
+        units as the graph's `length` edge attributes.
     rebuild_graph
         If True, consolidate the nodes topologically, rebuild the graph, and
         return as MultiDiGraph. Otherwise, consolidate the nodes geometrically
@@ -548,6 +556,7 @@ def consolidate_intersections(
         return _consolidate_intersections_rebuild_graph(
             G,
             tolerance,
+            edge_length_tolerance,
             reconnect_edges,
             node_attr_aggs,
         )
@@ -604,6 +613,7 @@ def _merge_nodes_geometric(
 def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
     G: nx.MultiDiGraph,
     tolerance: float | dict[int, float],
+    edge_length_tolerance: float | None,
     reconnect_edges: bool,  # noqa: FBT001
     node_attr_aggs: dict[str, Any] | None,
 ) -> nx.MultiDiGraph:
@@ -623,6 +633,9 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
         that single value will be used for all nodes. If dict (mapping node
         IDs to individual values), then those values will be used per node and
         any missing node IDs will not be buffered.
+    edge_length_tolerance
+        Ignore edges longer than this when determining whether nearby nodes
+        are topologically connected. If None, consider all edges.
     reconnect_edges
         If True, reconnect edges (and their geometries) to the consolidated
         nodes in rebuilt graph, and update the edge length attributes. If
@@ -673,8 +686,24 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
     # surface streets with bridge).
     for cluster_label, nodes_subset in gdf.groupby("cluster"):
         if len(nodes_subset) > 1:
-            # identify all the (weakly connected) component in cluster
-            wccs = list(nx.weakly_connected_components(G.subgraph(nodes_subset.index)))
+            H = G.subgraph(nodes_subset.index)
+            if edge_length_tolerance is not None:
+                # long edges can loop outside a spatial cluster and falsely
+                # connect nearby endpoints, as with cloverleaf ramps. Exclude
+                # them only from this connectivity check, not the rebuilt graph.
+                long_edges = [
+                    (u, v, k)
+                    for u, v, k, data in H.edges(keys=True, data=True)
+                    if data["length"] > edge_length_tolerance
+                ]
+                if long_edges:
+                    # copy only affected clusters so the common case retains
+                    # the subgraph view's lower runtime and memory overhead.
+                    H = H.copy()
+                    H.remove_edges_from(long_edges)
+
+            # identify all the weakly connected components in the cluster
+            wccs = list(nx.weakly_connected_components(H))
             if len(wccs) > 1:
                 # if there are multiple components in this cluster
                 for suffix, wcc in enumerate(wccs):

--- a/osmnx/simplification.py
+++ b/osmnx/simplification.py
@@ -452,7 +452,7 @@ def consolidate_intersections(
     G: nx.MultiDiGraph,
     *,
     tolerance: float | dict[int, float] = 10,
-    edge_length_tolerance: float | None = None,
+    max_length: float | None = None,
     rebuild_graph: bool = True,
     dead_ends: bool = False,
     reconnect_edges: bool = True,
@@ -503,13 +503,12 @@ def consolidate_intersections(
         that single value will be used for all nodes. If dict (mapping node
         IDs to individual values), then those values will be used per node and
         any missing node IDs will not be buffered.
-    edge_length_tolerance
-        When rebuilding the graph, ignore edges longer than this when
-        determining whether nearby nodes are topologically connected. This
-        prevents long edges that loop outside an intersection, such as
-        cloverleaf ramps, from merging their nearby endpoint nodes. If None,
-        consider all edges, preserving the existing behavior. Uses the same
-        units as the graph's `length` edge attributes.
+    max_length
+        If not None, when rebuilding the graph, ignore edges whose `length`
+        attributes exceed this value when determining whether nearby nodes are
+        topologically connected. This prevents long edges that loop outside
+        an intersection, such as cloverleaf ramps, from merging their nearby
+        endpoint nodes. The edges remain in the rebuilt graph.
     rebuild_graph
         If True, consolidate the nodes topologically, rebuild the graph, and
         return as MultiDiGraph. Otherwise, consolidate the nodes geometrically
@@ -556,7 +555,7 @@ def consolidate_intersections(
         return _consolidate_intersections_rebuild_graph(
             G,
             tolerance,
-            edge_length_tolerance,
+            max_length,
             reconnect_edges,
             node_attr_aggs,
         )
@@ -613,7 +612,7 @@ def _merge_nodes_geometric(
 def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
     G: nx.MultiDiGraph,
     tolerance: float | dict[int, float],
-    edge_length_tolerance: float | None,
+    max_length: float | None,
     reconnect_edges: bool,  # noqa: FBT001
     node_attr_aggs: dict[str, Any] | None,
 ) -> nx.MultiDiGraph:
@@ -633,7 +632,7 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
         that single value will be used for all nodes. If dict (mapping node
         IDs to individual values), then those values will be used per node and
         any missing node IDs will not be buffered.
-    edge_length_tolerance
+    max_length
         Ignore edges longer than this when determining whether nearby nodes
         are topologically connected. If None, consider all edges.
     reconnect_edges
@@ -687,18 +686,16 @@ def _consolidate_intersections_rebuild_graph(  # noqa: C901,PLR0912,PLR0915
     for cluster_label, nodes_subset in gdf.groupby("cluster"):
         if len(nodes_subset) > 1:
             H = G.subgraph(nodes_subset.index)
-            if edge_length_tolerance is not None:
-                # long edges can loop outside a spatial cluster and falsely
-                # connect nearby endpoints, as with cloverleaf ramps. Exclude
-                # them only from this connectivity check, not the rebuilt graph.
+
+            # long edges can loop outside a cluster and falsely connect nearby
+            # nodes: optionally exclude them from the connectivity check
+            if max_length is not None:
                 long_edges = [
                     (u, v, k)
                     for u, v, k, data in H.edges(keys=True, data=True)
-                    if data["length"] > edge_length_tolerance
+                    if data["length"] > max_length
                 ]
                 if long_edges:
-                    # copy only affected clusters so the common case retains
-                    # the subgraph view's lower runtime and memory overhead.
                     H = H.copy()
                     H.remove_edges_from(long_edges)
 

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -246,7 +246,7 @@ def test_stats() -> None:
 
 
 def test_consolidate_intersections() -> None:
-    """Test consolidating intersections with an edge length tolerance."""
+    """Test consolidating intersections with a maximum edge length."""
     G = nx.MultiDiGraph(crs="epsg:3857")
     G.add_node(0, x=0, y=0)
     G.add_node(1, x=1, y=0)

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -245,6 +245,34 @@ def test_stats() -> None:
     G_clean = ox.consolidate_intersections(G_proj, tolerance=tols, rebuild_graph=True)
 
 
+def test_consolidate_intersections() -> None:
+    """Test consolidating intersections with an edge length tolerance."""
+    G = nx.MultiDiGraph(crs="epsg:3857")
+    G.add_node(0, x=0, y=0)
+    G.add_node(1, x=1, y=0)
+    G.add_edge(0, 1, length=100)
+
+    Gc = ox.consolidate_intersections(G, tolerance=1, dead_ends=True)
+    assert len(Gc) == 1
+
+    Gc = ox.consolidate_intersections(
+        G,
+        tolerance=1,
+        edge_length_tolerance=200,
+        dead_ends=True,
+    )
+    assert len(Gc) == 1
+
+    Gc = ox.consolidate_intersections(
+        G,
+        tolerance=1,
+        edge_length_tolerance=50,
+        dead_ends=True,
+    )
+    assert len(Gc) == 2
+    assert len(Gc.edges) == 1
+
+
 @pytest.mark.xdist_group(name="group1")
 def test_bearings() -> None:
     """Test bearings and orientation entropy."""

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -258,7 +258,7 @@ def test_consolidate_intersections() -> None:
     Gc = ox.consolidate_intersections(
         G,
         tolerance=1,
-        edge_length_tolerance=200,
+        max_length=200,
         dead_ends=True,
     )
     assert len(Gc) == 1
@@ -266,7 +266,7 @@ def test_consolidate_intersections() -> None:
     Gc = ox.consolidate_intersections(
         G,
         tolerance=1,
-        edge_length_tolerance=50,
+        max_length=50,
         dead_ends=True,
     )
     assert len(Gc) == 2

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -248,6 +248,7 @@ def test_stats() -> None:
     G_clean = ox.consolidate_intersections(G_proj, tolerance=tols, rebuild_graph=True)
 
 
+@pytest.mark.xdist_group(name="group0")
 def test_consolidate_intersections() -> None:
     """Test consolidating intersections with a maximum edge length."""
     G = nx.MultiDiGraph(crs="epsg:3857")


### PR DESCRIPTION
Resolves #1342

Adds an optional `max_length` parameter to `consolidate_intersections`.

When provided, edges longer than this value are ignored when determining connectivity within an intersection cluster. This prevents long loop edges, such as cloverleaf ramps, from incorrectly merging nearby endpoint nodes. The edges remain in the rebuilt graph.

The default is `None`, preserving existing behavior. The implementation uses simple edge-length comparisons and copies only affected subgraphs. Real-world benchmarks showed approximately 1–2% runtime overhead when enabled.

Added test to verify behavior with no tolerance and with limits above and below the connecting edge's length.