### PR TITLE
better caching for test suite, locally and in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   ci:
     name: Python ${{ matrix.python-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
       # disable OSMnx cache only for scheduled runs on the most recent python
       USE_OSMNX_CACHE: ${{ github.event_name != 'schedule' || matrix.python-version != '3.14' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
-      # disable OSMnx cache only for scheduled runs on the most recent python
-      USE_OSMNX_CACHE: ${{ github.event_name != 'schedule' || matrix.python-version != '3.14' }}
+      # bypass the persistent OSMnx cache only for scheduled runs on the most recent python
+      USE_PERSISTENT_CACHE: >-
+        ${{ github.event_name != 'schedule' || matrix.python-version != '3.14' }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,9 +53,9 @@ jobs:
           uv python pin ${{ matrix.python-version }}
           uv sync --all-extras --group docs --group lint --group test
 
-      # use a persistent OSMnx cache for cache-enabled API test runs
+      # use a persistent OSMnx cache for persistent cache test runs
       - name: Cache OSMnx cache
-        if: ${{ env.USE_OSMNX_CACHE == 'true' }}
+        if: ${{ env.USE_PERSISTENT_CACHE == 'true' }}
         uses: actions/cache@v6
         with:
           path: tests/.cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:
-      # make live API calls only for scheduled runs on the most recent python
-      LIVE_API_CALLS: ${{ github.event_name == 'schedule' && matrix.python-version == '3.14' }}
+      # disable OSMnx cache only for scheduled runs on the most recent python
+      USE_OSMNX_CACHE: ${{ github.event_name != 'schedule' || matrix.python-version != '3.14' }}
     strategy:
       fail-fast: false
       matrix:
@@ -52,14 +52,12 @@ jobs:
           uv python pin ${{ matrix.python-version }}
           uv sync --all-extras --group docs --group lint --group test
 
-      # use a persistent OSMnx cache for all runs with LIVE_API_CALLS not set
-      # true. but other runs will not use the cache so they instead make live
-      # web API calls to test against real, current API responses.
+      # use a persistent OSMnx cache for cache-enabled API test runs
       - name: Cache OSMnx cache
-        if: ${{ env.LIVE_API_CALLS != 'true' }}
+        if: ${{ env.USE_OSMNX_CACHE == 'true' }}
         uses: actions/cache@v6
         with:
-          path: .temp/cache
+          path: tests/.cache
           key: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
           restore-keys: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-
 
@@ -84,7 +82,7 @@ jobs:
         run: uv run sphinx-build -E -W --keep-going -b html ./docs/source ./docs/build/html
 
       - name: Test code and coverage
-        run: uv run pytest --typeguard-packages=osmnx --cov=osmnx --cov-report=xml
+        run: uv run ./tests/run_tests.sh --typeguard-packages=osmnx --cov=osmnx --cov-report=xml
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         run: |
           uv build
           uv run twine check --strict dist/*
-          uv run validate-pyproject ./pyproject.toml
 
       - name: Test docs build
         run: uv run sphinx-build -E -W --keep-going -b html ./docs/source ./docs/build/html

--- a/.github/workflows/keep-cache-alive.yml
+++ b/.github/workflows/keep-cache-alive.yml
@@ -8,7 +8,7 @@ permissions:
 # so this runs every Thu to update the caches' last accessed times
 on:  # yamllint disable-line rule:truthy
   schedule:
-    - cron: 23 5 * * 4
+    - cron: 23 4 * * 4
 
 jobs:
   keepalive:
@@ -22,6 +22,6 @@ jobs:
       - name: Restore newest OSMnx caches
         uses: actions/cache/restore@v6
         with:
-          path: .temp/cache
+          path: tests/.cache
           key: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
           restore-keys: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-

--- a/.github/workflows/test-latest-deps.yml
+++ b/.github/workflows/test-latest-deps.yml
@@ -20,9 +20,7 @@ jobs:
     if: ${{ github.repository == 'gboeing/osmnx' }}
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    env:
-      USE_OSMNX_CACHE: 'true'
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-latest-deps.yml
+++ b/.github/workflows/test-latest-deps.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:
-      LIVE_API_CALLS: 'false'
+      USE_OSMNX_CACHE: 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -50,10 +50,10 @@ jobs:
       - name: Cache OSMnx cache
         uses: actions/cache@v6
         with:
-          path: .temp/cache
+          path: tests/.cache
           key: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
           restore-keys: |
             osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Test code
-        run: uv run --no-sync pytest
+        run: uv run --no-sync ./tests/run_tests.sh

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -20,9 +20,7 @@ jobs:
     if: ${{ github.repository == 'gboeing/osmnx' }}
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
-    env:
-      USE_OSMNX_CACHE: 'true'
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     env:
-      LIVE_API_CALLS: 'false'
+      USE_OSMNX_CACHE: 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
       - name: Cache OSMnx cache
         uses: actions/cache@v6
         with:
-          path: .temp/cache
+          path: tests/.cache
           key: osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-${{ github.run_id }}
           restore-keys: |
             osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-
@@ -59,4 +59,4 @@ jobs:
       - name: Test code
         run: |
           uv run --no-sync ./tests/verify_min_deps.py
-          uv run --no-sync pytest -W ignore
+          uv run --no-sync ./tests/run_tests.sh -W ignore

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix, --show-fixes]
-        types_or: [python, pyproject]
+        types_or: [python, pyi, jupyter, pyproject]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix, --show-fixes]
+        types_or: [python, pyproject]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/osmnx/_overpass.py
+++ b/osmnx/_overpass.py
@@ -446,15 +446,15 @@ def _overpass_request(data: OrderedDict[str, Any]) -> dict[str, Any]:
     response_json
         The Overpass API's response.
     """
-    # resolve url to same IP even if there is server round-robin redirecting
-    _http._config_dns(settings.overpass_url)
-
     # prepare the Overpass API URL and see if request already exists in cache
     url = settings.overpass_url.rstrip("/") + "/interpreter"
     prepared_url = str(requests.Request("GET", url, params=data).prepare().url)
     cached_response_json = _http._retrieve_from_cache(prepared_url)
     if isinstance(cached_response_json, dict):
         return cached_response_json
+
+    # resolve url to same IP even if there is server round-robin redirecting
+    _http._config_dns(settings.overpass_url)
 
     # pause then request this URL
     pause = _get_overpass_pause(settings.overpass_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ warn_unreachable = true
 checks = ["all", "ES01", "EX01", "GL08", "PR04", "SA01"]
 
 [tool.pytest.ini_options]
-addopts = ["-ra", "--verbose", "--maxfail=1", "--numprocesses=3", "--dist=loadgroup"]
+addopts = ["-ra", "--verbose", "--maxfail=1"]
 cache_dir = "~/.cache/pytest"
 filterwarnings = ["error", "ignore::UserWarning"]
 log_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ visualization = ["matplotlib>=3.6"]
 [dependency-groups]
 docs = ["furo>=2023", "sphinx>=9", "sphinx-autodoc-typehints>=2"]
 examples = ["folium>=0.12", "jupyterlab>=3.0", "mapclassify>=2.5", "igraph>=0.11"]
-lint = ["pip>=25", "prek>=0.2", "twine>=6", "validate-pyproject[all]>=0.24"]
+lint = ["pip>=25", "prek>=0.2", "twine>=6"]
 test = ["lxml>=6", "pytest>=9", "pytest-cov>=6", "pytest-xdist>=3", "typeguard>=4"]
 
 [project.urls]

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,8 @@ uv sync --all-extras --all-groups
 bash ./tests/lint_test.sh
 ```
 
+The first test run populates `tests/.cache` with one worker; later runs use four workers and the cache. Delete `tests/.cache/.cache_ready` to force the next run to rebuild the cache. Set `USE_OSMNX_CACHE=false` to test against live APIs with one worker.
+
 ## Continuous integration
 
 Pull requests trigger continuous integration tests via GitHub Actions (see [workflow](../.github/workflows/ci.yml)), including the following steps:

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ uv sync --all-extras --all-groups
 bash ./tests/lint_test.sh
 ```
 
-The first test run populates `tests/.cache` with one worker; later runs use four workers and the cache. Delete `tests/.cache/.cache_ready` to force the next run to rebuild the cache. Set `USE_OSMNX_CACHE=false` to test against live APIs with one worker.
+The first test run populates `tests/.cache/` with one worker then marks it ready. Later runs use four workers and the cache. Delete `tests/.cache/` to force the next run to rebuild the cache. Set `USE_PERSISTENT_CACHE=false` to bypass the persistent cache and test live APIs with one worker.
 
 ## Continuous integration
 

--- a/tests/latest_lint_test.sh
+++ b/tests/latest_lint_test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/
 
 # activate the virtual environment with pre-releases
 uv python pin 3.14
@@ -11,11 +11,11 @@ source .venv/bin/activate
 
 # run tests
 SKIP=no-commit-to-branch prek run --all-files
-pytest --typeguard-packages=osmnx --cov=osmnx --cov-report=term-missing:skip-covered
+./tests/run_tests.sh --typeguard-packages=osmnx --cov=osmnx --cov-report=term-missing:skip-covered
 
 # restore the environment without pre-releases
 uv python pin --rm
 uv sync --all-extras --all-groups --upgrade
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/

--- a/tests/lint_test.sh
+++ b/tests/lint_test.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 source .venv/bin/activate
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/
 
 # run the pre-commit hooks for linting/formatting
 SKIP=no-commit-to-branch prek run --all-files
@@ -16,11 +16,11 @@ twine check --strict ./dist/*
 validate-pyproject ./pyproject.toml
 
 # run the tests and report the test coverage
-pytest --typeguard-packages=osmnx --cov=osmnx --cov-report=term-missing:skip-covered
+./tests/run_tests.sh --typeguard-packages=osmnx --cov=osmnx --cov-report=term-missing:skip-covered
 
 # build the docs and test that links are alive
 sphinx-build -q -a -E -W --keep-going -b html ./docs/source ./docs/build/html
 sphinx-build -q -a -E -W --keep-going -b linkcheck ./docs/source ./docs/build/linkcheck
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/

--- a/tests/lint_test.sh
+++ b/tests/lint_test.sh
@@ -13,7 +13,6 @@ SKIP=no-commit-to-branch prek run --all-files
 # build and validate the package
 uv build
 twine check --strict ./dist/*
-validate-pyproject ./pyproject.toml
 
 # run the tests and report the test coverage
 ./tests/run_tests.sh --typeguard-packages=osmnx --cov=osmnx --cov-report=term-missing:skip-covered

--- a/tests/minimal_lint_test.sh
+++ b/tests/minimal_lint_test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/
 
 # activate the virtual environment with pre-releases
 uv python pin 3.11
@@ -11,11 +11,11 @@ source .venv/bin/activate
 
 # run tests
 python ./tests/verify_min_deps.py
-pytest -W ignore
+./tests/run_tests.sh -W ignore
 
 # restore the environment without pre-releases
 uv python pin --rm
 uv sync --all-extras --all-groups --upgrade
 
 # delete temp files and folders
-rm -r -f ./.coverage* ./.pytest_cache ./.temp ./dist ./docs/build ./*/__pycache__
+rm -r -f ./.coverage* ./.pytest_cache/ ./tests/.temp/ ./dist/ ./docs/build/ ./*/__pycache__/

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -3,18 +3,23 @@ set -euo pipefail
 
 CACHE_DIR="tests/.cache"
 CACHE_READY_FILE="${CACHE_DIR}/.cache_ready"
-USE_OSMNX_CACHE="${USE_OSMNX_CACHE:-true}"
+USE_PERSISTENT_CACHE="${USE_PERSISTENT_CACHE:-true}"
 
-# use four workers only with a ready cache and cache enabled
+# use four workers only with a persistent cache that's been marked ready
 WORKERS=1
-if [[ "$USE_OSMNX_CACHE" == "true" && -f "$CACHE_READY_FILE" ]]; then
+if [[ "$USE_PERSISTENT_CACHE" == "true" && -f "$CACHE_READY_FILE" ]]; then
     WORKERS=4
 fi
 
-echo "Running tests with ${WORKERS} worker(s); USE_OSMNX_CACHE=${USE_OSMNX_CACHE}."
+# if we're not using the persistent cache, verify the temp cache is cleared
+if [[ "$USE_PERSISTENT_CACHE" != "true" ]]; then
+    rm -r -f ./tests/.temp/cache/
+fi
+
+echo "Running tests with ${WORKERS} worker(s); USE_PERSISTENT_CACHE=${USE_PERSISTENT_CACHE}."
 pytest --numprocesses="$WORKERS" --dist=loadgroup "$@"
 
-# mark the cache ready after every successful cache-enabled run
-if [[ "$USE_OSMNX_CACHE" == "true" ]]; then
+# mark the persistent cache ready after every successful persistent-cache run
+if [[ "$USE_PERSISTENT_CACHE" == "true" ]]; then
     touch "$CACHE_READY_FILE"
 fi

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+CACHE_DIR="tests/.cache"
+CACHE_READY_FILE="${CACHE_DIR}/.cache_ready"
+USE_OSMNX_CACHE="${USE_OSMNX_CACHE:-true}"
+
+# use four workers only with a ready cache and cache enabled
+WORKERS=1
+if [[ "$USE_OSMNX_CACHE" == "true" && -f "$CACHE_READY_FILE" ]]; then
+    WORKERS=4
+fi
+
+echo "Running tests with ${WORKERS} worker(s); USE_OSMNX_CACHE=${USE_OSMNX_CACHE}."
+pytest --numprocesses="$WORKERS" --dist=loadgroup "$@"
+
+# mark the cache ready after every successful cache-enabled run
+if [[ "$USE_OSMNX_CACHE" == "true" ]]; then
+    touch "$CACHE_READY_FILE"
+fi

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -57,7 +57,7 @@ polygon_wkt = (
 polygon = ox.utils_geo.buffer_geometry(geom=wkt.loads(polygon_wkt), dist=1)
 
 
-@pytest.mark.xdist_group(name="group1")
+@pytest.mark.xdist_group(name="group0")
 def test_logging() -> None:
     """Test the logger."""
     ox.utils.log("test a fake default message")
@@ -74,7 +74,7 @@ def test_logging() -> None:
     ox.utils.ts(style="time")
 
 
-@pytest.mark.xdist_group(name="group1")
+@pytest.mark.xdist_group(name="group0")
 def test_exceptions() -> None:
     """Test the custom errors."""
     message = "testing exception"
@@ -180,7 +180,7 @@ def test_validating() -> None:  # noqa: PLR0915
     ox.convert.validate_graph(G)
 
 
-@pytest.mark.xdist_group(name="group1")
+@pytest.mark.xdist_group(name="group0")
 def test_geocoder() -> None:
     """Test retrieving elements by place name and OSM ID."""
     city = ox.geocode_to_gdf("R2999176", by_osmid=True)
@@ -377,7 +377,7 @@ def test_osm_xml() -> None:
     ox.settings.all_oneway = default_all_oneway
 
 
-@pytest.mark.xdist_group(name="group1")
+@pytest.mark.xdist_group(name="group0")
 def test_elevation() -> None:
     """Test working with elevation data."""
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")
@@ -411,7 +411,7 @@ def test_elevation() -> None:
     G = ox.add_edge_grades(G, add_absolute=True)
 
 
-@pytest.mark.xdist_group(name="group1")
+@pytest.mark.xdist_group(name="group0")
 def test_routing() -> None:
     """Test working with speed, travel time, and routing."""
     G = ox.graph_from_address(address=address, dist=500, dist_type="bbox", network_type="bike")

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -788,6 +788,7 @@ def test_graph_from() -> None:
     G = ox.graph_from_point(location_point, dist=500, custom_filter=cf_union, retain_all=True)
     ox.convert.validate_graph(G)
 
+    default_overpass_memory = ox.settings.overpass_memory
     ox.settings.overpass_memory = 1073741824
     G = ox.graph_from_point(
         location_point,
@@ -796,6 +797,7 @@ def test_graph_from() -> None:
         network_type="all",
     )
     ox.convert.validate_graph(G)
+    ox.settings.overpass_memory = default_overpass_memory
 
 
 @pytest.mark.xdist_group(name="group3")

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -32,16 +32,16 @@ from typeguard import suppress_type_checks
 
 import osmnx as ox
 
-# enable OSMnx cache by default
-use_osmnx_cache = os.getenv("USE_OSMNX_CACHE", "true").lower() == "true"
-ox.settings.use_cache = use_osmnx_cache
+# use the persistent OSMnx cache by default
+use_persistent_cache = os.getenv("USE_PERSISTENT_CACHE", "true").lower() == "true"
+ox.settings.cache_folder = "tests/.cache" if use_persistent_cache else "tests/.temp/cache"
 
-ox.settings.cache_folder = "tests/.cache"
 ox.settings.data_folder = "tests/.temp"
 ox.settings.imgs_folder = "tests/.temp"
 ox.settings.logs_folder = "tests/.temp"
 ox.settings.log_console = True
 ox.settings.log_file = True
+ox.settings.use_cache = True
 
 # define queries to use throughout tests
 location_point = (37.791427, -122.410018)
@@ -604,8 +604,9 @@ def test_endpoints() -> None:
     response_json = ox._nominatim._nominatim_request(params=params, request_type="lookup")
 
     # bad call: only make this deliberately uncacheable live API call when
-    # specifically enabled to do so
-    if not use_osmnx_cache:
+    # specifically configured to do so (i.e., not using the persistent cache).
+    # otherwise it will make a live API call when it's not supposed to.
+    if not use_persistent_cache:
         with pytest.raises(
             ox._errors.InsufficientResponseError,
             match="Nominatim API did not return a list of results",

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -558,29 +558,9 @@ def test_endpoints() -> None:
     default_requests_timeout = ox.settings.requests_timeout
     default_key = ox.settings.nominatim_key
     default_nominatim_url = ox.settings.nominatim_url
+    default_doh_url_template = ox.settings.doh_url_template
     default_overpass_url = ox.settings.overpass_url
     default_overpass_rate_limit = ox.settings.overpass_rate_limit
-
-    # test good and bad DNS resolution
-    ox.settings.requests_timeout = 1
-    ip = ox._http._resolve_host_via_doh("overpass-api.de")
-    ip = ox._http._resolve_host_via_doh("AAAAAAAAAAA")
-    _doh_url_template_default = ox.settings.doh_url_template
-    ox.settings.doh_url_template = "http://aaaaaa.hostdoesntexist.org/nothinguseful"
-    ip = ox._http._resolve_host_via_doh("overpass-api.de")
-    ox.settings.doh_url_template = None
-    ip = ox._http._resolve_host_via_doh("overpass-api.de")
-    ox.settings.doh_url_template = _doh_url_template_default
-
-    # Test changing the Overpass endpoint.
-    # This should fail because we didn't provide a valid endpoint
-    ox.settings.overpass_rate_limit = False
-    ox.settings.overpass_url = "http://NOT_A_VALID_ENDPOINT/api/"
-    with pytest.raises(RequestsConnectionError, match="Max retries exceeded with url"):
-        G = ox.graph_from_place(place1, network_type="all")
-
-    ox.settings.overpass_rate_limit = default_overpass_rate_limit
-    ox.settings.requests_timeout = default_requests_timeout
 
     params: OrderedDict[str, int | str] = OrderedDict()
     params["format"] = "json"
@@ -603,10 +583,32 @@ def test_endpoints() -> None:
     # good call
     response_json = ox._nominatim._nominatim_request(params=params, request_type="lookup")
 
-    # bad call: only make this deliberately uncacheable live API call when
-    # specifically configured to do so (i.e., not using the persistent cache).
-    # otherwise it will make a live API call when it's not supposed to.
+    # only allow live HTTP calls (for things we can't cache, because we only
+    # write to cache on success) for DOH requests or bad requests only if
+    # we're not relying on the persistent cache
     if not use_persistent_cache:
+        # test good and bad DNS resolution
+        ox.settings.requests_timeout = 1
+        ip = ox._http._resolve_host_via_doh("overpass-api.de")
+        ip = ox._http._resolve_host_via_doh("AAAAAAAAAAA")
+        ox.settings.doh_url_template = "http://aaaaaa.hostdoesntexist.org/nothinguseful"
+        ip = ox._http._resolve_host_via_doh("overpass-api.de")
+        ox.settings.doh_url_template = None
+        ip = ox._http._resolve_host_via_doh("overpass-api.de")
+
+        # Test changing the Overpass endpoint.
+        # This should fail because we didn't provide a valid endpoint
+        ox.settings.overpass_rate_limit = False
+        ox.settings.overpass_url = "http://NOT_A_VALID_ENDPOINT/api/"
+        with pytest.raises(RequestsConnectionError, match="Max retries exceeded with url"):
+            G = ox.graph_from_place(place1, network_type="all")
+
+        ox.settings.doh_url_template = default_doh_url_template
+        ox.settings.overpass_url = default_overpass_url
+        ox.settings.overpass_rate_limit = default_overpass_rate_limit
+        ox.settings.requests_timeout = default_requests_timeout
+
+        # bad call: deliberately uncacheable live API call
         with pytest.raises(
             ox._errors.InsufficientResponseError,
             match="Nominatim API did not return a list of results",

--- a/tests/test_osmnx.py
+++ b/tests/test_osmnx.py
@@ -32,13 +32,16 @@ from typeguard import suppress_type_checks
 
 import osmnx as ox
 
+# enable OSMnx cache by default
+use_osmnx_cache = os.getenv("USE_OSMNX_CACHE", "true").lower() == "true"
+ox.settings.use_cache = use_osmnx_cache
+
+ox.settings.cache_folder = "tests/.cache"
+ox.settings.data_folder = "tests/.temp"
+ox.settings.imgs_folder = "tests/.temp"
+ox.settings.logs_folder = "tests/.temp"
 ox.settings.log_console = True
 ox.settings.log_file = True
-ox.settings.use_cache = True
-ox.settings.data_folder = ".temp/data"
-ox.settings.logs_folder = ".temp/logs"
-ox.settings.imgs_folder = ".temp/imgs"
-ox.settings.cache_folder = ".temp/cache"
 
 # define queries to use throughout tests
 location_point = (37.791427, -122.410018)
@@ -602,7 +605,7 @@ def test_endpoints() -> None:
 
     # bad call: only make this deliberately uncacheable live API call when
     # specifically enabled to do so
-    if os.getenv("LIVE_API_CALLS", "true").lower() == "true":
+    if not use_osmnx_cache:
         with pytest.raises(
             ox._errors.InsufficientResponseError,
             match="Nominatim API did not return a list of results",
@@ -634,7 +637,7 @@ def test_save_load() -> None:  # noqa: PLR0915
 
     # save/load geopackage and convert graph to/from node/edge GeoDataFrames
     ox.save_graph_geopackage(G, directed=False)
-    fp = ".temp/data/graph-dir.gpkg"
+    fp = "tests/.temp/graph-dir.gpkg"
     ox.save_graph_geopackage(G, filepath=fp, directed=True)
     gdf_nodes1 = gpd.read_file(fp, layer="nodes").set_index("osmid")
     gdf_edges1 = gpd.read_file(fp, layer="edges").set_index(["u", "v", "key"])


### PR DESCRIPTION
Fix bug:
- Move DNS config after the cache check, otherwise it tries to resolve DNS even when we are hitting the local cache and *not* making a live API HTTP request

Improve tests' request caching:
- Persist OSMnx HTTP test responses in `tests/.cache`, both when run locally and in GitHub Actions.
- Build the cache with one worker, then use four workers once the `.cache_ready` marker file exists.
- Support env var `USE_PERSISTENT_CACHE=false` for forcing live web API testing.
- Remove standalone validate-pyproject checks in favor of RUF200, which covers that now.

See also #1398 