### PR TITLE
make bash explicit so windows runners will use it properly

### DIFF
--- a/.github/workflows/test-latest-deps.yml
+++ b/.github/workflows/test-latest-deps.yml
@@ -54,4 +54,4 @@ jobs:
             osmnx-cache-${{ runner.os }}-${{ matrix.python-version }}-
 
       - name: Test code
-        run: uv run --no-sync ./tests/run_tests.sh
+        run: uv run --no-sync bash ./tests/run_tests.sh

--- a/.github/workflows/test-minimum-deps.yml
+++ b/.github/workflows/test-minimum-deps.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test code
         run: |
           uv run --no-sync ./tests/verify_min_deps.py
-          uv run --no-sync ./tests/run_tests.sh -W ignore
+          uv run --no-sync bash ./tests/run_tests.sh -W ignore


### PR DESCRIPTION
small fix for #1397 so windows runners can run the "latest" and "minimum" dependency tests