### PR TITLE
Add actionlint CI workflow and pre-commit hook

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+self-hosted-runner:
+  labels: []
+
+# ShellCheck rules disabled inside run: blocks.
+# Each `run:` block is checked through ShellCheck; suppress noisy rules here.
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore:
+      - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
+      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
+      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
+---
 # actionlint configuration
 # https://github.com/rhysd/actionlint/blob/main/docs/config.md
 self-hosted-runner:
@@ -9,6 +10,6 @@ paths:
   ".github/workflows/**/*.{yml,yaml}":
     ignore:
       - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
-      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
-      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
-      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values
+      - 'shellcheck reported issue in this script: SC2086:.+'
+      - 'shellcheck reported issue in this script: SC2129:.+'
+      - 'shellcheck reported issue in this script: SC2155:.+'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download actionlint
+        id: download
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Run actionlint
+        run: |
+          ./actionlint -color
+        shell: bash

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,16 +1,17 @@
+---
 name: Actionlint
 
-on:
+"on":
   push:
     paths:
-      - '.github/workflows/**'
-      - '.github/actionlint.yaml'
-      - '.github/actionlint.yml'
+      - .github/workflows/**
+      - .github/actionlint.yaml
+      - .github/actionlint.yml
   pull_request:
     paths:
-      - '.github/workflows/**'
-      - '.github/actionlint.yaml'
-      - '.github/actionlint.yml'
+      - .github/workflows/**
+      - .github/actionlint.yaml
+      - .github/actionlint.yml
 
 permissions:
   contents: read
@@ -26,7 +27,9 @@ jobs:
       - uses: actions/checkout@v5
       - name: Download actionlint
         id: download
-        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        run: >
+          bash <(curl -sSf
+          https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Run actionlint
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,7 @@ repos:
           - pytest
           - scipy-stubs
           - types-requests
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
# Read these instructions carefully

Before you proceed, review the contributing guidelines in the CONTRIBUTING.md file, especially the sections on project coding standards and tests. Then fill out the template below.

## Checklist
- [x] I have read the contributing guidelines and have run the pre-commit hooks and tests locally.
- [ ] I have edited the changelog to reflect my changes. *(CI-only change; no user-facing library behaviour added or changed — no CHANGELOG entry added.)*
- [ ] If this is an enhancement, I have opened a feature proposal issue to discuss first. *(CI/tooling addition; no feature proposal required.)*

## Related issues

No existing issue. This is a CI tooling addition that adds workflow linting infrastructure — not a user-facing library change.

## Proposed changes

Adds [actionlint](https://github.com/rhysd/actionlint) to catch GitHub Actions workflow errors before they reach CI:

- **`.github/actionlint.yaml`** — configuration with ShellCheck enabled and common false-positive rules suppressed (SC2086, SC2129, SC2155, SC1091), which are noisy in workflows that use `${{ }}` interpolation.
- **`.github/workflows/actionlint.yml`** — dedicated workflow triggered on changes to `.github/workflows/**`; runs the official actionlint download script.
- **`.pre-commit-config.yaml`** — adds the actionlint pre-commit hook (v1.7.7) so workflow files are linted locally before commit.

The repo currently has 7 workflow files with no workflow-level linting beyond yamllint. actionlint catches schema errors, expression type mismatches, and shell bugs in `run:` blocks that yamllint cannot detect.

## Usage example

N/A — CI and pre-commit tooling change only; no library API is added or modified.

## Benchmarks

N/A — no existing functionality is changed.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
